### PR TITLE
Support overriding beamline parameters

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -11,6 +11,8 @@ Features
 
 * Functionality from ``scipp.neutron`` (as previously known as part of the scipp package) is now available in this package.
   This includes in particular the instrument view and "unit conversions" for time-of-flight neutron sources.
+* Convert supports a greatly enhanced way of obtaining required parameters of the beamline.
+  Instead of requiring raw component positions it can now work directly with, e.g., `two_theta`.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/docs/tutorials/powder-diffraction.ipynb
+++ b/docs/tutorials/powder-diffraction.ipynb
@@ -131,18 +131,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample.coords['theta'] = scn.scattering_angle(sample)\n",
-    "vanadium.coords['theta'] = scn.scattering_angle(vanadium)\n",
-    "theta_bins = sc.Variable(['theta'],\n",
-    "                         unit=sc.units.rad,\n",
-    "                         values=np.linspace(0.0, np.pi/2, num=2000))"
+    "sample.coords['two_theta'] = scn.two_theta(sample)\n",
+    "vanadium.coords['two_theta'] = scn.two_theta(vanadium)\n",
+    "two_theta_bins = sc.Variable(['two_theta'],\n",
+    "                             unit=sc.units.rad,\n",
+    "                             values=np.linspace(0.0, np.pi, num=2000))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We concatenate events lists from different spectra that fall into a given theta range into longer combined lists:"
+    "We concatenate events lists from different spectra that fall into a given $2\\theta$ range into longer combined lists:"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta_sample = sc.groupby(sample, 'theta', bins=theta_bins).bins.concatenate('spectrum')"
+    "theta_sample = sc.groupby(sample, 'two_theta', bins=two_theta_bins).bins.concatenate('spectrum')"
    ]
   },
   {
@@ -398,12 +398,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta = sc.Variable(['theta'],\n",
+    "two_theta = sc.Variable(['two_theta'],\n",
     "                    unit=sc.units.rad,\n",
-    "                    values=np.linspace(0.0, np.pi/2, num=16))\n",
+    "                    values=np.linspace(0.0, np.pi, num=16))\n",
     "\n",
-    "focussed_sample = sc.groupby(dspacing_sample, 'theta', bins=theta).bins.concatenate('spectrum')\n",
-    "focussed_vanadium = sc.groupby(dspacing_vanadium, 'theta', bins=theta).bins.concatenate('spectrum')\n",
+    "focussed_sample = sc.groupby(dspacing_sample, 'two_theta', bins=two_theta).bins.concatenate('spectrum')\n",
+    "focussed_vanadium = sc.groupby(dspacing_vanadium, 'two_theta', bins=two_theta).bins.concatenate('spectrum')\n",
     "norm = sc.histogram(focussed_vanadium, dspacing_bins)\n",
     "focussed_sample.bins /= sc.lookup(func=norm, dim='dspacing')\n",
     "normalized = sc.histogram(focussed_sample, dspacing_bins)"
@@ -439,10 +439,10 @@
    "outputs": [],
    "source": [
     "# compute centers of theta bins\n",
-    "angles = normalized.coords['theta'].values\n",
+    "angles = normalized.coords['two_theta'].values\n",
     "angles = 0.5*(angles[1:] + angles[:-1])\n",
     "sc.plot({f'{round(angles[group], 3)} rad':\n",
-    "         normalized['dspacing', 300:500]['theta', group]\n",
+    "         normalized['dspacing', 300:500]['two_theta', group]\n",
     "         for group in range(2,6)})"
    ]
   }

--- a/docs/tutorials/working-with-masks.ipynb
+++ b/docs/tutorials/working-with-masks.ipynb
@@ -188,7 +188,7 @@
     "- Mask a \"circle\" (in $x$-$y$ plane, i.e., a cylinder aligned with $\\hat z$)\n",
     "- Mask a ring based on $x$ and $y$\n",
     "- Mask a scattering-angle ($\\theta$) range.\n",
-    "  Hint: The scattering angle can be computed as `theta = scn.scattering_angle(data)`\n",
+    "  Hint: The scattering angle can be computed as `theta = 0.5 * scn.two_theta(data)`\n",
     "- Mask a wedge.\n",
     "  Hint: `phi = sc.atan2(y,x)`"
    ]
@@ -210,7 +210,7 @@
     "\n",
     "data.masks['ring'] = (0.14 * sc.units.m < r) & (r < 0.19 * sc.units.m)\n",
     "\n",
-    "theta = scn.scattering_angle(data)\n",
+    "theta = 0.5 * scn.two_theta(data)\n",
     "data.masks['theta'] = (0.03 * sc.units.rad < theta) & (theta < 0.04 * sc.units.rad)\n",
     "\n",
     "phi = sc.atan2(y,x) * ((180.0 * sc.units.deg) / (np.pi * sc.units.rad))\n",
