### PR TITLE
Add Neutron dim labels

### DIFF
--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -42,18 +42,18 @@ VariableConstView position(const dataset::CoordsConstView &meta) {
 }
 
 VariableConstView source_position(const dataset::CoordsConstView &meta) {
-  return meta[Dim("source_position")];
+  return meta[NeutronDim::SourcePosition];
 }
 
 VariableConstView sample_position(const dataset::CoordsConstView &meta) {
-  return meta[Dim("sample_position")];
+  return meta[NeutronDim::SamplePosition];
 }
 
 Variable Ltotal(const dataset::CoordsConstView &meta,
                 const ConvertMode scatter) {
   // TODO Avoid copies here and below if scipp buffer ownership model is changed
-  if (meta.contains(Dim("Ltotal")))
-    return copy(meta[Dim("Ltotal")]);
+  if (meta.contains(NeutronDim::Ltotal))
+    return copy(meta[NeutronDim::Ltotal]);
   // If there is not scattering this returns the straight distance from the
   // source, as required, e.g., for monitors or imaging.
   if (scatter == ConvertMode::Scatter)
@@ -63,16 +63,16 @@ Variable Ltotal(const dataset::CoordsConstView &meta,
 }
 
 Variable L1(const dataset::CoordsConstView &meta) {
-  if (meta.contains(Dim("L1")))
-    return copy(meta[Dim("L1")]);
+  if (meta.contains(NeutronDim::L1))
+    return copy(meta[NeutronDim::L1]);
   return norm(incident_beam(meta));
 }
 
 Variable L2(const dataset::CoordsConstView &meta) {
-  if (meta.contains(Dim("L2")))
-    return copy(meta[Dim("L2")]);
-  if (meta.contains(Dim("scattered_beam")))
-    return norm(meta[Dim("scattered_beam")]);
+  if (meta.contains(NeutronDim::L2))
+    return copy(meta[NeutronDim::L2]);
+  if (meta.contains(NeutronDim::ScatteredBeam))
+    return norm(meta[NeutronDim::ScatteredBeam]);
   // Use transform to avoid temporaries. For certain unit conversions this can
   // cause a speedup >50%. Short version would be:
   //   return norm(position(meta) - sample_position(meta));
@@ -88,14 +88,14 @@ Variable scattering_angle(const dataset::CoordsConstView &meta) {
 }
 
 Variable incident_beam(const dataset::CoordsConstView &meta) {
-  if (meta.contains(Dim("incident_beam")))
-    return copy(meta[Dim("incident_beam")]);
+  if (meta.contains(NeutronDim::IncidentBeam))
+    return copy(meta[NeutronDim::IncidentBeam]);
   return sample_position(meta) - source_position(meta);
 }
 
 Variable scattered_beam(const dataset::CoordsConstView &meta) {
-  if (meta.contains(Dim("scattered_beam")))
-    return copy(meta[Dim("scattered_beam")]);
+  if (meta.contains(NeutronDim::ScatteredBeam))
+    return copy(meta[NeutronDim::ScatteredBeam]);
   return position(meta) - sample_position(meta);
 }
 
@@ -108,14 +108,14 @@ auto normalize(Variable &&var) {
 } // namespace
 
 Variable cos_two_theta(const dataset::CoordsConstView &meta) {
-  if (meta.contains(Dim("two_theta")))
-    return cos(meta[Dim("two_theta")]);
+  if (meta.contains(NeutronDim::TwoTheta))
+    return cos(meta[NeutronDim::TwoTheta]);
   return dot(normalize(incident_beam(meta)), normalize(scattered_beam(meta)));
 }
 
 Variable two_theta(const dataset::CoordsConstView &meta) {
-  if (meta.contains(Dim("two_theta")))
-    return copy(meta[Dim("two_theta")]);
+  if (meta.contains(NeutronDim::TwoTheta))
+    return copy(meta[NeutronDim::TwoTheta]);
   return acos(cos_two_theta(meta));
 }
 

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -14,27 +14,27 @@ using namespace scipp;
 namespace scipp::neutron {
 
 namespace NeutronDim {
-Dim Tof = Dim("tof");
+Dim DSpacing = Dim("dspacing");
 Dim Energy = Dim("energy");
 Dim EnergyTransfer = Dim("energy_transfer");
-Dim DSpacing = Dim("dspacing");
+Dim FinalEnergy = Dim("final_energy");
+Dim IncidentBeam = Dim("incident_beam");
+Dim IncidentEnergy = Dim("incident_energy");
+Dim L1 = Dim("L1");
+Dim L2 = Dim("L2");
+Dim Ltotal = Dim("Ltotal");
+Dim Position = Dim("position");
 Dim Q = Dim("Q");
 Dim Qx = Dim("Qx");
 Dim Qy = Dim("Qy");
 Dim Qz = Dim("Qz");
-Dim TwoTheta = Dim("two_theta");
 Dim SamplePosition = Dim("sample_position");
-Dim SourcePosition = Dim("source_position");
-Dim Position = Dim("position");
-Dim L1 = Dim("L1");
-Dim L2 = Dim("L2");
-Dim Ltotal = Dim("Ltotal");
-Dim IncidentBeam = Dim("incident_beam");
 Dim ScatteredBeam = Dim("scattered_beam");
-Dim IncidentEnergy = Dim("incident_energy");
-Dim FinalEnergy = Dim("final_energy");
-Dim Wavelength = Dim("wavelength");
+Dim SourcePosition = Dim("source_position");
 Dim Spectrum = Dim("spectrum");
+Dim Tof = Dim("tof");
+Dim TwoTheta = Dim("two_theta");
+Dim Wavelength = Dim("wavelength");
 } // namespace NeutronDim
 
 VariableConstView position(const dataset::CoordsConstView &meta) {

--- a/neutron/beamline.cpp
+++ b/neutron/beamline.cpp
@@ -13,8 +13,32 @@ using namespace scipp;
 
 namespace scipp::neutron {
 
+namespace NeutronDim {
+Dim Tof = Dim("tof");
+Dim Energy = Dim("energy");
+Dim EnergyTransfer = Dim("energy_transfer");
+Dim DSpacing = Dim("dspacing");
+Dim Q = Dim("Q");
+Dim Qx = Dim("Qx");
+Dim Qy = Dim("Qy");
+Dim Qz = Dim("Qz");
+Dim TwoTheta = Dim("two_theta");
+Dim SamplePosition = Dim("sample_position");
+Dim SourcePosition = Dim("source_position");
+Dim Position = Dim("position");
+Dim L1 = Dim("L1");
+Dim L2 = Dim("L2");
+Dim Ltotal = Dim("Ltotal");
+Dim IncidentBeam = Dim("incident_beam");
+Dim ScatteredBeam = Dim("scattered_beam");
+Dim IncidentEnergy = Dim("incident_energy");
+Dim FinalEnergy = Dim("final_energy");
+Dim Wavelength = Dim("wavelength");
+Dim Spectrum = Dim("spectrum");
+} // namespace NeutronDim
+
 VariableConstView position(const dataset::CoordsConstView &meta) {
-  return meta[Dim::Position];
+  return meta[NeutronDim::Position];
 }
 
 VariableConstView source_position(const dataset::CoordsConstView &meta) {
@@ -96,13 +120,14 @@ Variable two_theta(const dataset::CoordsConstView &meta) {
 }
 
 VariableConstView incident_energy(const dataset::CoordsConstView &meta) {
-  return meta.contains(Dim::IncidentEnergy) ? meta[Dim::IncidentEnergy]
-                                            : VariableConstView{};
+  return meta.contains(NeutronDim::IncidentEnergy)
+             ? meta[NeutronDim::IncidentEnergy]
+             : VariableConstView{};
 }
 
 VariableConstView final_energy(const dataset::CoordsConstView &meta) {
-  return meta.contains(Dim::FinalEnergy) ? meta[Dim::FinalEnergy]
-                                         : VariableConstView{};
+  return meta.contains(NeutronDim::FinalEnergy) ? meta[NeutronDim::FinalEnergy]
+                                                : VariableConstView{};
 }
 
 } // namespace scipp::neutron

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -87,18 +87,19 @@ static T convert_with_factor(T &&d, const Dim from, const Dim to,
 
 namespace {
 
-const std::array<Dim, 2> no_scatter_params{NeutronDim::Position, Dim("Ltotal")};
+const std::array<Dim, 2> no_scatter_params{NeutronDim::Position,
+                                           NeutronDim::Ltotal};
 
 auto scatter_params(const Dim dim) {
   static std::set<Dim> pos_invariant{NeutronDim::DSpacing, NeutronDim::Q};
   static std::vector<Dim> params{NeutronDim::Position,
-                                 Dim("incident_beam"),
-                                 Dim("scattered_beam"),
+                                 NeutronDim::IncidentBeam,
+                                 NeutronDim::ScatteredBeam,
                                  NeutronDim::IncidentEnergy,
                                  NeutronDim::FinalEnergy,
-                                 Dim("Ltotal"),
-                                 Dim("L1"),
-                                 Dim("L2")};
+                                 NeutronDim::Ltotal,
+                                 NeutronDim::L1,
+                                 NeutronDim::L2};
   if (dim == NeutronDim::Tof)
     return scipp::span<Dim>{};
   return pos_invariant.count(dim) ? scipp::span(params)

--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -87,19 +87,19 @@ static T convert_with_factor(T &&d, const Dim from, const Dim to,
 
 namespace {
 
-const std::array<Dim, 2> no_scatter_params{Dim::Position, Dim("Ltotal")};
+const std::array<Dim, 2> no_scatter_params{NeutronDim::Position, Dim("Ltotal")};
 
 auto scatter_params(const Dim dim) {
-  static std::set<Dim> pos_invariant{Dim::DSpacing, Dim::Q};
-  static std::vector<Dim> params{Dim::Position,
+  static std::set<Dim> pos_invariant{NeutronDim::DSpacing, NeutronDim::Q};
+  static std::vector<Dim> params{NeutronDim::Position,
                                  Dim("incident_beam"),
                                  Dim("scattered_beam"),
-                                 Dim::IncidentEnergy,
-                                 Dim::FinalEnergy,
+                                 NeutronDim::IncidentEnergy,
+                                 NeutronDim::FinalEnergy,
                                  Dim("Ltotal"),
                                  Dim("L1"),
                                  Dim("L2")};
-  if (dim == Dim::Tof)
+  if (dim == NeutronDim::Tof)
     return scipp::span<Dim>{};
   return pos_invariant.count(dim) ? scipp::span(params)
                                   : scipp::span(params).subspan(3);
@@ -124,7 +124,7 @@ T coords_to_attrs(T &&x, const Dim from, const Dim to,
   if (scatter == ConvertMode::Scatter) {
     for (const auto &param : scatter_params(to))
       to_attr(param);
-  } else if (from == Dim::Tof) {
+  } else if (from == NeutronDim::Tof) {
     for (const auto &param : no_scatter_params)
       to_attr(param);
   }
@@ -153,7 +153,7 @@ T attrs_to_coords(T &&x, const Dim from, const Dim to,
   if (scatter == ConvertMode::Scatter) {
     for (const auto &param : scatter_params(from))
       to_coord(param);
-  } else if (to == Dim::Tof) {
+  } else if (to == NeutronDim::Tof) {
     for (const auto &param : no_scatter_params)
       to_coord(param);
   }
@@ -161,7 +161,8 @@ T attrs_to_coords(T &&x, const Dim from, const Dim to,
 }
 
 void check_scattering(const Dim from, const Dim to, const ConvertMode scatter) {
-  std::set<Dim> scattering{Dim::DSpacing, Dim::Q, Dim::EnergyTransfer};
+  std::set<Dim> scattering{NeutronDim::DSpacing, NeutronDim::Q,
+                           NeutronDim::EnergyTransfer};
   if ((scatter == ConvertMode::NoScatter) &&
       (scattering.count(from) || scattering.count(to)))
     throw std::runtime_error(
@@ -188,47 +189,48 @@ T convert_impl(T d, const Dim from, const Dim to, const ConvertMode scatter) {
   // tricky, since in particular the conversions are generic lambdas (passable
   // to `transform`) and are not readily stored as function pointers or
   // std::function.
-  if ((from == Dim::Tof) && (to == Dim::DSpacing))
+  if ((from == NeutronDim::Tof) && (to == NeutronDim::DSpacing))
     return convert_with_factor(std::move(d), from, to,
                                constants::tof_to_dspacing(d));
-  if ((from == Dim::DSpacing) && (to == Dim::Tof))
+  if ((from == NeutronDim::DSpacing) && (to == NeutronDim::Tof))
     return convert_with_factor(std::move(d), from, to,
                                reciprocal(constants::tof_to_dspacing(d)));
 
-  if ((from == Dim::Tof) && (to == Dim::Wavelength))
+  if ((from == NeutronDim::Tof) && (to == NeutronDim::Wavelength))
     return convert_with_factor(std::move(d), from, to,
                                constants::tof_to_wavelength(d, scatter));
-  if ((from == Dim::Wavelength) && (to == Dim::Tof))
+  if ((from == NeutronDim::Wavelength) && (to == NeutronDim::Tof))
     return convert_with_factor(
         std::move(d), from, to,
         reciprocal(constants::tof_to_wavelength(d, scatter)));
 
-  if ((from == Dim::Tof) && (to == Dim::Energy))
+  if ((from == NeutronDim::Tof) && (to == NeutronDim::Energy))
     return convert_generic(std::move(d), from, to, conversions::tof_to_energy,
                            constants::tof_to_energy(d, scatter));
-  if ((from == Dim::Energy) && (to == Dim::Tof))
+  if ((from == NeutronDim::Energy) && (to == NeutronDim::Tof))
     return convert_generic(std::move(d), from, to, conversions::energy_to_tof,
                            constants::tof_to_energy(d, scatter));
 
-  if ((from == Dim::Tof) && (to == Dim::EnergyTransfer))
+  if ((from == NeutronDim::Tof) && (to == NeutronDim::EnergyTransfer))
     return convert_arg_tuple(std::move(d), from, to,
                              conversions::tof_to_energy_transfer,
                              constants::tof_to_energy_transfer(d));
-  if ((from == Dim::EnergyTransfer) && (to == Dim::Tof))
+  if ((from == NeutronDim::EnergyTransfer) && (to == NeutronDim::Tof))
     return convert_arg_tuple(std::move(d), from, to,
                              conversions::energy_transfer_to_tof,
                              constants::tof_to_energy_transfer(d));
 
   // lambda <-> Q conversion is symmetric
-  if (((from == Dim::Wavelength) && (to == Dim::Q)) ||
-      ((from == Dim::Q) && (to == Dim::Wavelength)))
+  if (((from == NeutronDim::Wavelength) && (to == NeutronDim::Q)) ||
+      ((from == NeutronDim::Q) && (to == NeutronDim::Wavelength)))
     return convert_generic(std::move(d), from, to, conversions::wavelength_to_q,
                            constants::wavelength_to_q(d));
 
   try {
     // Could get better performance by doing a direct conversion.
-    return convert_impl(convert_impl(std::move(d), from, Dim::Tof, scatter),
-                        Dim::Tof, to, scatter);
+    return convert_impl(
+        convert_impl(std::move(d), from, NeutronDim::Tof, scatter),
+        NeutronDim::Tof, to, scatter);
   } catch (const except::UnitError &) {
     throw except::UnitError("Conversion between " + to_string(from) + " and " +
                             to_string(to) +

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -14,27 +14,27 @@ namespace scipp::neutron {
 enum class ConvertMode { Scatter, NoScatter };
 
 namespace NeutronDim {
-SCIPPNEUTRON_EXPORT extern Dim Tof;
+SCIPPNEUTRON_EXPORT extern Dim DSpacing;
 SCIPPNEUTRON_EXPORT extern Dim Energy;
 SCIPPNEUTRON_EXPORT extern Dim EnergyTransfer;
-SCIPPNEUTRON_EXPORT extern Dim DSpacing;
+SCIPPNEUTRON_EXPORT extern Dim FinalEnergy;
+SCIPPNEUTRON_EXPORT extern Dim IncidentBeam;
+SCIPPNEUTRON_EXPORT extern Dim IncidentEnergy;
+SCIPPNEUTRON_EXPORT extern Dim L1;
+SCIPPNEUTRON_EXPORT extern Dim L2;
+SCIPPNEUTRON_EXPORT extern Dim Ltotal;
+SCIPPNEUTRON_EXPORT extern Dim Position;
 SCIPPNEUTRON_EXPORT extern Dim Q;
 SCIPPNEUTRON_EXPORT extern Dim Qx;
 SCIPPNEUTRON_EXPORT extern Dim Qy;
 SCIPPNEUTRON_EXPORT extern Dim Qz;
-SCIPPNEUTRON_EXPORT extern Dim TwoTheta;
 SCIPPNEUTRON_EXPORT extern Dim SamplePosition;
-SCIPPNEUTRON_EXPORT extern Dim SourcePosition;
-SCIPPNEUTRON_EXPORT extern Dim Position;
-SCIPPNEUTRON_EXPORT extern Dim L1;
-SCIPPNEUTRON_EXPORT extern Dim L2;
-SCIPPNEUTRON_EXPORT extern Dim Ltotal;
-SCIPPNEUTRON_EXPORT extern Dim IncidentBeam;
 SCIPPNEUTRON_EXPORT extern Dim ScatteredBeam;
-SCIPPNEUTRON_EXPORT extern Dim IncidentEnergy;
-SCIPPNEUTRON_EXPORT extern Dim FinalEnergy;
-SCIPPNEUTRON_EXPORT extern Dim Wavelength;
+SCIPPNEUTRON_EXPORT extern Dim SourcePosition;
 SCIPPNEUTRON_EXPORT extern Dim Spectrum;
+SCIPPNEUTRON_EXPORT extern Dim Tof;
+SCIPPNEUTRON_EXPORT extern Dim TwoTheta;
+SCIPPNEUTRON_EXPORT extern Dim Wavelength;
 } // namespace NeutronDim
 
 SCIPPNEUTRON_EXPORT VariableConstView

--- a/neutron/include/scipp/neutron/beamline.h
+++ b/neutron/include/scipp/neutron/beamline.h
@@ -13,6 +13,30 @@ namespace scipp::neutron {
 
 enum class ConvertMode { Scatter, NoScatter };
 
+namespace NeutronDim {
+SCIPPNEUTRON_EXPORT extern Dim Tof;
+SCIPPNEUTRON_EXPORT extern Dim Energy;
+SCIPPNEUTRON_EXPORT extern Dim EnergyTransfer;
+SCIPPNEUTRON_EXPORT extern Dim DSpacing;
+SCIPPNEUTRON_EXPORT extern Dim Q;
+SCIPPNEUTRON_EXPORT extern Dim Qx;
+SCIPPNEUTRON_EXPORT extern Dim Qy;
+SCIPPNEUTRON_EXPORT extern Dim Qz;
+SCIPPNEUTRON_EXPORT extern Dim TwoTheta;
+SCIPPNEUTRON_EXPORT extern Dim SamplePosition;
+SCIPPNEUTRON_EXPORT extern Dim SourcePosition;
+SCIPPNEUTRON_EXPORT extern Dim Position;
+SCIPPNEUTRON_EXPORT extern Dim L1;
+SCIPPNEUTRON_EXPORT extern Dim L2;
+SCIPPNEUTRON_EXPORT extern Dim Ltotal;
+SCIPPNEUTRON_EXPORT extern Dim IncidentBeam;
+SCIPPNEUTRON_EXPORT extern Dim ScatteredBeam;
+SCIPPNEUTRON_EXPORT extern Dim IncidentEnergy;
+SCIPPNEUTRON_EXPORT extern Dim FinalEnergy;
+SCIPPNEUTRON_EXPORT extern Dim Wavelength;
+SCIPPNEUTRON_EXPORT extern Dim Spectrum;
+} // namespace NeutronDim
+
 SCIPPNEUTRON_EXPORT VariableConstView
 position(const dataset::CoordsConstView &meta);
 SCIPPNEUTRON_EXPORT VariableConstView

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -29,11 +29,11 @@ Dataset makeDatasetWithBeamline() {
                                                 units::m, Values{sample_pos}));
   // TODO Need fuzzy comparison for variables to write a convenient test with
   // detectors away from the axes.
-  beamline.setCoord(
-      Dim("position"),
-      makeVariable<Eigen::Vector3d>(Dims{Dim::Spectrum}, Shape{2}, units::m,
-                                    Values{Eigen::Vector3d{1.0, 0.0, 0.01},
-                                           Eigen::Vector3d{0.0, 1.0, 0.01}}));
+  beamline.setCoord(Dim("position"),
+                    makeVariable<Eigen::Vector3d>(
+                        Dims{NeutronDim::Spectrum}, Shape{2}, units::m,
+                        Values{Eigen::Vector3d{1.0, 0.0, 0.01},
+                               Eigen::Vector3d{0.0, 1.0, 0.01}}));
   return beamline;
 }
 
@@ -41,12 +41,12 @@ class BeamlineTest : public ::testing::Test {
 protected:
   Dataset dataset{makeDatasetWithBeamline()};
 
-  Variable L2_override = makeVariable<double>(Dims{Dim::Spectrum}, Shape{2},
-                                              units::m, Values{1.1, 1.2});
+  Variable L2_override = makeVariable<double>(
+      Dims{NeutronDim::Spectrum}, Shape{2}, units::m, Values{1.1, 1.2});
   Variable incident_beam_override =
       incident_beam(dataset.meta()) * (1.23 * units::one);
   Variable scattered_beam_override = makeVariable<Eigen::Vector3d>(
-      Dims{Dim::Spectrum}, Shape{2}, units::m,
+      Dims{NeutronDim::Spectrum}, Shape{2}, units::m,
       Values{Eigen::Vector3d{1.0, 0.1, 0.11}, Eigen::Vector3d{0.1, 1.0, 0.11}});
 };
 
@@ -79,8 +79,8 @@ TEST_F(BeamlineTest, L1) {
 }
 
 TEST_F(BeamlineTest, L2) {
-  const auto L2_computed = makeVariable<double>(Dims{Dim::Spectrum}, Shape{2},
-                                                units::m, Values{1.0, 1.0});
+  const auto L2_computed = makeVariable<double>(
+      Dims{NeutronDim::Spectrum}, Shape{2}, units::m, Values{1.0, 1.0});
   // No overrides, computed based on positions
   ASSERT_EQ(L2(dataset.meta()), L2_computed);
   dataset.coords().set(Dim("L2"), L2_override);
@@ -142,18 +142,18 @@ template <class T> constexpr T pi = T(3.1415926535897932385L);
 
 TEST_F(BeamlineTest, scattering_angle) {
   const auto two_theta_computed =
-      makeVariable<double>(Dims{Dim::Spectrum}, Shape{2}, units::rad,
+      makeVariable<double>(Dims{NeutronDim::Spectrum}, Shape{2}, units::rad,
                            Values{pi<double> / 2, pi<double> / 2});
   const auto theta_computed = 0.5 * units::one * two_theta_computed;
-  const auto cos_two_theta_computed =
-      makeVariable<double>(Dims{Dim::Spectrum}, Shape{2}, Values{0.0, 0.0});
+  const auto cos_two_theta_computed = makeVariable<double>(
+      Dims{NeutronDim::Spectrum}, Shape{2}, Values{0.0, 0.0});
 
   ASSERT_EQ(cos_two_theta(dataset.meta()), cos_two_theta_computed);
   ASSERT_EQ(two_theta(dataset.meta()), two_theta_computed);
   ASSERT_EQ(scattering_angle(dataset.meta()), theta_computed);
 
   const auto two_theta_override = makeVariable<double>(
-      Dims{Dim::Spectrum}, Shape{2}, units::rad, Values{0.1, 0.2});
+      Dims{NeutronDim::Spectrum}, Shape{2}, units::rad, Values{0.1, 0.2});
   // Setting `theta` or `scattering_angle` has no effect. These are slightly
   // ambiguous and are therefore not interpreted by the beamline helpers.
   dataset.coords().set(Dim("theta"), two_theta_override);
@@ -201,7 +201,7 @@ TEST_F(BeamlineTest, no_scatter) {
   ASSERT_THROW(scattering_angle(d.meta()), except::NotFoundError);
   ASSERT_EQ(Ltotal(d.meta(), ConvertMode::NoScatter),
             makeVariable<double>(
-                Dims{Dim::Spectrum}, Shape{2}, units::m,
+                Dims{NeutronDim::Spectrum}, Shape{2}, units::m,
                 Values{(Eigen::Vector3d{1.0, 0.0, 0.01} - source_pos).norm(),
                        (Eigen::Vector3d{0.0, 1.0, 0.01} - source_pos).norm()}));
 }

--- a/neutron/test/beamline_test.cpp
+++ b/neutron/test/beamline_test.cpp
@@ -18,18 +18,15 @@ static const auto sample_pos = Eigen::Vector3d{0.0, 0.0, 0.01};
 
 Dataset makeDatasetWithBeamline() {
   Dataset beamline;
-  Dataset components;
-  // Source and sample
-  components.setData("position", makeVariable<Eigen::Vector3d>(
-                                     Dims{Dim::Row}, Shape{2}, units::m,
-                                     Values{source_pos, sample_pos}));
-  beamline.setCoord(Dim("source_position"), makeVariable<Eigen::Vector3d>(
-                                                units::m, Values{source_pos}));
-  beamline.setCoord(Dim("sample_position"), makeVariable<Eigen::Vector3d>(
-                                                units::m, Values{sample_pos}));
+  beamline.setCoord(
+      NeutronDim::SourcePosition,
+      makeVariable<Eigen::Vector3d>(units::m, Values{source_pos}));
+  beamline.setCoord(
+      NeutronDim::SamplePosition,
+      makeVariable<Eigen::Vector3d>(units::m, Values{sample_pos}));
   // TODO Need fuzzy comparison for variables to write a convenient test with
   // detectors away from the axes.
-  beamline.setCoord(Dim("position"),
+  beamline.setCoord(NeutronDim::Position,
                     makeVariable<Eigen::Vector3d>(
                         Dims{NeutronDim::Spectrum}, Shape{2}, units::m,
                         Values{Eigen::Vector3d{1.0, 0.0, 0.01},
@@ -63,17 +60,17 @@ TEST_F(BeamlineTest, L1) {
   const auto L1_override = 10.1 * units::m;
   // No overrides, computed based on positions
   ASSERT_EQ(L1(dataset.meta()), 10.0 * units::m);
-  dataset.coords().set(Dim("L1"), L1_override);
+  dataset.coords().set(NeutronDim::L1, L1_override);
   // Explicit L1 used
   ASSERT_EQ(L1(dataset.meta()), L1_override);
-  dataset.coords().set(Dim("incident_beam"), incident_beam_override);
+  dataset.coords().set(NeutronDim::IncidentBeam, incident_beam_override);
   // Explicit L1 has higher priority than incident_beam
   ASSERT_EQ(L1(dataset.meta()), L1_override);
   ASSERT_NE(L1(dataset.meta()), norm(incident_beam_override));
-  dataset.coords().erase(Dim("L1"));
+  dataset.coords().erase(NeutronDim::L1);
   // Now incident_beam is used
   ASSERT_EQ(L1(dataset.meta()), norm(incident_beam_override));
-  dataset.coords().erase(Dim("incident_beam"));
+  dataset.coords().erase(NeutronDim::IncidentBeam);
   // Back to computation based on positions
   ASSERT_EQ(L1(dataset.meta()), 10.0 * units::m);
 }
@@ -83,17 +80,17 @@ TEST_F(BeamlineTest, L2) {
       Dims{NeutronDim::Spectrum}, Shape{2}, units::m, Values{1.0, 1.0});
   // No overrides, computed based on positions
   ASSERT_EQ(L2(dataset.meta()), L2_computed);
-  dataset.coords().set(Dim("L2"), L2_override);
+  dataset.coords().set(NeutronDim::L2, L2_override);
   // Explicit L2 used
   ASSERT_EQ(L2(dataset.meta()), L2_override);
-  dataset.coords().set(Dim("scattered_beam"), scattered_beam_override);
+  dataset.coords().set(NeutronDim::ScatteredBeam, scattered_beam_override);
   // Explicit L2 has higher priority than scattered_beam
   ASSERT_EQ(L2(dataset.meta()), L2_override);
   ASSERT_NE(L2(dataset.meta()), norm(scattered_beam_override));
-  dataset.coords().erase(Dim("L2"));
+  dataset.coords().erase(NeutronDim::L2);
   // Now scattered_beam is used
   ASSERT_EQ(L2(dataset.meta()), norm(scattered_beam_override));
-  dataset.coords().erase(Dim("scattered_beam"));
+  dataset.coords().erase(NeutronDim::ScatteredBeam);
   // Back to computation based on positions
   ASSERT_EQ(L2(dataset.meta()), L2_computed);
 }
@@ -102,9 +99,9 @@ TEST_F(BeamlineTest, incident_beam) {
   const auto incident_beam_computed =
       sample_position(dataset.meta()) - source_position(dataset.meta());
   ASSERT_EQ(incident_beam(dataset.meta()), incident_beam_computed);
-  dataset.coords().set(Dim("incident_beam"), incident_beam_override);
+  dataset.coords().set(NeutronDim::IncidentBeam, incident_beam_override);
   ASSERT_EQ(incident_beam(dataset.meta()), incident_beam_override);
-  dataset.coords().erase(Dim("incident_beam"));
+  dataset.coords().erase(NeutronDim::IncidentBeam);
   ASSERT_EQ(incident_beam(dataset.meta()), incident_beam_computed);
 }
 
@@ -112,9 +109,9 @@ TEST_F(BeamlineTest, scattered_beam) {
   const auto scattered_beam_computed =
       position(dataset.meta()) - sample_position(dataset.meta());
   ASSERT_EQ(scattered_beam(dataset.meta()), scattered_beam_computed);
-  dataset.coords().set(Dim("scattered_beam"), scattered_beam_override);
+  dataset.coords().set(NeutronDim::ScatteredBeam, scattered_beam_override);
   ASSERT_EQ(scattered_beam(dataset.meta()), scattered_beam_override);
-  dataset.coords().erase(Dim("scattered_beam"));
+  dataset.coords().erase(NeutronDim::ScatteredBeam);
   ASSERT_EQ(scattered_beam(dataset.meta()), scattered_beam_computed);
 }
 
@@ -123,7 +120,7 @@ TEST_F(BeamlineTest, Ltotal) {
   ASSERT_EQ(Ltotal(dataset.meta(), ConvertMode::Scatter), L_computed);
   ASSERT_EQ(Ltotal(dataset.meta(), ConvertMode::NoScatter),
             norm(source_position(dataset.meta()) - position(dataset.meta())));
-  dataset.coords().set(Dim("L2"), L2_override);
+  dataset.coords().set(NeutronDim::L2, L2_override);
   ASSERT_NE(Ltotal(dataset.meta(), ConvertMode::Scatter), L_computed);
   ASSERT_EQ(Ltotal(dataset.meta(), ConvertMode::Scatter),
             L1(dataset.meta()) + L2(dataset.meta()));
@@ -132,7 +129,7 @@ TEST_F(BeamlineTest, Ltotal) {
   ASSERT_EQ(Ltotal(dataset.meta(), ConvertMode::NoScatter),
             norm(source_position(dataset.meta()) - position(dataset.meta())));
   const auto L_override = L1(dataset.meta()) + L2_override * (1.1 * units::one);
-  dataset.coords().set(Dim("Ltotal"), L_override);
+  dataset.coords().set(NeutronDim::Ltotal, L_override);
   // Note that now L2 is also overridden by L
   ASSERT_EQ(Ltotal(dataset.meta(), ConvertMode::Scatter), L_override);
   ASSERT_EQ(Ltotal(dataset.meta(), ConvertMode::NoScatter), L_override);
@@ -168,20 +165,20 @@ TEST_F(BeamlineTest, scattering_angle) {
   dataset.coords().erase(Dim("scattering_angle"));
 
   // override via two_theta
-  dataset.coords().set(Dim("two_theta"), two_theta_override);
+  dataset.coords().set(NeutronDim::TwoTheta, two_theta_override);
   ASSERT_EQ(cos_two_theta(dataset.meta()), cos(two_theta_override));
   ASSERT_EQ(two_theta(dataset.meta()), two_theta_override);
   ASSERT_EQ(scattering_angle(dataset.meta()),
             0.5 * units::one * two_theta_override);
 
-  dataset.coords().set(Dim("scattered_beam"), scattered_beam_override);
+  dataset.coords().set(NeutronDim::ScatteredBeam, scattered_beam_override);
   // No change, two_theta has higher priority...
   ASSERT_EQ(cos_two_theta(dataset.meta()), cos(two_theta_override));
   ASSERT_EQ(two_theta(dataset.meta()), two_theta_override);
   ASSERT_EQ(scattering_angle(dataset.meta()),
             0.5 * units::one * two_theta_override);
   // ... erase ...
-  dataset.coords().erase(Dim("two_theta"));
+  dataset.coords().erase(NeutronDim::TwoTheta);
   // ... now scattered_beam is used
   ASSERT_NE(cos_two_theta(dataset.meta()), cos(two_theta_override));
   ASSERT_NE(two_theta(dataset.meta()), two_theta_override);
@@ -195,7 +192,7 @@ TEST_F(BeamlineTest, scattering_angle) {
 
 TEST_F(BeamlineTest, no_scatter) {
   Dataset d(dataset);
-  d.coords().erase(Dim("sample_position"));
+  d.coords().erase(NeutronDim::SamplePosition);
   ASSERT_THROW(L1(d.meta()), except::NotFoundError);
   ASSERT_THROW(L2(d.meta()), except::NotFoundError);
   ASSERT_THROW(scattering_angle(d.meta()), except::NotFoundError);

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -25,40 +25,44 @@ Dataset makeBeamline() {
   tof.setCoord(Dim("sample_position"),
                makeVariable<Eigen::Vector3d>(units::m, Values{sample_pos}));
 
-  tof.setCoord(Dim("position"), makeVariable<Eigen::Vector3d>(
-                                    Dims{Dim::Spectrum}, Shape{2}, units::m,
-                                    Values{Eigen::Vector3d{1.0, 0.0, 0.0},
-                                           Eigen::Vector3d{0.1, 0.0, 1.0}}));
+  tof.setCoord(Dim("position"),
+               makeVariable<Eigen::Vector3d>(
+                   Dims{NeutronDim::Spectrum}, Shape{2}, units::m,
+                   Values{Eigen::Vector3d{1.0, 0.0, 0.0},
+                          Eigen::Vector3d{0.1, 0.0, 1.0}}));
   return tof;
 }
 
 Dataset makeTofDataset() {
   Dataset tof = makeBeamline();
-  tof.setCoord(Dim::Tof,
-               makeVariable<double>(Dims{Dim::Tof}, Shape{4}, units::us,
+  tof.setCoord(NeutronDim::Tof,
+               makeVariable<double>(Dims{NeutronDim::Tof}, Shape{4}, units::us,
                                     Values{4000, 5000, 6100, 7300}));
   tof.setData("counts",
-              makeVariable<double>(Dims{Dim::Spectrum, Dim::Tof}, Shape{2, 3},
-                                   units::counts, Values{1, 2, 3, 4, 5, 6}));
+              makeVariable<double>(Dims{NeutronDim::Spectrum, NeutronDim::Tof},
+                                   Shape{2, 3}, units::counts,
+                                   Values{1, 2, 3, 4, 5, 6}));
 
   return tof;
 }
 
 Variable makeTofBucketedEvents() {
   Variable indices = makeVariable<std::pair<scipp::index, scipp::index>>(
-      Dims{Dim::Spectrum}, Shape{2}, Values{std::pair{0, 4}, std::pair{4, 7}});
+      Dims{NeutronDim::Spectrum}, Shape{2},
+      Values{std::pair{0, 4}, std::pair{4, 7}});
   Variable tofs =
       makeVariable<double>(Dims{Dim::Event}, Shape{7}, units::us,
                            Values{1000, 3000, 2000, 4000, 5000, 6000, 3000});
   Variable weights =
       makeVariable<double>(Dims{Dim::Event}, Shape{7}, Values{}, Variances{});
-  DataArray buffer = DataArray(weights, {{Dim::Tof, tofs}});
+  DataArray buffer = DataArray(weights, {{NeutronDim::Tof, tofs}});
   return make_bins(std::move(indices), Dim::Event, std::move(buffer));
 }
 
 Variable makeCountDensityData(const units::Unit &unit) {
-  return makeVariable<double>(Dims{Dim::Spectrum, Dim::Tof}, Shape{2, 3},
-                              units::counts / unit, Values{1, 2, 3, 4, 5, 6});
+  return makeVariable<double>(Dims{NeutronDim::Spectrum, NeutronDim::Tof},
+                              Shape{2, 3}, units::counts / unit,
+                              Values{1, 2, 3, 4, 5, 6});
 }
 
 class ConvertTest : public testing::TestWithParam<Dataset> {};
@@ -70,12 +74,14 @@ INSTANTIATE_TEST_SUITE_P(SingleEntryDataset, ConvertTest,
 // Dataset.
 TEST_P(ConvertTest, DataArray_from_tof) {
   Dataset tof = GetParam();
-  for (const auto &dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-    const auto expected = convert(tof, Dim::Tof, dim, ConvertMode::Scatter);
+  for (const auto &dim :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+    const auto expected =
+        convert(tof, NeutronDim::Tof, dim, ConvertMode::Scatter);
     Dataset result;
     for (const auto &data : tof)
       result.setData(data.name(),
-                     convert(data, Dim::Tof, dim, ConvertMode::Scatter));
+                     convert(data, NeutronDim::Tof, dim, ConvertMode::Scatter));
     for (const auto &data : result)
       EXPECT_EQ(data, expected[data.name()]);
   }
@@ -83,13 +89,15 @@ TEST_P(ConvertTest, DataArray_from_tof) {
 
 TEST_P(ConvertTest, DataArray_to_tof) {
   Dataset tof = GetParam();
-  for (const auto &dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-    const auto input = convert(tof, Dim::Tof, dim, ConvertMode::Scatter);
-    const auto expected = convert(input, dim, Dim::Tof, ConvertMode::Scatter);
+  for (const auto &dim :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+    const auto input = convert(tof, NeutronDim::Tof, dim, ConvertMode::Scatter);
+    const auto expected =
+        convert(input, dim, NeutronDim::Tof, ConvertMode::Scatter);
     Dataset result;
     for (const auto &data : input)
       result.setData(data.name(),
-                     convert(data, dim, Dim::Tof, ConvertMode::Scatter));
+                     convert(data, dim, NeutronDim::Tof, ConvertMode::Scatter));
     for (const auto &data : result)
       EXPECT_EQ(data, expected[data.name()]);
   }
@@ -97,10 +105,14 @@ TEST_P(ConvertTest, DataArray_to_tof) {
 
 TEST_P(ConvertTest, DataArray_non_tof) {
   Dataset tof = GetParam();
-  for (const auto &from : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-    const auto input = convert(tof, Dim::Tof, from, ConvertMode::Scatter);
-    for (const auto &to : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-      const auto expected = convert(tof, Dim::Tof, to, ConvertMode::Scatter);
+  for (const auto &from :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+    const auto input =
+        convert(tof, NeutronDim::Tof, from, ConvertMode::Scatter);
+    for (const auto &to :
+         {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+      const auto expected =
+          convert(tof, NeutronDim::Tof, to, ConvertMode::Scatter);
       Dataset result;
       for (const auto &data : input)
         result.setData(data.name(),
@@ -115,57 +127,62 @@ TEST_P(ConvertTest, DataArray_non_tof) {
 
 TEST_P(ConvertTest, convert_slice) {
   Dataset tof = GetParam();
-  const auto slice = Slice{Dim::Spectrum, 0};
+  const auto slice = Slice{NeutronDim::Spectrum, 0};
   // Note: Converting slics of data*sets* not supported right now, since meta
   // data handling implementation in `convert` is current based on dataset
   // coords, but slicing converts this into attrs of *items*.
-  for (const auto &dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-    EXPECT_EQ(convert(tof["counts"].slice(slice), Dim::Tof, dim,
+  for (const auto &dim :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+    EXPECT_EQ(convert(tof["counts"].slice(slice), NeutronDim::Tof, dim,
                       ConvertMode::Scatter),
-              convert(tof["counts"], Dim::Tof, dim, ConvertMode::Scatter)
+              convert(tof["counts"], NeutronDim::Tof, dim, ConvertMode::Scatter)
                   .slice(slice));
   }
 }
 
 TEST_P(ConvertTest, fail_count_density) {
   const Dataset tof = GetParam();
-  for (const Dim dim : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
+  for (const Dim dim :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
     Dataset a = tof;
-    Dataset b = convert(a, Dim::Tof, dim, ConvertMode::Scatter);
-    EXPECT_NO_THROW(convert(a, Dim::Tof, dim, ConvertMode::Scatter));
-    EXPECT_NO_THROW(convert(b, dim, Dim::Tof, ConvertMode::Scatter));
-    a.setData("", makeCountDensityData(a.coords()[Dim::Tof].unit()));
+    Dataset b = convert(a, NeutronDim::Tof, dim, ConvertMode::Scatter);
+    EXPECT_NO_THROW(convert(a, NeutronDim::Tof, dim, ConvertMode::Scatter));
+    EXPECT_NO_THROW(convert(b, dim, NeutronDim::Tof, ConvertMode::Scatter));
+    a.setData("", makeCountDensityData(a.coords()[NeutronDim::Tof].unit()));
     b.setData("", makeCountDensityData(b.coords()[dim].unit()));
-    EXPECT_THROW(convert(a, Dim::Tof, dim, ConvertMode::Scatter),
+    EXPECT_THROW(convert(a, NeutronDim::Tof, dim, ConvertMode::Scatter),
                  except::UnitError);
-    EXPECT_THROW(convert(b, dim, Dim::Tof, ConvertMode::Scatter),
+    EXPECT_THROW(convert(b, dim, NeutronDim::Tof, ConvertMode::Scatter),
                  except::UnitError);
   }
 }
 
 TEST_P(ConvertTest, scattering_conversions_fail_with_NoScatter_mode) {
   Dataset tof = GetParam();
-  EXPECT_THROW(convert(tof, Dim::Tof, Dim::DSpacing, ConvertMode::NoScatter),
+  EXPECT_THROW(convert(tof, NeutronDim::Tof, NeutronDim::DSpacing,
+                       ConvertMode::NoScatter),
                std::runtime_error);
-  EXPECT_NO_THROW(convert(tof, Dim::Tof, Dim::DSpacing, ConvertMode::Scatter));
-  const auto wavelength =
-      convert(tof, Dim::Tof, Dim::Wavelength, ConvertMode::Scatter);
-  EXPECT_THROW(
-      convert(wavelength, Dim::Wavelength, Dim::Q, ConvertMode::NoScatter),
-      std::runtime_error);
-  EXPECT_NO_THROW(
-      convert(wavelength, Dim::Wavelength, Dim::Q, ConvertMode::Scatter));
+  EXPECT_NO_THROW(convert(tof, NeutronDim::Tof, NeutronDim::DSpacing,
+                          ConvertMode::Scatter));
+  const auto wavelength = convert(tof, NeutronDim::Tof, NeutronDim::Wavelength,
+                                  ConvertMode::Scatter);
+  EXPECT_THROW(convert(wavelength, NeutronDim::Wavelength, NeutronDim::Q,
+                       ConvertMode::NoScatter),
+               std::runtime_error);
+  EXPECT_NO_THROW(convert(wavelength, NeutronDim::Wavelength, NeutronDim::Q,
+                          ConvertMode::Scatter));
 }
 
 TEST_P(ConvertTest, Tof_to_DSpacing) {
   Dataset tof = GetParam();
 
-  auto dspacing = convert(tof, Dim::Tof, Dim::DSpacing, ConvertMode::Scatter);
+  auto dspacing =
+      convert(tof, NeutronDim::Tof, NeutronDim::DSpacing, ConvertMode::Scatter);
 
-  ASSERT_FALSE(dspacing.coords().contains(Dim::Tof));
-  ASSERT_TRUE(dspacing.coords().contains(Dim::DSpacing));
+  ASSERT_FALSE(dspacing.coords().contains(NeutronDim::Tof));
+  ASSERT_TRUE(dspacing.coords().contains(NeutronDim::DSpacing));
 
-  const auto &coord = dspacing.coords()[Dim::DSpacing];
+  const auto &coord = dspacing.coords()[NeutronDim::DSpacing];
 
   // Spectrum 1
   // sin(2 theta) = 0.1/(L-10)
@@ -174,15 +191,16 @@ TEST_P(ConvertTest, Tof_to_DSpacing) {
 
   ASSERT_TRUE(dspacing.contains("counts"));
   EXPECT_EQ(dspacing["counts"].dims(),
-            Dimensions({{Dim::Spectrum, 2}, {Dim::DSpacing, 3}}));
-  // Due to conversion, the coordinate now also depends on Dim::Spectrum.
-  ASSERT_EQ(coord.dims(), Dimensions({{Dim::Spectrum, 2}, {Dim::DSpacing, 4}}));
+            Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::DSpacing, 3}}));
+  // Due to conversion, the coordinate now also depends on NeutronDim::Spectrum.
+  ASSERT_EQ(coord.dims(),
+            Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::DSpacing, 4}}));
   EXPECT_EQ(coord.unit(), units::angstrom);
 
   const auto values = coord.values<double>();
   // Rule of thumb (https://www.psi.ch/niag/neutron-physics):
   // v [m/s] = 3956 / \lambda [ Angstrom ]
-  Variable tof_in_seconds = tof.coords()[Dim::Tof] * (1e-6 * units::one);
+  Variable tof_in_seconds = tof.coords()[NeutronDim::Tof] * (1e-6 * units::one);
   const auto tofs = tof_in_seconds.values<double>();
   // Spectrum 0 is 11 m from source
   // 2d sin(theta) = n \lambda
@@ -206,7 +224,8 @@ TEST_P(ConvertTest, Tof_to_DSpacing) {
               values[7] * 1e-3);
 
   const auto &data = dspacing["counts"];
-  ASSERT_EQ(data.dims(), Dimensions({{Dim::Spectrum, 2}, {Dim::DSpacing, 3}}));
+  ASSERT_EQ(data.dims(),
+            Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::DSpacing, 3}}));
   EXPECT_TRUE(equals(data.values<double>(), {1, 2, 3, 4, 5, 6}));
   EXPECT_EQ(data.unit(), units::counts);
   ASSERT_EQ(dspacing["counts"].attrs()[Dim("position")],
@@ -225,17 +244,17 @@ TEST_P(ConvertTest, DSpacing_to_Tof) {
    * original data. */
 
   const Dataset tof_original = GetParam();
-  const auto dspacing =
-      convert(tof_original, Dim::Tof, Dim::DSpacing, ConvertMode::Scatter);
-  const auto tof =
-      convert(dspacing, Dim::DSpacing, Dim::Tof, ConvertMode::Scatter);
+  const auto dspacing = convert(tof_original, NeutronDim::Tof,
+                                NeutronDim::DSpacing, ConvertMode::Scatter);
+  const auto tof = convert(dspacing, NeutronDim::DSpacing, NeutronDim::Tof,
+                           ConvertMode::Scatter);
 
   ASSERT_TRUE(tof.contains("counts"));
   /* Broadcasting is needed as conversion introduces the dependance on
-   * Dim::Spectrum */
-  const auto expected_tofs =
-      broadcast(tof_original.coords()[Dim::Tof], tof.coords()[Dim::Tof].dims());
-  EXPECT_TRUE(equals(tof.coords()[Dim::Tof].values<double>(),
+   * NeutronDim::Spectrum */
+  const auto expected_tofs = broadcast(tof_original.coords()[NeutronDim::Tof],
+                                       tof.coords()[NeutronDim::Tof].dims());
+  EXPECT_TRUE(equals(tof.coords()[NeutronDim::Tof].values<double>(),
                      expected_tofs.values<double>(), 1e-12));
 
   ASSERT_EQ(tof.coords()[Dim("position")],
@@ -249,26 +268,27 @@ TEST_P(ConvertTest, DSpacing_to_Tof) {
 TEST_P(ConvertTest, Tof_to_Wavelength) {
   Dataset tof = GetParam();
 
-  auto wavelength =
-      convert(tof, Dim::Tof, Dim::Wavelength, ConvertMode::Scatter);
+  auto wavelength = convert(tof, NeutronDim::Tof, NeutronDim::Wavelength,
+                            ConvertMode::Scatter);
 
-  ASSERT_FALSE(wavelength.coords().contains(Dim::Tof));
-  ASSERT_TRUE(wavelength.coords().contains(Dim::Wavelength));
+  ASSERT_FALSE(wavelength.coords().contains(NeutronDim::Tof));
+  ASSERT_TRUE(wavelength.coords().contains(NeutronDim::Wavelength));
 
-  const auto &coord = wavelength.coords()[Dim::Wavelength];
+  const auto &coord = wavelength.coords()[NeutronDim::Wavelength];
 
   ASSERT_TRUE(wavelength.contains("counts"));
-  EXPECT_EQ(wavelength["counts"].dims(),
-            Dimensions({{Dim::Spectrum, 2}, {Dim::Wavelength, 3}}));
-  // Due to conversion, the coordinate now also depends on Dim::Spectrum.
-  ASSERT_EQ(coord.dims(),
-            Dimensions({{Dim::Spectrum, 2}, {Dim::Wavelength, 4}}));
+  EXPECT_EQ(
+      wavelength["counts"].dims(),
+      Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::Wavelength, 3}}));
+  // Due to conversion, the coordinate now also depends on NeutronDim::Spectrum.
+  ASSERT_EQ(coord.dims(), Dimensions({{NeutronDim::Spectrum, 2},
+                                      {NeutronDim::Wavelength, 4}}));
   EXPECT_EQ(coord.unit(), units::angstrom);
 
   const auto values = coord.values<double>();
   // Rule of thumb (https://www.psi.ch/niag/neutron-physics):
   // v [m/s] = 3956 / \lambda [ Angstrom ]
-  Variable tof_in_seconds = tof.coords()[Dim::Tof] * (1e-6 * units::one);
+  Variable tof_in_seconds = tof.coords()[NeutronDim::Tof] * (1e-6 * units::one);
   const auto tofs = tof_in_seconds.values<double>();
   // Spectrum 0 is 11 m from source
   EXPECT_NEAR(values[0], 3956.0 / (11.0 / tofs[0]), values[0] * 1e-3);
@@ -284,8 +304,8 @@ TEST_P(ConvertTest, Tof_to_Wavelength) {
 
   ASSERT_TRUE(wavelength.contains("counts"));
   const auto &data = wavelength["counts"];
-  ASSERT_EQ(data.dims(),
-            Dimensions({{Dim::Spectrum, 2}, {Dim::Wavelength, 3}}));
+  ASSERT_EQ(data.dims(), Dimensions({{NeutronDim::Spectrum, 2},
+                                     {NeutronDim::Wavelength, 3}}));
   EXPECT_TRUE(equals(data.values<double>(), {1, 2, 3, 4, 5, 6}));
   EXPECT_EQ(data.unit(), units::counts);
 
@@ -299,17 +319,18 @@ TEST_P(ConvertTest, Wavelength_to_Tof) {
   // original data.
 
   const Dataset tof_original = GetParam();
-  const auto wavelength =
-      convert(tof_original, Dim::Tof, Dim::Wavelength, ConvertMode::Scatter);
-  const auto tof =
-      convert(wavelength, Dim::Wavelength, Dim::Tof, ConvertMode::Scatter);
+  const auto wavelength = convert(tof_original, NeutronDim::Tof,
+                                  NeutronDim::Wavelength, ConvertMode::Scatter);
+  const auto tof = convert(wavelength, NeutronDim::Wavelength, NeutronDim::Tof,
+                           ConvertMode::Scatter);
 
   ASSERT_TRUE(tof.contains("counts"));
   // Broadcasting is needed as conversion introduces the dependance on
-  // Dim::Spectrum
-  EXPECT_TRUE(all(is_approx(tof.coords()[Dim::Tof],
-                            tof_original.coords()[Dim::Tof], 1e-12 * units::us))
-                  .value<bool>());
+  // NeutronDim::Spectrum
+  EXPECT_TRUE(
+      all(is_approx(tof.coords()[NeutronDim::Tof],
+                    tof_original.coords()[NeutronDim::Tof], 1e-12 * units::us))
+          .value<bool>());
 
   ASSERT_EQ(tof.coords()[Dim("position")],
             tof_original.coords()[Dim("position")]);
@@ -322,12 +343,13 @@ TEST_P(ConvertTest, Wavelength_to_Tof) {
 TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
   Dataset tof = GetParam();
 
-  auto energy = convert(tof, Dim::Tof, Dim::Energy, ConvertMode::Scatter);
+  auto energy =
+      convert(tof, NeutronDim::Tof, NeutronDim::Energy, ConvertMode::Scatter);
 
-  ASSERT_FALSE(energy.coords().contains(Dim::Tof));
-  ASSERT_TRUE(energy.coords().contains(Dim::Energy));
+  ASSERT_FALSE(energy.coords().contains(NeutronDim::Tof));
+  ASSERT_TRUE(energy.coords().contains(NeutronDim::Energy));
 
-  const auto &coord = energy.coords()[Dim::Energy];
+  const auto &coord = energy.coords()[NeutronDim::Energy];
 
   constexpr auto joule_to_mev = 6.241509125883257e21;
   constexpr auto neutron_mass = 1.674927471e-27;
@@ -339,13 +361,14 @@ TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
 
   ASSERT_TRUE(energy.contains("counts"));
   EXPECT_EQ(energy["counts"].dims(),
-            Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 3}}));
-  // Due to conversion, the coordinate now also depends on Dim::Spectrum.
-  ASSERT_EQ(coord.dims(), Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 4}}));
+            Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::Energy, 3}}));
+  // Due to conversion, the coordinate now also depends on NeutronDim::Spectrum.
+  ASSERT_EQ(coord.dims(),
+            Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::Energy, 4}}));
   EXPECT_EQ(coord.unit(), units::meV);
 
   const auto values = coord.values<double>();
-  Variable tof_in_seconds = tof.coords()[Dim::Tof] * (1e-6 * units::one);
+  Variable tof_in_seconds = tof.coords()[NeutronDim::Tof] * (1e-6 * units::one);
   const auto tofs = tof_in_seconds.values<double>();
 
   // Spectrum 0 is 11 m from source
@@ -378,7 +401,8 @@ TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
 
   ASSERT_TRUE(energy.contains("counts"));
   const auto &data = energy["counts"];
-  ASSERT_EQ(data.dims(), Dimensions({{Dim::Spectrum, 2}, {Dim::Energy, 3}}));
+  ASSERT_EQ(data.dims(),
+            Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::Energy, 3}}));
   EXPECT_TRUE(equals(data.values<double>(), {1, 2, 3, 4, 5, 6}));
   EXPECT_EQ(data.unit(), units::counts);
 
@@ -391,17 +415,17 @@ TEST_P(ConvertTest, Tof_to_Energy_Elastic_fails_if_inelastic_params_present) {
   // definitely be possible to support this.
   Dataset tof = GetParam();
   EXPECT_NO_THROW_DISCARD(
-      convert(tof, Dim::Tof, Dim::Energy, ConvertMode::Scatter));
-  tof.coords().set(Dim::IncidentEnergy, 2.1 * units::meV);
+      convert(tof, NeutronDim::Tof, NeutronDim::Energy, ConvertMode::Scatter));
+  tof.coords().set(NeutronDim::IncidentEnergy, 2.1 * units::meV);
   EXPECT_THROW_DISCARD(
-      convert(tof, Dim::Tof, Dim::Energy, ConvertMode::Scatter),
+      convert(tof, NeutronDim::Tof, NeutronDim::Energy, ConvertMode::Scatter),
       std::runtime_error);
-  tof.coords().erase(Dim::IncidentEnergy);
+  tof.coords().erase(NeutronDim::IncidentEnergy);
   EXPECT_NO_THROW_DISCARD(
-      convert(tof, Dim::Tof, Dim::Energy, ConvertMode::Scatter));
-  tof.coords().set(Dim::FinalEnergy, 2.1 * units::meV);
+      convert(tof, NeutronDim::Tof, NeutronDim::Energy, ConvertMode::Scatter));
+  tof.coords().set(NeutronDim::FinalEnergy, 2.1 * units::meV);
   EXPECT_THROW_DISCARD(
-      convert(tof, Dim::Tof, Dim::Energy, ConvertMode::Scatter),
+      convert(tof, NeutronDim::Tof, NeutronDim::Energy, ConvertMode::Scatter),
       std::runtime_error);
 }
 
@@ -411,16 +435,17 @@ TEST_P(ConvertTest, Energy_to_Tof_Elastic) {
    * the original data. */
 
   const Dataset tof_original = GetParam();
-  const auto energy =
-      convert(tof_original, Dim::Tof, Dim::Energy, ConvertMode::Scatter);
-  const auto tof = convert(energy, Dim::Energy, Dim::Tof, ConvertMode::Scatter);
+  const auto energy = convert(tof_original, NeutronDim::Tof, NeutronDim::Energy,
+                              ConvertMode::Scatter);
+  const auto tof = convert(energy, NeutronDim::Energy, NeutronDim::Tof,
+                           ConvertMode::Scatter);
 
   ASSERT_TRUE(tof.contains("counts"));
   /* Broadcasting is needed as conversion introduces the dependance on
-   * Dim::Spectrum */
-  const auto expected =
-      broadcast(tof_original.coords()[Dim::Tof], tof.coords()[Dim::Tof].dims());
-  EXPECT_TRUE(equals(tof.coords()[Dim::Tof].values<double>(),
+   * NeutronDim::Spectrum */
+  const auto expected = broadcast(tof_original.coords()[NeutronDim::Tof],
+                                  tof.coords()[NeutronDim::Tof].dims());
+  EXPECT_TRUE(equals(tof.coords()[NeutronDim::Tof].values<double>(),
                      expected.values<double>(), 1e-12));
 
   ASSERT_EQ(tof.coords()[Dim("position")],
@@ -433,50 +458,51 @@ TEST_P(ConvertTest, Energy_to_Tof_Elastic) {
 
 TEST_P(ConvertTest, Tof_to_EnergyTransfer) {
   Dataset tof = GetParam();
-  EXPECT_THROW_DISCARD(
-      convert(tof, Dim::Tof, Dim::EnergyTransfer, ConvertMode::Scatter),
-      std::runtime_error);
-  tof.coords().set(Dim::IncidentEnergy, 35.0 * units::meV);
-  const auto direct =
-      convert(tof, Dim::Tof, Dim::EnergyTransfer, ConvertMode::Scatter);
-  auto tof_direct =
-      convert(direct, Dim::EnergyTransfer, Dim::Tof, ConvertMode::Scatter);
-  ASSERT_TRUE(all(is_approx(tof_direct.coords()[Dim::Tof],
-                            tof.coords()[Dim::Tof], 1e-11 * units::us))
+  EXPECT_THROW_DISCARD(convert(tof, NeutronDim::Tof, NeutronDim::EnergyTransfer,
+                               ConvertMode::Scatter),
+                       std::runtime_error);
+  tof.coords().set(NeutronDim::IncidentEnergy, 35.0 * units::meV);
+  const auto direct = convert(tof, NeutronDim::Tof, NeutronDim::EnergyTransfer,
+                              ConvertMode::Scatter);
+  auto tof_direct = convert(direct, NeutronDim::EnergyTransfer, NeutronDim::Tof,
+                            ConvertMode::Scatter);
+  ASSERT_TRUE(all(is_approx(tof_direct.coords()[NeutronDim::Tof],
+                            tof.coords()[NeutronDim::Tof], 1e-11 * units::us))
                   .value<bool>());
-  tof_direct.coords().set(Dim::Tof, tof.coords()[Dim::Tof]);
+  tof_direct.coords().set(NeutronDim::Tof, tof.coords()[NeutronDim::Tof]);
   EXPECT_EQ(tof_direct, tof);
 
-  tof.coords().set(Dim::FinalEnergy, 35.0 * units::meV);
-  EXPECT_THROW_DISCARD(
-      convert(tof, Dim::Tof, Dim::EnergyTransfer, ConvertMode::Scatter),
-      std::runtime_error);
-  tof.coords().erase(Dim::IncidentEnergy);
-  const auto indirect =
-      convert(tof, Dim::Tof, Dim::EnergyTransfer, ConvertMode::Scatter);
-  auto tof_indirect =
-      convert(indirect, Dim::EnergyTransfer, Dim::Tof, ConvertMode::Scatter);
-  ASSERT_TRUE(all(is_approx(tof_indirect.coords()[Dim::Tof],
-                            tof.coords()[Dim::Tof], 1e-12 * units::us))
+  tof.coords().set(NeutronDim::FinalEnergy, 35.0 * units::meV);
+  EXPECT_THROW_DISCARD(convert(tof, NeutronDim::Tof, NeutronDim::EnergyTransfer,
+                               ConvertMode::Scatter),
+                       std::runtime_error);
+  tof.coords().erase(NeutronDim::IncidentEnergy);
+  const auto indirect = convert(
+      tof, NeutronDim::Tof, NeutronDim::EnergyTransfer, ConvertMode::Scatter);
+  auto tof_indirect = convert(indirect, NeutronDim::EnergyTransfer,
+                              NeutronDim::Tof, ConvertMode::Scatter);
+  ASSERT_TRUE(all(is_approx(tof_indirect.coords()[NeutronDim::Tof],
+                            tof.coords()[NeutronDim::Tof], 1e-12 * units::us))
                   .value<bool>());
-  tof_indirect.coords().set(Dim::Tof, tof.coords()[Dim::Tof]);
+  tof_indirect.coords().set(NeutronDim::Tof, tof.coords()[NeutronDim::Tof]);
   EXPECT_EQ(tof_indirect, tof);
 
-  EXPECT_NE(direct.coords()[Dim::EnergyTransfer],
-            indirect.coords()[Dim::EnergyTransfer]);
+  EXPECT_NE(direct.coords()[NeutronDim::EnergyTransfer],
+            indirect.coords()[NeutronDim::EnergyTransfer]);
 }
 
 TEST_P(ConvertTest, convert_with_factor_type_promotion) {
   Dataset tof = GetParam();
-  tof.setCoord(Dim::Tof,
-               makeVariable<float>(Dims{Dim::Tof}, Shape{4}, units::us,
+  tof.setCoord(NeutronDim::Tof,
+               makeVariable<float>(Dims{NeutronDim::Tof}, Shape{4}, units::us,
                                    Values{4000, 5000, 6100, 7300}));
-  for (auto &&d : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-    auto res = convert(tof, Dim::Tof, d, ConvertMode::Scatter);
+  for (auto &&d :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+    auto res = convert(tof, NeutronDim::Tof, d, ConvertMode::Scatter);
     EXPECT_EQ(res.coords()[d].dtype(), core::dtype<float>);
 
-    res = convert(res, d, Dim::Tof, ConvertMode::Scatter);
-    EXPECT_EQ(res.coords()[Dim::Tof].dtype(), core::dtype<float>);
+    res = convert(res, d, NeutronDim::Tof, ConvertMode::Scatter);
+    EXPECT_EQ(res.coords()[NeutronDim::Tof].dtype(), core::dtype<float>);
   }
 }
 
@@ -484,23 +510,24 @@ TEST(ConvertBucketsTest, events_converted) {
   Dataset tof = makeTofDataset();
   // Standard dense coord for comparison purposes. The final 0 is a dummy.
   const auto coord = makeVariable<double>(
-      Dims{Dim::Spectrum, Dim::Tof}, Shape{2, 4}, units::us,
+      Dims{NeutronDim::Spectrum, NeutronDim::Tof}, Shape{2, 4}, units::us,
       Values{1000, 3000, 2000, 4000, 5000, 6000, 3000, 0});
-  tof.coords().set(Dim::Tof, coord);
+  tof.coords().set(NeutronDim::Tof, coord);
   tof.setData("bucketed", makeTofBucketedEvents());
-  for (auto &&d : {Dim::DSpacing, Dim::Wavelength, Dim::Energy}) {
-    auto res = convert(tof, Dim::Tof, d, ConvertMode::Scatter);
+  for (auto &&d :
+       {NeutronDim::DSpacing, NeutronDim::Wavelength, NeutronDim::Energy}) {
+    auto res = convert(tof, NeutronDim::Tof, d, ConvertMode::Scatter);
     auto values = res["bucketed"].values<bucket<DataArray>>();
     Variable expected(
-        res.coords()[d].slice({Dim::Spectrum, 0}).slice({d, 0, 4}));
+        res.coords()[d].slice({NeutronDim::Spectrum, 0}).slice({d, 0, 4}));
     expected.rename(d, Dim::Event);
-    EXPECT_FALSE(values[0].coords().contains(Dim::Tof));
+    EXPECT_FALSE(values[0].coords().contains(NeutronDim::Tof));
     EXPECT_TRUE(values[0].coords().contains(d));
     EXPECT_EQ(values[0].coords()[d], expected);
-    expected =
-        Variable(res.coords()[d].slice({Dim::Spectrum, 1}).slice({d, 0, 3}));
+    expected = Variable(
+        res.coords()[d].slice({NeutronDim::Spectrum, 1}).slice({d, 0, 3}));
     expected.rename(d, Dim::Event);
-    EXPECT_FALSE(values[1].coords().contains(Dim::Tof));
+    EXPECT_FALSE(values[1].coords().contains(NeutronDim::Tof));
     EXPECT_TRUE(values[1].coords().contains(d));
     EXPECT_EQ(values[1].coords()[d], expected);
   }

--- a/neutron/test/convert_test.cpp
+++ b/neutron/test/convert_test.cpp
@@ -20,12 +20,12 @@ Dataset makeBeamline() {
   Dataset tof;
   static const auto source_pos = Eigen::Vector3d{0.0, 0.0, -10.0};
   static const auto sample_pos = Eigen::Vector3d{0.0, 0.0, 0.0};
-  tof.setCoord(Dim("source_position"),
+  tof.setCoord(NeutronDim::SourcePosition,
                makeVariable<Eigen::Vector3d>(units::m, Values{source_pos}));
-  tof.setCoord(Dim("sample_position"),
+  tof.setCoord(NeutronDim::SamplePosition,
                makeVariable<Eigen::Vector3d>(units::m, Values{sample_pos}));
 
-  tof.setCoord(Dim("position"),
+  tof.setCoord(NeutronDim::Position,
                makeVariable<Eigen::Vector3d>(
                    Dims{NeutronDim::Spectrum}, Shape{2}, units::m,
                    Values{Eigen::Vector3d{1.0, 0.0, 0.0},
@@ -228,14 +228,14 @@ TEST_P(ConvertTest, Tof_to_DSpacing) {
             Dimensions({{NeutronDim::Spectrum, 2}, {NeutronDim::DSpacing, 3}}));
   EXPECT_TRUE(equals(data.values<double>(), {1, 2, 3, 4, 5, 6}));
   EXPECT_EQ(data.unit(), units::counts);
-  ASSERT_EQ(dspacing["counts"].attrs()[Dim("position")],
-            tof.coords()[Dim("position")]);
+  ASSERT_EQ(dspacing["counts"].attrs()[NeutronDim::Position],
+            tof.coords()[NeutronDim::Position]);
 
-  ASSERT_FALSE(dspacing.coords().contains(Dim("position")));
-  ASSERT_EQ(dspacing.coords()[Dim("source_position")],
-            tof.coords()[Dim("source_position")]);
-  ASSERT_EQ(dspacing.coords()[Dim("sample_position")],
-            tof.coords()[Dim("sample_position")]);
+  ASSERT_FALSE(dspacing.coords().contains(NeutronDim::Position));
+  ASSERT_EQ(dspacing.coords()[NeutronDim::SourcePosition],
+            tof.coords()[NeutronDim::SourcePosition]);
+  ASSERT_EQ(dspacing.coords()[NeutronDim::SamplePosition],
+            tof.coords()[NeutronDim::SamplePosition]);
 }
 
 TEST_P(ConvertTest, DSpacing_to_Tof) {
@@ -257,12 +257,12 @@ TEST_P(ConvertTest, DSpacing_to_Tof) {
   EXPECT_TRUE(equals(tof.coords()[NeutronDim::Tof].values<double>(),
                      expected_tofs.values<double>(), 1e-12));
 
-  ASSERT_EQ(tof.coords()[Dim("position")],
-            tof_original.coords()[Dim("position")]);
-  ASSERT_EQ(tof.coords()[Dim("source_position")],
-            tof_original.coords()[Dim("source_position")]);
-  ASSERT_EQ(tof.coords()[Dim("sample_position")],
-            tof_original.coords()[Dim("sample_position")]);
+  ASSERT_EQ(tof.coords()[NeutronDim::Position],
+            tof_original.coords()[NeutronDim::Position]);
+  ASSERT_EQ(tof.coords()[NeutronDim::SourcePosition],
+            tof_original.coords()[NeutronDim::SourcePosition]);
+  ASSERT_EQ(tof.coords()[NeutronDim::SamplePosition],
+            tof_original.coords()[NeutronDim::SamplePosition]);
 }
 
 TEST_P(ConvertTest, Tof_to_Wavelength) {
@@ -309,8 +309,9 @@ TEST_P(ConvertTest, Tof_to_Wavelength) {
   EXPECT_TRUE(equals(data.values<double>(), {1, 2, 3, 4, 5, 6}));
   EXPECT_EQ(data.unit(), units::counts);
 
-  for (const auto &name : {"position", "source_position", "sample_position"})
-    ASSERT_EQ(wavelength.coords()[Dim(name)], tof.coords()[Dim(name)]);
+  for (const auto &dim : {NeutronDim::Position, NeutronDim::SourcePosition,
+                          NeutronDim::SamplePosition})
+    ASSERT_EQ(wavelength.coords()[dim], tof.coords()[dim]);
 }
 
 TEST_P(ConvertTest, Wavelength_to_Tof) {
@@ -332,12 +333,12 @@ TEST_P(ConvertTest, Wavelength_to_Tof) {
                     tof_original.coords()[NeutronDim::Tof], 1e-12 * units::us))
           .value<bool>());
 
-  ASSERT_EQ(tof.coords()[Dim("position")],
-            tof_original.coords()[Dim("position")]);
-  ASSERT_EQ(tof.coords()[Dim("source_position")],
-            tof_original.coords()[Dim("source_position")]);
-  ASSERT_EQ(tof.coords()[Dim("sample_position")],
-            tof_original.coords()[Dim("sample_position")]);
+  ASSERT_EQ(tof.coords()[NeutronDim::Position],
+            tof_original.coords()[NeutronDim::Position]);
+  ASSERT_EQ(tof.coords()[NeutronDim::SourcePosition],
+            tof_original.coords()[NeutronDim::SourcePosition]);
+  ASSERT_EQ(tof.coords()[NeutronDim::SamplePosition],
+            tof_original.coords()[NeutronDim::SamplePosition]);
 }
 
 TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
@@ -406,8 +407,9 @@ TEST_P(ConvertTest, Tof_to_Energy_Elastic) {
   EXPECT_TRUE(equals(data.values<double>(), {1, 2, 3, 4, 5, 6}));
   EXPECT_EQ(data.unit(), units::counts);
 
-  for (const auto &name : {"position", "source_position", "sample_position"})
-    ASSERT_EQ(energy.coords()[Dim(name)], tof.coords()[Dim(name)]);
+  for (const auto &dim : {NeutronDim::Position, NeutronDim::SourcePosition,
+                          NeutronDim::SamplePosition})
+    ASSERT_EQ(energy.coords()[dim], tof.coords()[dim]);
 }
 
 TEST_P(ConvertTest, Tof_to_Energy_Elastic_fails_if_inelastic_params_present) {
@@ -448,12 +450,12 @@ TEST_P(ConvertTest, Energy_to_Tof_Elastic) {
   EXPECT_TRUE(equals(tof.coords()[NeutronDim::Tof].values<double>(),
                      expected.values<double>(), 1e-12));
 
-  ASSERT_EQ(tof.coords()[Dim("position")],
-            tof_original.coords()[Dim("position")]);
-  ASSERT_EQ(tof.coords()[Dim("source_position")],
-            tof_original.coords()[Dim("source_position")]);
-  ASSERT_EQ(tof.coords()[Dim("sample_position")],
-            tof_original.coords()[Dim("sample_position")]);
+  ASSERT_EQ(tof.coords()[NeutronDim::Position],
+            tof_original.coords()[NeutronDim::Position]);
+  ASSERT_EQ(tof.coords()[NeutronDim::SourcePosition],
+            tof_original.coords()[NeutronDim::SourcePosition]);
+  ASSERT_EQ(tof.coords()[NeutronDim::SamplePosition],
+            tof_original.coords()[NeutronDim::SamplePosition]);
 }
 
 TEST_P(ConvertTest, Tof_to_EnergyTransfer) {


### PR DESCRIPTION
https://github.com/scipp/scipp/pull/1744 removes neutron specific labels. Add `NeutronDim::Tof` and friends.