### PR TITLE
Prototype Scipp-Mantid comparison testing

### DIFF
--- a/python/tests/mantid_scipp_comparison.py
+++ b/python/tests/mantid_scipp_comparison.py
@@ -1,0 +1,70 @@
+from mantid_data_helper import MantidDataHelper
+import scipp as sc
+import scipp.compat.mantid as mantid
+import time
+
+
+class MantidScippComparison:
+    def __init__(self, test_description=None):
+        self._test_description = test_description
+
+    def _execute_with_timing(self, op, input):
+        start = time.time()
+        result = op(input)
+        stop = time.time()
+        return result, (stop - start) * sc.Unit('s')
+
+    def _assert(self, a, b, allow_failure):
+        try:
+            assert sc.is_equal(a, b)
+        except AssertionError as ae:
+            if allow_failure:
+                print(ae)
+            else:
+                raise (ae)
+
+    def run(self, allow_failure=False):
+        import mantid.simpleapi as sapi
+        results = sc.Dataset()
+        for name, (hash, algorithm) in self._filenames.items():
+            file = MantidDataHelper.find_file(hash, algorithm)
+            print('Loading', name)
+            in_ws = sapi.Load(Filename=file, StoreInADS=False)
+            out_mantid_da, time_mantid = self._execute_with_timing(
+                self._run_mantid, input=in_ws)
+            in_da = mantid.from_mantid(in_ws).astype(
+                sc.dtype.float64)  # Converters set weights float32
+            out_scipp_da, time_scipp = self._execute_with_timing(
+                self._run_scipp, input=in_da)
+
+            self._assert(out_scipp_da, out_mantid_da, allow_failure)
+
+            result = sc.DataArray(sc.equal(out_mantid_da, out_scipp_da).data,
+                                  coords={
+                                      'diff':
+                                      out_mantid_da.data - out_scipp_da.data,
+                                      'is_approx':
+                                      sc.is_approx(
+                                          out_mantid_da.data,
+                                          out_scipp_da.data,
+                                          1e-9 * sc.Unit('counts') +
+                                          1e-9 * sc.abs(out_mantid_da.data)),
+                                      'duration_scipp':
+                                      time_scipp,
+                                      'duration_mantid':
+                                      time_mantid
+                                  })
+
+            results[f'with_{name}' if self._test_description is None else
+                    f'{self._test_description}_with_{name}'] = result
+        return results
+
+    @property
+    def _filenames(self):
+        pass
+
+    def _run_mantid(self, input):
+        raise RuntimeError("_run_mantid not implemented in base")
+
+    def _run_scipp(self, input):
+        raise RuntimeError("_run_scipp not implemented in base")

--- a/python/tests/mantid_scipp_comparison.py
+++ b/python/tests/mantid_scipp_comparison.py
@@ -1,6 +1,6 @@
 from mantid_data_helper import MantidDataHelper
 import scipp as sc
-import scipp.compat.mantid as mantid
+import scippneutron.mantid as mantid
 import time
 
 

--- a/python/tests/test_histogram_events.py
+++ b/python/tests/test_histogram_events.py
@@ -28,8 +28,7 @@ class HistogramEventsTest(MantidScippComparison):
     def _run_scipp(self, input):
         return sc.histogram(x=input,
                             bins=sc.Variable(dims=['tof'],
-                                             values=np.arange(0, 1010, 10),
-                                             dtype=sc.dtype.float64,
+                                             values=np.linspace(0, 1000, num=11),
                                              unit=sc.units.us))
 
 

--- a/python/tests/test_histogram_events.py
+++ b/python/tests/test_histogram_events.py
@@ -1,7 +1,7 @@
 from mantid_scipp_comparison import MantidScippComparison
 from mantid_data_helper import mantid_is_available
 import pytest
-import scipp.compat.mantid as mantid
+import scippneutron.mantid as mantid
 import scipp as sc
 import numpy as np
 

--- a/python/tests/test_histogram_events.py
+++ b/python/tests/test_histogram_events.py
@@ -1,0 +1,40 @@
+from mantid_scipp_comparison import MantidScippComparison
+from mantid_data_helper import mantid_is_available
+import pytest
+import scipp.compat.mantid as mantid
+import scipp as sc
+import numpy as np
+
+
+class HistogramEventsTest(MantidScippComparison):
+    def __init__(self):
+        super(HistogramEventsTest, self).__init__('histogram_events_test')
+
+    @property
+    def _filenames(self):
+        return {
+            "CNCS_51936_event.nxs": ("5ba401e489260a44374b5be12b780911", "MD5")
+        }
+
+    def _run_mantid(self, input):
+        import mantid.simpleapi as sapi
+        # Note Mantid rebin inclusive of last bin boundary
+        out = sapi.Rebin(InputWorkspace=input,
+                         Params=[0, 10, 1000],
+                         PreserveEvents=False,
+                         StoreInADS=False)
+        return mantid.from_mantid(out)
+
+    def _run_scipp(self, input):
+        return sc.histogram(x=input,
+                            bins=sc.Variable(dims=['tof'],
+                                             values=np.arange(0, 1010, 10),
+                                             dtype=sc.dtype.float64,
+                                             unit=sc.units.us))
+
+
+@pytest.mark.skipif(not mantid_is_available(),
+                    reason='Mantid framework is unavailable')
+def test_histogram_events():
+    rebin = HistogramEventsTest()
+    print(rebin.run(allow_failure=True))

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -10,7 +10,7 @@ import os
 import scipp as sc
 from mantid_data_helper import MantidDataHelper
 from mantid_data_helper import mantid_is_available