@@ -250,7 +250,7 @@
    "outputs": [],
    "source": [
     "theta_edges = sc.array(dims=['theta'], unit='rad', values=np.linspace(0, 0.1, num=100))\n",
-    "data.coords['theta'] = scn.scattering_angle(data)\n",
+    "data.coords['theta'] = 0.5 * scn.two_theta(data)\n",
     "# - prompt-pulse mask is preserved since we did not sum over time-of-flight.\n",
     "# - Masked pixels (spectra) cannot be preserved since we sum over spectra,\n",
     "#   and the sum simply skips the masked spectra.\n",

--- a/docs/user-guide/groupby.ipynb
+++ b/docs/user-guide/groupby.ipynb
@@ -89,10 +89,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pos_hist.coords['scattering_angle'] = scn.scattering_angle(pos_hist)\n",
-    "theta = sc.Variable(['scattering_angle'],\n",
-    "                    unit=sc.units.rad,\n",
-    "                    values=np.linspace(0.0, np.pi/2, num=500))"
+    "pos_hist.coords['two_theta'] = scn.two_theta(pos_hist)\n",
+    "two_theta = sc.Variable(['two_theta'],\n",
+    "                        unit=sc.units.rad,\n",
+    "                        values=np.linspace(0.0, np.pi, num=500))"
    ]
   },
   {
@@ -108,14 +108,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta_hist = sc.groupby(pos_hist, 'scattering_angle', bins=theta).sum('spectrum')"
+    "theta_hist = sc.groupby(pos_hist, 'two_theta', bins=two_theta).sum('spectrum')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result has `spectrum` replaced by the physically meaningful `scattering_angle` dimension and the resulting plot is easily interpretable:"
+    "The result has `spectrum` replaced by the physically meaningful `two_theta` dimension and the resulting plot is easily interpretable:"
    ]
   },
   {
@@ -160,10 +160,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events.coords['scattering_angle'] = scn.scattering_angle(events)\n",
-    "theta = sc.Variable(['scattering_angle'],\n",
+    "events.coords['two_theta'] = scn.two_theta(events)\n",
+    "theta = sc.Variable(['two_theta'],\n",
     "                    unit=sc.units.rad,\n",
-    "                    values=np.linspace(0.0, np.pi/2, num=500))"
+    "                    values=np.linspace(0.0, np.pi, num=500))"
    ]
   },
   {
@@ -180,14 +180,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta_events = sc.groupby(events, 'scattering_angle', bins=theta).concatenate('spectrum')"
+    "theta_events = sc.groupby(events, 'two_theta', bins=theta).concatenate('spectrum')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result has dimension `spectrum` replaced by the physically meaningful `scattering_angle` and results in the same plot as before with histogrammed data."
+    "The result has dimension `spectrum` replaced by the physically meaningful `two_theta` and results in the same plot as before with histogrammed data."
    ]
   },
   {

--- a/docs/user-guide/overview.rst
+++ b/docs/user-guide/overview.rst
@@ -31,17 +31,20 @@ Unit Conversion
 Beamline geometry
 ~~~~~~~~~~~~~~~~~
 
+Note that ``theta`` or ``scattering_angle`` are deliberately not supported, due to some ambiguity on how the terms are used in the community, and possible confusion of ``theta`` (from Bagg's law) with ``theta`` in spherical coordinates.
+
 .. autosummary::
    :toctree: ../generated
 
    position
    source_position
    sample_position
-   flight_path_length
-   l1
-   l2
-   scattering_angle
+   Ltotal
+   L1
+   L2
    two_theta
+   incident_beam
+   scattered_beam
 
 Loading Nexus files
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/user-guide/unit-conversions.ipynb
+++ b/docs/user-guide/unit-conversions.ipynb
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The parameters given in the table above are retrived from the coordinates or attributes of the input data.\n",
+    "The parameters given in the table above are retrieved from the coordinates or attributes of the input data.\n",
     "The following graph illustrates which coords (or attrs) are known and used by `convert`.\n",
     "Read the graph as follows:\n",
     "- Ellipses represent geometry-related parameters of the beamline, e.g., `two_theta`.\n",
@@ -130,7 +130,7 @@
     "- If, e.g., `L2` is not found it is computed as the norm of the `scattered_beam` coord or attr.\n",
     "- If, `scattered_beam` is not found it us computed as `position - sample_position`.\n",
     "\n",
-    "There are two case, scattering conversion and non-scattering conversion (e.g., for beam monitors or for imaging beamlines).\n",
+    "There are two cases, scattering conversion and non-scattering conversion (e.g., for beam monitors or for imaging beamlines).\n",
     "\n",
     "Case 1: `convert(..., scatter=True)`"
    ]

--- a/docs/user-guide/unit-conversions.ipynb
+++ b/docs/user-guide/unit-conversions.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Unit conversions"
+    "# Unit conversions\n",
+    "\n",
+    "## Available conversions"
    ]
   },
   {
@@ -45,6 +47,118 @@
     "| `tof`|`energy_transfer` (indirect)|$E = \\frac{m_{\\mathrm{n}}L^2_{\\mathrm{1}}}{2\\left(t-t_0\\right)^{2}} - E_f$|\n",
     "|`energy`|`tof`|$t = \\frac{L_{\\mathrm{total}}}{\\sqrt{\\frac{2 E}{m_{\\mathrm{n}}}}}$|"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Beamline geometry parameters used in unit conversions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "from graphviz import Digraph\n",
+    "dot = Digraph()\n",
+    "dot.edge('source_position', 'incident_beam')\n",
+    "dot.edge('sample_position', 'incident_beam')\n",
+    "dot.edge('position', 'scattered_beam')\n",
+    "dot.edge('sample_position', 'scattered_beam')\n",
+    "dot.edge('incident_beam', 'L1', label='norm')\n",
+    "dot.edge('scattered_beam', 'L2', label='norm')\n",
+    "dot.edge('L1', 'Ltotal')\n",
+    "dot.edge('L2', 'Ltotal')\n",
+    "dot.edge('incident_beam', 'two_theta')\n",
+    "dot.edge('scattered_beam', 'two_theta')\n",
+    "dot.node('wavelength', shape='box', style='filled', color='lightgrey')\n",
+    "dot.node('energy', shape='box', style='filled', color='lightgrey')\n",
+    "dot.node('energy_transfer (direct)', shape='box', style='filled', color='lightgrey')\n",
+    "dot.node('energy_transfer (indirect)', shape='box', style='filled', color='lightgrey')\n",
+    "dot.node('dspacing', shape='box', style='filled', color='lightgrey')\n",
+    "dot.node('Q', shape='box', style='filled', color='lightgrey')\n",
+    "dot.edge('Ltotal', 'energy')\n",
+    "dot.edge('L1', 'energy_transfer (direct)')\n",
+    "dot.edge('L2', 'energy_transfer (direct)')\n",
+    "dot.edge('incident_energy', 'energy_transfer (direct)')\n",
+    "dot.edge('L1', 'energy_transfer (indirect)')\n",
+    "dot.edge('L2', 'energy_transfer (indirect)')\n",
+    "dot.edge('final_energy', 'energy_transfer (indirect)')\n",
+    "dot.edge('Ltotal', 'wavelength')\n",
+    "dot.edge('Ltotal', 'dspacing')\n",
+    "dot.edge('two_theta', 'dspacing')\n",
+    "dot.edge('two_theta', 'Q')\n",
+    "dot.edge('wavelength', 'Q')\n",
+    "scattering = dot\n",
+    "\n",
+    "dot = Digraph()\n",
+    "dot.edge('source_position', 'Ltotal')\n",
+    "dot.edge('position', 'Ltotal')\n",
+    "dot.node('wavelength', shape='box', style='filled', color='lightgrey')\n",
+    "dot.node('energy', shape='box', style='filled', color='lightgrey')\n",
+    "dot.edge('Ltotal', 'energy')\n",
+    "dot.edge('Ltotal', 'wavelength')\n",
+    "nonscattering = dot\n",
+    "\n",
+    "def show_geometry_params(scatter):\n",
+    "    if scatter:\n",
+    "        display(scattering)\n",
+    "    else:\n",
+    "        display(nonscattering)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parameters given in the table above are retrived from the coordinates or attributes of the input data.\n",
+    "The following graph illustrates which coords (or attrs) are known and used by `convert`.\n",
+    "Read the graph as follows:\n",
+    "- Ellipses represent geometry-related parameters of the beamline, e.g., `two_theta`.\n",
+    "- The grey rectangles denote an input or output unit, e.g., `wavelength`.\n",
+    "- A unit conversion involving a particular input or output unit will require the parameters connected to the rectangle by arrows.\n",
+    "- If a unit conversion requires a parameter the tree of paramameter ellipses is searched bottom-up.\n",
+    "\n",
+    "Example:\n",
+    "- Consider a unit conversion to `wavelength` (from, e.g., `tof`) *or* from `wavelength` (to, e.g., `tof`) will require the parameters connected to the rectangle by arrows, in this case `Ltotal`.\n",
+    "- If a coord or attr with name `Ltotal` is found it is used for the conversion.\n",
+    "- If `Ltotal` is not found it will be computed based on coords or attrs `L1` and `L2`.\n",
+    "- If, e.g., `L2` is not found it is computed as the norm of the `scattered_beam` coord or attr.\n",
+    "- If, `scattered_beam` is not found it us computed as `position - sample_position`.\n",
+    "\n",
+    "There are two case, scattering conversion and non-scattering conversion (e.g., for beam monitors or for imaging beamlines).\n",
+    "\n",
+    "Case 1: `convert(..., scatter=True)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_geometry_params(scatter=True) # helper defined in hidden cell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Case 2: `convert(..., scatter=False)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_geometry_params(scatter=False) # helper defined in hidden cell"
+   ]
   }
  ],
  "metadata": {
@@ -63,8 +177,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
-  }
+   "version": "3.7.10"
+  },
+  "toc-autonumbering": false,
+  "toc-showcode": false,
+  "toc-showmarkdowntxt": false,
+  "toc-showtags": false
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -25,26 +25,26 @@ VariableConstView sample_position(const dataset::CoordsConstView &meta) {
   return meta[Dim("sample_position")];
 }
 
-Variable flight_path_length(const dataset::CoordsConstView &meta,
-                            const ConvertMode scatter) {
+Variable Ltotal(const dataset::CoordsConstView &meta,
+                const ConvertMode scatter) {
   // TODO Avoid copies here and below if scipp buffer ownership model is changed
   if (meta.contains(Dim("Ltotal")))
     return copy(meta[Dim("Ltotal")]);
   // If there is not scattering this returns the straight distance from the
   // source, as required, e.g., for monitors or imaging.
   if (scatter == ConvertMode::Scatter)
-    return l1(meta) + l2(meta);
+    return L1(meta) + L2(meta);
   else
     return norm(position(meta) - source_position(meta));
 }
 
-Variable l1(const dataset::CoordsConstView &meta) {
+Variable L1(const dataset::CoordsConstView &meta) {
   if (meta.contains(Dim("L1")))
     return copy(meta[Dim("L1")]);
   return norm(incident_beam(meta));
 }
 
-Variable l2(const dataset::CoordsConstView &meta) {
+Variable L2(const dataset::CoordsConstView &meta) {
   if (meta.contains(Dim("L2")))
     return copy(meta[Dim("L2")]);
   if (meta.contains(Dim("scattered_beam")))

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -28,8 +28,8 @@ VariableConstView sample_position(const dataset::CoordsConstView &meta) {
 Variable flight_path_length(const dataset::CoordsConstView &meta,
                             const ConvertMode scatter) {
   // TODO Avoid copies here and below if scipp buffer ownership model is changed
-  if (meta.contains(Dim("L")))
-    return copy(meta[Dim("L")]);
+  if (meta.contains(Dim("Ltotal")))
+    return copy(meta[Dim("Ltotal")]);
   // If there is not scattering this returns the straight distance from the
   // source, as required, e.g., for monitors or imaging.
   if (scatter == ConvertMode::Scatter)

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -41,12 +41,14 @@ Variable flight_path_length(const dataset::CoordsConstView &meta,
 Variable l1(const dataset::CoordsConstView &meta) {
   if (meta.contains(Dim("L1")))
     return copy(meta[Dim("L1")]);
-  return norm(sample_position(meta) - source_position(meta));
+  return norm(incident_beam(meta));
 }
 
 Variable l2(const dataset::CoordsConstView &meta) {
   if (meta.contains(Dim("L2")))
     return copy(meta[Dim("L2")]);
+  if (meta.contains(Dim("scattered_beam")))
+    return norm(meta[Dim("scattered_beam")]);
   // Use transform to avoid temporaries. For certain unit conversions this can
   // cause a speedup >50%. Short version would be:
   //   return norm(position(meta) - sample_position(meta));
@@ -61,16 +63,30 @@ Variable scattering_angle(const dataset::CoordsConstView &meta) {
   return 0.5 * units::one * two_theta(meta);
 }
 
+Variable incident_beam(const dataset::CoordsConstView &meta) {
+  if (meta.contains(Dim("incident_beam")))
+    return copy(meta[Dim("incident_beam")]);
+  return sample_position(meta) - source_position(meta);
+}
+
+Variable scattered_beam(const dataset::CoordsConstView &meta) {
+  if (meta.contains(Dim("scattered_beam")))
+    return copy(meta[Dim("scattered_beam")]);
+  return position(meta) - sample_position(meta);
+}
+
+namespace {
+auto normalize(Variable &&var) {
+  const auto length = norm(var);
+  var /= length;
+  return std::move(var);
+}
+} // namespace
+
 Variable cos_two_theta(const dataset::CoordsConstView &meta) {
   if (meta.contains(Dim("two_theta")))
     return cos(meta[Dim("two_theta")]);
-  auto beam = sample_position(meta) - source_position(meta);
-  const auto l1 = norm(beam);
-  beam /= l1;
-  auto scattered = position(meta) - sample_position(meta);
-  const auto l2 = norm(scattered);
-  scattered /= l2;
-  return dot(beam, scattered);
+  return dot(normalize(incident_beam(meta)), normalize(scattered_beam(meta)));
 }
 
 Variable two_theta(const dataset::CoordsConstView &meta) {

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -54,15 +54,18 @@ Variable scattering_angle(const dataset::CoordsConstView &meta) {
   return 0.5 * units::one * two_theta(meta);
 }
 
-Variable two_theta(const dataset::CoordsConstView &meta) {
+Variable cos_two_theta(const dataset::CoordsConstView &meta) {
   auto beam = sample_position(meta) - source_position(meta);
   const auto l1 = norm(beam);
   beam /= l1;
   auto scattered = position(meta) - sample_position(meta);
   const auto l2 = norm(scattered);
   scattered /= l2;
+  return dot(beam, scattered);
+}
 
-  return acos(dot(beam, scattered));
+Variable two_theta(const dataset::CoordsConstView &meta) {
+  return acos(cos_two_theta(meta));
 }
 
 VariableConstView incident_energy(const dataset::CoordsConstView &meta) {

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -27,6 +27,9 @@ VariableConstView sample_position(const dataset::CoordsConstView &meta) {
 
 Variable flight_path_length(const dataset::CoordsConstView &meta,
                             const ConvertMode scatter) {
+  // TODO Avoid copies here and below if scipp buffer ownership model is changed
+  if (meta.contains(Dim("L")))
+    return copy(meta[Dim("L")]);
   // If there is not scattering this returns the straight distance from the
   // source, as required, e.g., for monitors or imaging.
   if (scatter == ConvertMode::Scatter)
@@ -36,10 +39,14 @@ Variable flight_path_length(const dataset::CoordsConstView &meta,
 }
 
 Variable l1(const dataset::CoordsConstView &meta) {
+  if (meta.contains(Dim("L1")))
+    return copy(meta[Dim("L1")]);
   return norm(sample_position(meta) - source_position(meta));
 }
 
 Variable l2(const dataset::CoordsConstView &meta) {
+  if (meta.contains(Dim("L2")))
+    return copy(meta[Dim("L2")]);
   // Use transform to avoid temporaries. For certain unit conversions this can
   // cause a speedup >50%. Short version would be:
   //   return norm(position(meta) - sample_position(meta));

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -62,6 +62,8 @@ Variable scattering_angle(const dataset::CoordsConstView &meta) {
 }
 
 Variable cos_two_theta(const dataset::CoordsConstView &meta) {
+  if (meta.contains(Dim("two_theta")))
+    return cos(meta[Dim("two_theta")]);
   auto beam = sample_position(meta) - source_position(meta);
   const auto l1 = norm(beam);
   beam /= l1;
@@ -72,6 +74,8 @@ Variable cos_two_theta(const dataset::CoordsConstView &meta) {
 }
 
 Variable two_theta(const dataset::CoordsConstView &meta) {
+  if (meta.contains(Dim("two_theta")))
+    return copy(meta[Dim("two_theta")]);
   return acos(cos_two_theta(meta));
 }
 

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -19,10 +19,10 @@ SCIPPNEUTRON_EXPORT VariableConstView
 source_position(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT VariableConstView
 sample_position(const dataset::CoordsConstView &meta);
-SCIPPNEUTRON_EXPORT Variable flight_path_length(
-    const dataset::CoordsConstView &meta, const ConvertMode scatter);
-SCIPPNEUTRON_EXPORT Variable l1(const dataset::CoordsConstView &meta);
-SCIPPNEUTRON_EXPORT Variable l2(const dataset::CoordsConstView &meta);
+SCIPPNEUTRON_EXPORT Variable Ltotal(const dataset::CoordsConstView &meta,
+                                    const ConvertMode scatter);
+SCIPPNEUTRON_EXPORT Variable L1(const dataset::CoordsConstView &meta);
+SCIPPNEUTRON_EXPORT Variable L2(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT Variable
 scattering_angle(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT Variable

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -25,6 +25,8 @@ SCIPPNEUTRON_EXPORT Variable l1(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT Variable l2(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT Variable
 scattering_angle(const dataset::CoordsConstView &meta);
+SCIPPNEUTRON_EXPORT Variable
+cos_two_theta(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT Variable two_theta(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT VariableConstView
 incident_energy(const dataset::CoordsConstView &meta);

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -32,5 +32,9 @@ SCIPPNEUTRON_EXPORT VariableConstView
 incident_energy(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT VariableConstView
 final_energy(const dataset::CoordsConstView &meta);
+SCIPPNEUTRON_EXPORT Variable
+incident_beam(const dataset::CoordsConstView &meta);
+SCIPPNEUTRON_EXPORT Variable
+scattered_beam(const dataset::CoordsConstView &meta);
 
 } // namespace scipp::neutron

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -41,24 +41,11 @@ constexpr auto tof_to_wavelength_physical_constants =
     llnl::units::constants::mn;
 
 template <class T> auto tof_to_dspacing(const T &d) {
-  const auto &sourcePos = source_position(d.meta());
-  const auto &samplePos = sample_position(d.meta());
-
-  auto beam = samplePos - sourcePos;
-  const auto l1 = norm(beam);
-  beam /= l1;
-  auto scattered = position(d.meta()) - samplePos;
-  const auto l2 = norm(scattered);
-  scattered /= l2;
-
-  // l_total = l1 + l2
-  auto conversionFactor(l1 + l2);
-
-  conversionFactor *= Variable(tof_to_dspacing_physical_constants * sqrt(0.5));
-  conversionFactor *= sqrt(1.0 * units::one - dot(beam, scattered));
-
-  reciprocal(conversionFactor, conversionFactor);
-  return conversionFactor;
+  auto factor = flight_path_length(d.meta(), ConvertMode::Scatter);
+  factor *= Variable(tof_to_dspacing_physical_constants * sqrt(0.5));
+  factor *= sqrt(1.0 * units::one - cos_two_theta(d.meta()));
+  reciprocal(factor, factor);
+  return factor;
 }
 
 template <class T>

--- a/neutron/include/scipp/neutron/constants.h
+++ b/neutron/include/scipp/neutron/constants.h
@@ -41,7 +41,7 @@ constexpr auto tof_to_wavelength_physical_constants =
     llnl::units::constants::mn;
 
 template <class T> auto tof_to_dspacing(const T &d) {
-  auto factor = flight_path_length(d.meta(), ConvertMode::Scatter);
+  auto factor = Ltotal(d.meta(), ConvertMode::Scatter);
   factor *= Variable(tof_to_dspacing_physical_constants * sqrt(0.5));
   factor *= sqrt(1.0 * units::one - cos_two_theta(d.meta()));
   reciprocal(factor, factor);
@@ -51,7 +51,7 @@ template <class T> auto tof_to_dspacing(const T &d) {
 template <class T>
 static auto tof_to_wavelength(const T &d, const ConvertMode scatter) {
   return Variable(tof_to_wavelength_physical_constants) /
-         flight_path_length(d.meta(), scatter);
+         Ltotal(d.meta(), scatter);
 }
 
 template <class T> auto tof_to_energy(const T &d, const ConvertMode scatter) {
@@ -60,7 +60,7 @@ template <class T> auto tof_to_energy(const T &d, const ConvertMode scatter) {
         "Data contains coords for incident or final energy. Conversion to "
         "energy for inelastic data not implemented yet.");
   // l_total = l1 + l2
-  auto conversionFactor = flight_path_length(d.meta(), scatter);
+  auto conversionFactor = Ltotal(d.meta(), scatter);
   // l_total^2
   conversionFactor *= conversionFactor;
   conversionFactor *= Variable(tof_to_energy_physical_constants);
@@ -79,10 +79,10 @@ template <class T> auto tof_to_energy_transfer(const T &d) {
         "Data contains neither coords for incident nor for final energy, this "
         "does not appear to be inelastic-scattering data, cannot convert to "
         "energy transfer.");
-  auto l1_square = l1(d.meta());
+  auto l1_square = L1(d.meta());
   l1_square *= l1_square;
   l1_square *= Variable(tof_to_energy_physical_constants);
-  auto l2_square = l2(d.meta());
+  auto l2_square = L2(d.meta());
   l2_square *= l2_square;
   l2_square *= Variable(tof_to_energy_physical_constants);
   if (Ei) { // Direct-inelastic.

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -134,7 +134,7 @@ TEST_F(BeamlineTest, flight_path_length) {
   ASSERT_EQ(flight_path_length(dataset.meta(), ConvertMode::NoScatter),
             norm(source_position(dataset.meta()) - position(dataset.meta())));
   const auto L_override = l1(dataset.meta()) + L2_override * (1.1 * units::one);
-  dataset.coords().set(Dim("L"), L_override);
+  dataset.coords().set(Dim("Ltotal"), L_override);
   // Note that now L2 is also overridden by L
   ASSERT_EQ(flight_path_length(dataset.meta(), ConvertMode::Scatter),
             L_override);

--- a/neutron/test/constants_test.cpp
+++ b/neutron/test/constants_test.cpp
@@ -49,17 +49,17 @@ Variable scattering_angle(const Dummy &) {
   return 0.123 * units::rad;
 }
 
-Variable l1(const Dummy &dummy) {
+Variable L1(const Dummy &dummy) {
   return norm(sample_position(dummy) - source_position(dummy));
 }
 
-Variable l2(const Dummy &dummy) {
+Variable L2(const Dummy &dummy) {
   return norm(position(dummy) - sample_position(dummy));
 }
 
-Variable flight_path_length(const Dummy &dummy, const ConvertMode scatter) {
+Variable Ltotal(const Dummy &dummy, const ConvertMode scatter) {
   if (scatter == ConvertMode::Scatter)
-    return l1(dummy) + l2(dummy);
+    return L1(dummy) + L2(dummy);
   else
     return norm(position(dummy) - source_position(dummy));
 }
@@ -73,15 +73,15 @@ class ConstantsTest : public ::testing::Test {
 protected:
   mock::Dummy dummy;
   const Variable theta = mock::scattering_angle(dummy);
-  const Variable L1 = mock::l1(dummy);
-  const Variable L2 = mock::l2(dummy);
+  const Variable L1 = mock::L1(dummy);
+  const Variable L2 = mock::L2(dummy);
   const Variable source = mock::source_position(dummy);
   const Variable sample = mock::sample_position(dummy);
   const Variable det = mock::position(dummy);
 };
 
 TEST_F(ConstantsTest, tof_to_dspacing) {
-  const Variable L = mock::flight_path_length(dummy, ConvertMode::Scatter);
+  const Variable L = mock::Ltotal(dummy, ConvertMode::Scatter);
   EXPECT_EQ(constants::tof_to_dspacing(dummy),
             reciprocal(L *
                        Variable(constants::tof_to_dspacing_physical_constants *
@@ -91,7 +91,7 @@ TEST_F(ConstantsTest, tof_to_dspacing) {
 
 TEST_F(ConstantsTest, tof_to_wavelength) {
   for (const auto &scatter : {ConvertMode::Scatter, ConvertMode::NoScatter}) {
-    auto L = mock::flight_path_length(dummy, scatter);
+    auto L = mock::Ltotal(dummy, scatter);
     EXPECT_EQ(constants::tof_to_wavelength(dummy, scatter),
               Variable(constants::tof_to_wavelength_physical_constants) / L);
   }
@@ -99,7 +99,7 @@ TEST_F(ConstantsTest, tof_to_wavelength) {
 
 TEST_F(ConstantsTest, tof_to_energy) {
   for (const auto &scatter : {ConvertMode::Scatter, ConvertMode::NoScatter}) {
-    auto L = mock::flight_path_length(dummy, scatter);
+    auto L = mock::Ltotal(dummy, scatter);
     EXPECT_EQ(constants::tof_to_energy(dummy, scatter),
               L * L * Variable(constants::tof_to_energy_physical_constants));
   }

--- a/neutron/test/constants_test.cpp
+++ b/neutron/test/constants_test.cpp
@@ -34,6 +34,16 @@ Variable position(const Dummy &) {
       units::m);
 }
 
+Variable cos_two_theta(const Dummy &) {
+  // Note: Not related to actual positions.
+  return cos(2.0 * 0.123 * units::rad);
+}
+
+Variable two_theta(const Dummy &) {
+  // Note: Not related to actual positions.
+  return 2.0 * 0.123 * units::rad;
+}
+
 Variable scattering_angle(const Dummy &) {
   // Note: Not related to actual positions.
   return 0.123 * units::rad;
@@ -68,18 +78,6 @@ protected:
   const Variable source = mock::source_position(dummy);
   const Variable sample = mock::sample_position(dummy);
   const Variable det = mock::position(dummy);
-
-  Variable normalized_beam() const {
-    auto beam = sample - source;
-    beam /= norm(beam);
-    return beam;
-  }
-
-  Variable normalized_scatter() const {
-    auto scatter = det - sample;
-    scatter /= norm(scatter);
-    return scatter;
-  }
 };
 
 TEST_F(ConstantsTest, tof_to_dspacing) {
@@ -88,8 +86,7 @@ TEST_F(ConstantsTest, tof_to_dspacing) {
             reciprocal(L *
                        Variable(constants::tof_to_dspacing_physical_constants *
                                 sqrt(0.5)) *
-                       sqrt(1.0 * units::one -
-                            dot(normalized_beam(), normalized_scatter()))));
+                       sqrt(1.0 * units::one - cos(two_theta(dummy)))));
 }
 
 TEST_F(ConstantsTest, tof_to_wavelength) {

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -40,9 +40,8 @@ template <class T> void bind_beamline(py::module &m) {
   m.def(
       "Ltotal",
       [](ConstView self, const bool scatter) {
-        return flight_path_length(self.meta(), scatter
-                                                   ? ConvertMode::Scatter
-                                                   : ConvertMode::NoScatter);
+        return Ltotal(self.meta(),
+                      scatter ? ConvertMode::Scatter : ConvertMode::NoScatter);
       },
       py::arg("data"), py::arg("scatter"),
       R"(
@@ -70,14 +69,14 @@ template <class T> void bind_beamline(py::module &m) {
     :rtype: Variable)");
 
   m.def(
-      "L1", [](ConstView self) { return l1(self.meta()); }, R"(
+      "L1", [](ConstView self) { return L1(self.meta()); }, R"(
     Compute L1, the length of the primary flight path (distance between neutron source and sample) from a data array or a dataset.
 
     :return: A scalar variable containing L1.
     :rtype: Variable)");
 
   m.def(
-      "L2", [](ConstView self) { return l2(self.meta()); }, R"(
+      "L2", [](ConstView self) { return L2(self.meta()); }, R"(
     Compute L2, the length of the secondary flight paths (distances between sample and detector pixels) from a data array or a dataset.
 
     :return: A variable containing L2 for all detector pixels.

--- a/python/neutron.cpp
+++ b/python/neutron.cpp
@@ -38,7 +38,7 @@ template <class T> void bind_beamline(py::module &m) {
     :rtype: Variable)");
 
   m.def(
-      "flight_path_length",
+      "Ltotal",
       [](ConstView self, const bool scatter) {
         return flight_path_length(self.meta(), scatter
                                                    ? ConvertMode::Scatter
@@ -48,31 +48,39 @@ template <class T> void bind_beamline(py::module &m) {
       R"(
     Compute the length of the total flight path from a data array or a dataset.
 
-    If `scatter=True` this is the sum of `l1` and `l2`, otherwise the distance between `source_position` and `position`.
+    If `scatter=True` this is defined as the sum of `L1` and `L2`, otherwise the distance between `source_position` and `position`.
 
     :return: A scalar variable containing the total length of the flight path.
     :rtype: Variable)");
 
   m.def(
-      "l1", [](ConstView self) { return l1(self.meta()); }, R"(
+      "incident_beam",
+      [](ConstView self) { return incident_beam(self.meta()); }, R"(
+    Compute the indicent beam vector, the direction and length of the primary flight path from a data array or a dataset.
+
+    :return: A scalar variable containing the incident beam vector.
+    :rtype: Variable)");
+
+  m.def(
+      "scattered_beam",
+      [](ConstView self) { return scattered_beam(self.meta()); }, R"(
+    Compute the scattered beam, the directions and lengths of the secondary flight paths from a data array or a dataset.
+
+    :return: A variable containing the scattered beam vectors for all detector pixels.
+    :rtype: Variable)");
+
+  m.def(
+      "L1", [](ConstView self) { return l1(self.meta()); }, R"(
     Compute L1, the length of the primary flight path (distance between neutron source and sample) from a data array or a dataset.
 
     :return: A scalar variable containing L1.
     :rtype: Variable)");
 
   m.def(
-      "l2", [](ConstView self) { return l2(self.meta()); }, R"(
+      "L2", [](ConstView self) { return l2(self.meta()); }, R"(
     Compute L2, the length of the secondary flight paths (distances between sample and detector pixels) from a data array or a dataset.
 
     :return: A variable containing L2 for all detector pixels.
-    :rtype: Variable)");
-
-  m.def(
-      "scattering_angle",
-      [](ConstView self) { return scattering_angle(self.meta()); }, R"(
-    Compute :math:`\theta`, the scattering angle in Bragg's law, from a data array or a dataset.
-
-    :return: A variable containing :math:`\theta` for all detector pixels.
     :rtype: Variable)");
 
   m.def(

--- a/python/src/scippneutron/__init__.py
+++ b/python/src/scippneutron/__init__.py
@@ -7,7 +7,7 @@
 
 from ._scippneutron import __version__
 from ._scippneutron import convert
-from ._scippneutron import position, source_position, sample_position, flight_path_length, l1, l2, scattering_angle, two_theta
+from ._scippneutron import position, source_position, sample_position, incident_beam, scattered_beam, Ltotal, L1, L2, two_theta
 from .mantid import from_mantid, to_mantid, load, fit
 from .instrument_view import instrument_view
 from .load_nexus import load_nexus

--- a/python/tests/mantid_scipp_comparison/test_beamline_calculations.py
+++ b/python/tests/mantid_scipp_comparison/test_beamline_calculations.py
@@ -30,7 +30,7 @@ class TestBeamlineCalculations:
                 return data.detectorInfo().l1() * sc.Unit('m')
 
             def _run_scipp(self, data):
-                return sn.l1(data)
+                return sn.L1(data)
 
         test = L1Comparison()
         test.run()
@@ -44,7 +44,7 @@ class TestBeamlineCalculations:
                     values=[data.detectorInfo().l2(i) for i in [0, 1, 2, 3]])
 
             def _run_scipp(self, data):
-                return sn.l2(data)
+                return sn.L2(data)
 
         test = L2Comparison()
         test.run()

--- a/python/tests/mantid_scipp_comparison/test_beamline_calculations.py
+++ b/python/tests/mantid_scipp_comparison/test_beamline_calculations.py
@@ -14,7 +14,7 @@ class BeamlineComparision(MantidScippComparison):
         import mantid.simpleapi as sapi
         ws = sapi.CreateSampleWorkspace(SourceDistanceFromSample=10.0,
                                         BankDistanceFromSample=1.1,
-                                        BankPixelWidth=1,
+                                        BankPixelWidth=2,
                                         NumBanks=1,
                                         XMax=200,
                                         StoreInADS=False)
@@ -26,33 +26,41 @@ class BeamlineComparision(MantidScippComparison):
 class TestBeamlineCalculations:
     def test_beamline_calculations_l1(self):
         class L1Comparison(BeamlineComparision):
-            def _run_mantid(self, input):
-                return input.detectorInfo().l1() * sc.Unit('m')
+            def _run_mantid(self, data):
+                return data.detectorInfo().l1() * sc.Unit('m')
 
-            def _run_scipp(self, input):
-                return sn.l1(input)
+            def _run_scipp(self, data):
+                return sn.l1(data)
 
         test = L1Comparison()
         test.run()
 
     def test_bealine_calculations_l2(self):
         class L2Comparison(BeamlineComparision):
-            def _run_mantid(self, input):
-                return input.detectorInfo().l2(0) * sc.Unit('m')
+            def _run_mantid(self, data):
+                return sc.array(
+                    dims=['spectrum'],
+                    unit='m',
+                    values=[data.detectorInfo().l2(i) for i in [0, 1, 2, 3]])
 
-            def _run_scipp(self, input):
-                return sn.l2(input)
+            def _run_scipp(self, data):
+                return sn.l2(data)
 
         test = L2Comparison()
         test.run()
 
     def test_bealine_calculations_two_theta(self):
         class TwoThetaComparison(BeamlineComparision):
-            def _run_mantid(self, input):
-                return input.detectorInfo().twoTheta(0) * sc.Unit('rad')
+            def _run_mantid(self, data):
+                return sc.array(dims=['spectrum'],
+                                unit='rad',
+                                values=[
+                                    data.detectorInfo().twoTheta(i)
+                                    for i in [0, 1, 2, 3]
+                                ])
 
-            def _run_scipp(self, input):
-                return sn.scattering_angle(input)
+            def _run_scipp(self, data):
+                return sn.two_theta(data)
 
         test = TwoThetaComparison()
         test.run()

--- a/python/tests/test_neutron.py
+++ b/python/tests/test_neutron.py
@@ -67,7 +67,7 @@ def test_neutron_beamline():
         scn.L2(d),
         sc.Variable(dims=['position'], values=np.ones(4), unit=sc.units.m))
     two_theta = scn.two_theta(d)
-    assert scn.L1(d) + scn.L2(d) == scn.Ltotal(d, scatter=True)
+    assert sc.is_equal(scn.L1(d) + scn.L2(d), scn.Ltotal(d, scatter=True))
     assert two_theta.unit == sc.units.rad
     assert two_theta.dims == ['position']
 

--- a/python/tests/test_neutron.py
+++ b/python/tests/test_neutron.py
@@ -67,7 +67,7 @@ def test_neutron_beamline():
         scn.L2(d),
         sc.Variable(dims=['position'], values=np.ones(4), unit=sc.units.m))
     two_theta = scn.two_theta(d)
-    assert scn.L1(d) + scn.L2(d) == scn.Ltotal(d)
+    assert scn.L1(d) + scn.L2(d) == scn.Ltotal(d, scatter=True)
     assert two_theta.unit == sc.units.rad
     assert two_theta.dims == ['position']
 

--- a/python/tests/test_neutron.py
+++ b/python/tests/test_neutron.py
@@ -62,14 +62,14 @@ def test_neutron_beamline():
         sc.Variable(value=np.array([0, 0, 0]),
                     dtype=sc.dtype.vector_3_float64,
                     unit=sc.units.m))
-    assert sc.is_equal(scn.l1(d), 10.0 * sc.units.m)
+    assert sc.is_equal(scn.L1(d), 10.0 * sc.units.m)
     assert sc.is_equal(
-        scn.l2(d),
+        scn.L2(d),
         sc.Variable(dims=['position'], values=np.ones(4), unit=sc.units.m))
     two_theta = scn.two_theta(d)
+    assert scn.L1(d) + scn.L2(d) == scn.Ltotal(d)
     assert two_theta.unit == sc.units.rad
     assert two_theta.dims == ['position']
-    assert sc.is_equal(scn.scattering_angle(d), 0.5 * two_theta)
 
 
 def test_neutron_instrument_view_3d():

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -45,3 +45,4 @@ dependencies:
   - sphinx=3.4.3 # see https://github.com/sphinx-doc/sphinx/issues/8885
   - sphinx_rtd_theme
   - nbsphinx
+  - python-graphviz

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -45,3 +45,4 @@ dependencies:
   - sphinx=3.4.3 # see https://github.com/sphinx-doc/sphinx/issues/8885
   - sphinx_rtd_theme
   - nbsphinx
+  - python-graphviz


### PR DESCRIPTION
Fixes https://github.com/scipp/scipp/issues/1672 (and more).

How does it work?
- All operations try to refer only to what the actually need to know, e.g., `L2` instead of `position` and `sample_position`. The helper functions `l2` can then figure out how to obtain it.
- Most explicit matching coords take priority.

Todo (Future):
- Considering to support providing overriding via arguments to `convert` rather than via coords, but this is more complicated, and could become easier if the ownership model is changed. I suggest to avoid this for now. This would make it slightly ambiguous as to whether existing coords or coords from args are used, so maybe we want to avoid this entirely.