-from scipp.compat import mantid as mantidcompat
+from scippneutron import mantid as mantidcompat
 
 
 def memory_is_at_least_gb(required):

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -9,15 +9,8 @@ import os
 
 import scipp as sc
 from mantid_data_helper import MantidDataHelper
+from mantid_data_helper import mantid_is_available
 from scipp.compat import mantid as mantidcompat
-
-
-def mantid_is_available():
-    try:
-        import mantid  # noqa: F401
-        return True
-    except ImportError:
-        return False
 
 
 def memory_is_at_least_gb(required):
@@ -39,7 +32,7 @@ class TestMantidConversion(unittest.TestCase):
         # This needs OutputWorkspace specified, as it doesn't
         # pick up the name from the class variable name
         cls.base_event_ws = mantid.LoadEventNexus(
-            MantidDataHelper.find_file(filename),
+            MantidDataHelper.find_known_file(filename),
             OutputWorkspace="test_ws{}".format(__file__),
             SpectrumMax=200,
             StoreInADS=False)
@@ -270,7 +263,7 @@ class TestMantidConversion(unittest.TestCase):
     def test_Workspace2D_with_separate_monitors(self):
         from mantid.simpleapi import mtd
         mtd.clear()
-        filename = MantidDataHelper.find_file("WISH00016748.raw")
+        filename = MantidDataHelper.find_known_file("WISH00016748.raw")
         # This test would use 20 GB of memory if "SpectrumMax" was not set
         ds = mantidcompat.load(filename,
                                mantid_args={
@@ -291,7 +284,7 @@ class TestMantidConversion(unittest.TestCase):
     def test_Workspace2D_with_include_monitors(self):
         from mantid.simpleapi import mtd
         mtd.clear()
-        filename = MantidDataHelper.find_file("WISH00016748.raw")
+        filename = MantidDataHelper.find_known_file("WISH00016748.raw")
         # This test would use 20 GB of memory if "SpectrumMax" was not set
         ds = mantidcompat.load(filename,
                                mantid_args={
@@ -311,7 +304,7 @@ class TestMantidConversion(unittest.TestCase):
     def test_EventWorkspace_with_monitors(self):
         from mantid.simpleapi import mtd
         mtd.clear()
-        filename = MantidDataHelper.find_file("CNCS_51936_event.nxs")
+        filename = MantidDataHelper.find_known_file("CNCS_51936_event.nxs")
         ds = mantidcompat.load(filename,
                                mantid_args={
                                    "LoadMonitors": True,
@@ -412,7 +405,8 @@ class TestMantidConversion(unittest.TestCase):
         ds = sc.Dataset()
 
         sc.compat.mantid.load_component_info(
-            ds, MantidDataHelper.find_file("iris26176_graphite002_sqw.nxs"))
+            ds,
+            MantidDataHelper.find_known_file("iris26176_graphite002_sqw.nxs"))
 
         # check that no workspaces have been leaked in the ADS
         assert len(mtd) == 0, f"Workspaces present: {mtd.getObjectNames()}"
@@ -466,7 +460,7 @@ class TestMantidConversion(unittest.TestCase):
         from mantid.simpleapi import mtd
         mtd.clear()
 
-        data = sc.neutron.load(filename=MantidDataHelper.find_file(
+        data = sc.neutron.load(filename=MantidDataHelper.find_known_file(
             "iris26176_graphite002_sqw.nxs"))
 
         params, diff = sc.compat.mantid.fit(
@@ -868,7 +862,7 @@ def test_extract_energy_final_when_not_present():
 def test_extract_energy_initial():
     from mantid.simpleapi import mtd
     mtd.clear()
-    filename = MantidDataHelper.find_file("CNCS_51936_event.nxs")
+    filename = MantidDataHelper.find_known_file("CNCS_51936_event.nxs")
     ds = mantidcompat.load(filename, mantid_args={"SpectrumMax": 1})
     assert sc.is_equal(ds.coords["incident-energy"],
                        sc.scalar(value=3.0, unit=sc.Unit("meV")))


### PR DESCRIPTION
Previously proposed here https://github.com/scipp/scipp/pull/1716

Moved across now that we have separate scipp-neturon

* Not including bespoke CI aspects yet. 
* Only single comparison so far, framework should be easy to extend


executing `pytest ... -s` will yield more detailed comparison info and timings.
```
<scipp.Dataset>
Dimensions: {{spectrum, 51200}, {tof, 100}}
Coordinates:
  diff                      float64    [counts]         (spectrum, tof)  [0.000000, 0.000000, ..., 0.000000, 0.000000]  [0.000000, 0.000000, ..., 0.000000, 0.000000]
  duration_mantid           float64    [s]              ()  [0.877711]
  duration_scipp            float64    [s]              ()  [0.137778]
  is_approx                 bool       [dimensionless]  (spectrum, tof)  [True, True, ..., True, True]
Data:
  histogram_events_test_with_CNCS_51936_event.nxs  bool       [dimensionless]  (spectrum, tof)  [True, True, ..., True, True]


PASSED
```