### PR TITLE
Parse transformations in load nexus

### DIFF
--- a/python/src/scippneutron/_loading_common.py
+++ b/python/src/scippneutron/_loading_common.py
@@ -28,17 +28,19 @@ class BadSource(Exception):
     pass
 
 
-unsigned_to_signed = {
-    np.uint8: np.int8,
-    np.uint16: np.int16,
+map_to_supported_type = {
+    np.int8: np.int32,
+    np.int16: np.int32,
+    np.uint8: np.int32,
+    np.uint16: np.int32,
     np.uint32: np.int32,
     np.uint64: np.int64,
 }
 
 
-def ensure_not_unsigned(dataset_type: Any):
+def ensure_supported_int_type(dataset_type: Any):
     try:
-        return unsigned_to_signed[dataset_type]
+        return map_to_supported_type[dataset_type]
     except KeyError:
         return dataset_type
 
@@ -54,7 +56,7 @@ def load_dataset(dataset: h5py.Dataset,
       otherwise retain dataset dtype
     """
     if dtype is None:
-        dtype = ensure_not_unsigned(dataset.dtype.type)
+        dtype = ensure_supported_int_type(dataset.dtype.type)
     variable = sc.empty(dims=dimensions,
                         shape=dataset.shape,
                         dtype=dtype,

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -142,7 +142,7 @@ def _load_event_group(group: h5py.Group, file_root: h5py.File,
     detector_id_type = ensure_supported_int_type(detector_ids.dtype.type)
     event_id_type = ensure_supported_int_type(event_id_ds.dtype.type)
     _check_event_ids_and_det_number_types_valid(detector_id_type,
-                                                event_id_type, group.name)
+                                                event_id_type)
 
     detector_ids = sc.Variable(dims=[_detector_dimension],
                                values=detector_ids,
@@ -172,8 +172,7 @@ def _load_event_group(group: h5py.Group, file_root: h5py.File,
 
 
 def _check_event_ids_and_det_number_types_valid(detector_id_type: np.dtype,
-                                                event_id_type: np.dtype,
-                                                group_name: str):
+                                                event_id_type: np.dtype):
     """
     These must be integers and must be the same type or we'll have
     problems trying to bin events by detector id. Check here so that
@@ -182,16 +181,14 @@ def _check_event_ids_and_det_number_types_valid(detector_id_type: np.dtype,
     """
     if not np.issubdtype(detector_id_type, np.integer):
         raise BadSource(
-            f"detector_numbers dataset in NXdetector is not an integer "
-            f"type, skipping loading {group_name}")
+            "detector_numbers dataset in NXdetector is not an integer "
+            "type")
     if not np.issubdtype(event_id_type, np.integer):
-        raise BadSource(f"event_ids dataset is not an integer type, "
-                        f"skipping loading {group_name}")
+        raise BadSource("event_ids dataset is not an integer type")
     if detector_id_type != event_id_type:
         raise BadSource(
-            f"event_ids and detector_numbers datasets in corresponding "
-            f"NXdetector were not of the same type, skipping "
-            f"loading {group_name}")
+            "event_ids and detector_numbers datasets in corresponding "
+            "NXdetector were not of the same type")
 
 
 def load_detector_data(event_data_groups: List[h5py.Group],

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from warnings import warn
 from itertools import groupby
 
-_detector_dimension = "detector-id"
+_detector_dimension = "detector_id"
 _event_dimension = "event"
 
 

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import h5py
 from typing import Optional, List
 import numpy as np
-from ._loading_common import BadSource, ensure_not_unsigned, load_dataset
+from ._loading_common import BadSource, ensure_supported_int_type, load_dataset
 import scipp as sc
 from datetime import datetime
 from warnings import warn
@@ -96,7 +96,7 @@ def _load_event_group(group: h5py.Group, quiet: bool) -> DetectorData:
     # the last pulse.
     event_id_ds = group["event_id"]
     event_index = group["event_index"][...].astype(
-        ensure_not_unsigned(group["event_index"].dtype.type))
+        ensure_supported_int_type(group["event_index"].dtype.type))
     if event_index[-1] < event_id_ds.len():
         event_index = np.append(
             event_index,
@@ -125,7 +125,7 @@ def _load_event_group(group: h5py.Group, quiet: bool) -> DetectorData:
         # will not have a bin)
         detector_ids = np.unique(event_id.values)
 
-    detector_id_type = ensure_not_unsigned(detector_ids.dtype.type)
+    detector_id_type = ensure_supported_int_type(detector_ids.dtype.type)
     _check_event_ids_and_det_number_types_valid(detector_id_type,
                                                 event_id_ds.dtype.type,
                                                 group.name)

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -140,9 +140,9 @@ def _load_event_group(group: h5py.Group, file_root: h5py.File,
         detector_ids = np.unique(event_id.values)
 
     detector_id_type = ensure_supported_int_type(detector_ids.dtype.type)
+    event_id_type = ensure_supported_int_type(event_id_ds.dtype.type)
     _check_event_ids_and_det_number_types_valid(detector_id_type,
-                                                event_id_ds.dtype.type,
-                                                group.name)
+                                                event_id_type, group.name)
 
     detector_ids = sc.Variable(dims=[_detector_dimension],
                                values=detector_ids,

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -77,7 +77,7 @@ def _load_pixel_positions(detector_group: h5py.Group, detector_ids_size: int,
         # Get and apply transformation matrix
         transformation = get_full_transformation_matrix(
             detector_group, file_root)
-        for row_index in range(array.shape[0]):
+        for row_index in range(n_rows):
             array[row_index, :] = np.matmul(transformation,
                                             array[row_index, :])
 

--- a/python/src/scippneutron/_loading_log_data.py
+++ b/python/src/scippneutron/_loading_log_data.py
@@ -37,7 +37,7 @@ def _add_log_to_data(log_data_name: str, log_data: sc.Variable,
             unique_name_found = True
         else:
             name_changed = True
-            log_data_name = f"{group_path[path_position]}-{log_data_name}"
+            log_data_name = f"{group_path[path_position]}_{log_data_name}"
             path_position -= 1
     if name_changed:
         warn(f"Name of log group at {'/'.join(group_path)} is not unique: "

--- a/python/src/scippneutron/_loading_log_data.py
+++ b/python/src/scippneutron/_loading_log_data.py
@@ -54,6 +54,9 @@ def _load_log_data_from_group(group: h5py.Group) -> Tuple[str, sc.Variable]:
     except KeyError:
         raise BadSource(f"NXlog at {group.name} has no value dataset")
 
+    if values.size == 0:
+        raise BadSource(f"NXlog at {group.name} has an empty value dataset")
+
     try:
         unit = ensure_str(group[value_dataset_name].attrs["units"])
     except KeyError:
@@ -63,6 +66,9 @@ def _load_log_data_from_group(group: h5py.Group) -> Tuple[str, sc.Variable]:
         dimension_label = "time"
         is_time_series = True
         times = load_dataset(group[time_dataset_name], [dimension_label])
+        if group[time_dataset_name].size != values.size:
+            raise BadSource(f"NXlog at {group.name} has time and value "
+                            f"datasets of different sizes")
     except KeyError:
         dimension_label = property_name
         is_time_series = False

--- a/python/src/scippneutron/_loading_log_data.py
+++ b/python/src/scippneutron/_loading_log_data.py
@@ -73,7 +73,6 @@ def _load_log_data_from_group(group: h5py.Group) -> Tuple[str, sc.Variable]:
         dimension_label = property_name
         is_time_series = False
 
-    values = np.squeeze(values)
     if np.ndim(values) > 1:
         raise BadSource(f"NXlog at {group.name} has {value_dataset_name} "
                         f"dataset with more than 1 dimension, handling "

--- a/python/src/scippneutron/_loading_log_data.py
+++ b/python/src/scippneutron/_loading_log_data.py
@@ -7,7 +7,7 @@ from typing import Tuple
 import scipp as sc
 import h5py
 from ._loading_common import (ensure_str, BadSource, load_dataset,
-                              ensure_not_unsigned)
+                              ensure_supported_int_type)
 from warnings import warn
 
 
@@ -40,7 +40,7 @@ def _add_log_to_data(log_data_name: str, log_data: sc.Variable,
             log_data_name = f"{group_path[path_position]}-{log_data_name}"
             path_position -= 1
     if name_changed:
-        warn(f"Name of log group at {group_path} is not unique: "
+        warn(f"Name of log group at {'/'.join(group_path)} is not unique: "
              f"{log_data_name} used as attribute name.")
 
 
@@ -76,13 +76,13 @@ def _load_log_data_from_group(group: h5py.Group) -> Tuple[str, sc.Variable]:
     if np.ndim(values) == 0:
         property_data = sc.Variable(value=values,
                                     unit=unit,
-                                    dtype=ensure_not_unsigned(
+                                    dtype=ensure_supported_int_type(
                                         group[value_dataset_name].dtype.type))
     else:
         property_data = sc.Variable(values=values,
                                     unit=unit,
                                     dims=[dimension_label],
-                                    dtype=ensure_not_unsigned(
+                                    dtype=ensure_supported_int_type(
                                         group[value_dataset_name].dtype.type))
 
     if is_time_series:

--- a/python/src/scippneutron/_loading_positions.py
+++ b/python/src/scippneutron/_loading_positions.py
@@ -1,0 +1,57 @@
+from _warnings import warn
+from typing import List, Optional, Any
+import h5py
+import numpy as np
+import scipp as sc
+from ._loading_common import get_units
+
+
+def load_position_of_unique_component(
+        groups: List[h5py.Group],
+        data: sc.Variable,
+        name: str,
+        nx_class: str,
+        default_position: Optional[np.ndarray] = None):
+    if len(groups) > 1:
+        warn(f"More than one {nx_class} found in file, "
+             f"skipping loading {name} position")
+        return
+    group = groups[0]
+    if "distance" in group:
+        position = np.array([0, 0, group["distance"][...]])
+        unit_str = get_units(group["distance"])
+        if not unit_str:
+            warn(f"'distance' dataset in {nx_class} is missing "
+                 f"units attribute, skipping loading {name} position")
+            return
+        units = sc.Unit(unit_str)
+    elif default_position is None:
+        warn(f"No position given for {name} in file")
+        return
+    else:
+        position = np.array([0, 0, 0])
+        units = sc.units.m
+    _add_attr_to_loaded_data(f"{name}_position",
+                             data,
+                             position,
+                             unit=units,
+                             dtype=sc.dtype.vector_3_float64)
+
+
+def _add_attr_to_loaded_data(attr_name: str,
+                             data: sc.Variable,
+                             value: np.ndarray,
+                             unit: sc.Unit,
+                             dtype: Optional[Any] = None):
+    try:
+        data = data.attrs
+    except AttributeError:
+        pass
+
+    try:
+        if dtype is not None:
+            data[attr_name] = sc.Variable(value=value, dtype=dtype, unit=unit)
+        else:
+            data[attr_name] = sc.Variable(value=value, unit=unit)
+    except KeyError:
+        pass

--- a/python/src/scippneutron/_loading_positions.py
+++ b/python/src/scippneutron/_loading_positions.py
@@ -1,11 +1,15 @@
 from _warnings import warn
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Tuple
 import h5py
 import numpy as np
 import scipp as sc
 from ._loading_common import get_units
 from ._loading_transformations import (get_position_from_transformations,
                                        TransformationError)
+
+
+class PositionError(Exception):
+    pass
 
 
 def load_position_of_unique_component(
@@ -19,13 +23,59 @@ def load_position_of_unique_component(
         warn(f"More than one {nx_class} found in file, "
              f"skipping loading {name} position")
         return
-    group = groups[0]
+    try:
+        position, units = _get_position_of_component(groups[0], name, nx_class,
+                                                     file_root,
+                                                     default_position)
+    except PositionError:
+        return
+    _add_attr_to_loaded_data(f"{name}_position",
+                             data,
+                             position,
+                             unit=units,
+                             dtype=sc.dtype.vector_3_float64)
+
+
+def load_positions_of_components(
+        groups: List[h5py.Group],
+        data: sc.Variable,
+        name: str,
+        nx_class: str,
+        file_root: h5py.File,
+        default_position: Optional[np.ndarray] = None):
+    for group in groups:
+        try:
+            position, units = _get_position_of_component(
+                group, name, nx_class, file_root, default_position)
+        except PositionError:
+            continue
+        if len(groups) == 1:
+            _add_attr_to_loaded_data(f"{name}_position",
+                                     data,
+                                     position,
+                                     unit=units,
+                                     dtype=sc.dtype.vector_3_float64)
+        else:
+            _add_attr_to_loaded_data(f"{group.name.split('/')[-1]}_position",
+                                     data,
+                                     position,
+                                     unit=units,
+                                     dtype=sc.dtype.vector_3_float64)
+
+
+def _get_position_of_component(
+    group: h5py.Group,
+    name: str,
+    nx_class: str,
+    file_root: h5py.File,
+    default_position: Optional[np.ndarray] = None
+) -> Tuple[np.ndarray, sc.Unit]:
     if "depends_on" in group:
         try:
             position = get_position_from_transformations(group, file_root)
         except TransformationError as e:
             warn(f"Skipping loading {name} position due to error: {e}")
-            return
+            raise PositionError
         units = sc.units.m
     elif "distance" in group:
         position = np.array([0, 0, group["distance"][...]])
@@ -33,19 +83,16 @@ def load_position_of_unique_component(
         if not unit_str:
             warn(f"'distance' dataset in {nx_class} is missing "
                  f"units attribute, skipping loading {name} position")
-            return
+            raise PositionError
         units = sc.Unit(unit_str)
     elif default_position is None:
         warn(f"No position given for {name} in file")
-        return
+        raise PositionError
     else:
         position = np.array([0, 0, 0])
         units = sc.units.m
-    _add_attr_to_loaded_data(f"{name}_position",
-                             data,
-                             position,
-                             unit=units,
-                             dtype=sc.dtype.vector_3_float64)
+
+    return position, units
 
 
 def _add_attr_to_loaded_data(attr_name: str,

--- a/python/src/scippneutron/_loading_positions.py
+++ b/python/src/scippneutron/_loading_positions.py
@@ -4,6 +4,7 @@ import h5py
 import numpy as np
 import scipp as sc
 from ._loading_common import get_units
+from ._loading_transformations import get_position_from_transformations
 
 
 def load_position_of_unique_component(
@@ -11,13 +12,17 @@ def load_position_of_unique_component(
         data: sc.Variable,
         name: str,
         nx_class: str,
+        file_root: h5py.File,
         default_position: Optional[np.ndarray] = None):
     if len(groups) > 1:
         warn(f"More than one {nx_class} found in file, "
              f"skipping loading {name} position")
         return
     group = groups[0]
-    if "distance" in group:
+    if "depends_on" in group:
+        position = get_position_from_transformations(group, file_root)
+        units = sc.units.m
+    elif "distance" in group:
         position = np.array([0, 0, group["distance"][...]])
         unit_str = get_units(group["distance"])
         if not unit_str:

--- a/python/src/scippneutron/_loading_positions.py
+++ b/python/src/scippneutron/_loading_positions.py
@@ -4,7 +4,8 @@ import h5py
 import numpy as np
 import scipp as sc
 from ._loading_common import get_units
-from ._loading_transformations import get_position_from_transformations
+from ._loading_transformations import (get_position_from_transformations,
+                                       TransformationError)
 
 
 def load_position_of_unique_component(
@@ -20,7 +21,11 @@ def load_position_of_unique_component(
         return
     group = groups[0]
     if "depends_on" in group:
-        position = get_position_from_transformations(group, file_root)
+        try:
+            position = get_position_from_transformations(group, file_root)
+        except TransformationError as e:
+            warn(f"Skipping loading {name} position due to error: {e}")
+            return
         units = sc.units.m
     elif "distance" in group:
         position = np.array([0, 0, group["distance"][...]])

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -114,10 +114,10 @@ def _append_transformation(transform: Union[h5py.Dataset, h5py.Group],
     offset = [0., 0., 0.]
     if 'offset' in attributes:
         offset = attributes['offset'].astype(float)
-    if attributes['transformation_type'] == 'translation':
+    if ensure_str(attributes['transformation_type']) == 'translation':
         _append_translation(offset, transform, transformations, vector,
                             group_name)
-    elif attributes['transformation_type'] == 'rotation':
+    elif ensure_str(attributes['transformation_type']) == 'rotation':
         _append_rotation(offset, transform, transformations, vector,
                          group_name)
     else:

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -8,7 +8,6 @@ from typing import Union, List
 import scipp as sc
 import h5py
 from cmath import isclose
-import scippneutron
 
 
 class TransformationError(Exception):
@@ -164,8 +163,7 @@ def _append_translation(offset: List[float], transform: h5py.Dataset,
     magnitude = transform[...].astype(float).item()
     if units != sc.units.m:
         magnitude_var = magnitude * units
-        magnitude_var = sc.Dataset({'distance': magnitude_var})
-        magnitude_var = scippneutron.convert(magnitude_var, units, sc.units.m)
+        magnitude_var = sc.to_unit(magnitude_var, sc.units.m)
         magnitude = magnitude_var.value
     # -1 as describes passive transformation
     vector = direction_unit_vector * -1. * magnitude

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -180,6 +180,9 @@ def _get_transformation_magnitude_and_unit(
                 raise TransformationError(f"Found multivalued NXlog as a "
                                           f"transformation for {group_name}, "
                                           f"this is not yet supported")
+            if transform["value"].size == 0:
+                raise TransformationError(f"Found empty NXlog as a "
+                                          f"transformation for {group_name}")
             magnitude = transform["value"][...].astype(float).item()
         except KeyError:
             raise TransformationError(

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Matthew Jones
+
+import numpy as np
+from ._loading_common import ensure_str
+from typing import Union, List
+import scipp as sc
+import h5py
+
+
+class TransformationError(Exception):
+    pass
+
+
+def _alt_rotation_matrix_from_axis_and_angle(axis: np.ndarray,
+                                             angle_radians: float):
+    axis_x = axis[0]
+    axis_y = axis[1]
+    axis_z = axis[2]
+    cos_t = np.cos(angle_radians)
+    sin_t = np.sin(angle_radians)
+    one_minus_cos_t = 1 - cos_t
+    x_sin_t = axis_x * sin_t
+    y_sint_t = axis_y * sin_t
+    z_sint_t = axis_z * sin_t
+    return np.array([[
+        cos_t + axis_x**2.0 * one_minus_cos_t,
+        axis_x * axis_y * one_minus_cos_t - z_sint_t,
+        axis_x * axis_z * one_minus_cos_t + y_sint_t
+    ],
+                     [
+                         axis_y * axis_x * one_minus_cos_t + z_sint_t,
+                         cos_t + axis_y**2.0 * one_minus_cos_t,
+                         axis_y * axis_z * one_minus_cos_t - x_sin_t
+                     ],
+                     [
+                         axis_z * axis_x * one_minus_cos_t - y_sint_t,
+                         axis_z * axis_y * one_minus_cos_t + x_sin_t,
+                         cos_t + axis_z**2.0 * one_minus_cos_t
+                     ]])
+
+
+def _rotation_matrix_from_axis_and_angle(axis: np.ndarray,
+                                         angle_radians: float):
+    # Following convention for passive transformation
+    # Variable naming follows that used in
+    # https://doi.org/10.1061/(ASCE)SU.1943-5428.0000247
+    i = np.identity(3)
+    l1, l2, l3 = tuple(axis)
+    ll = np.array([[0, -l3, l2], [l3, 0, -l1], [-l2, l1, 0]])
+    l1l2 = np.matmul(l1, l2)
+    l1l3 = np.matmul(l1, l3)
+    l2l3 = np.matmul(l2, l3)
+    l1_squared = np.matmul(l1, l1)
+    l2_squared = np.matmul(l2, l2)
+    l3_squared = np.matmul(l3, l3)
+    ll_2 = np.array([[-(l2_squared + l3_squared), l1l2, l1l3],
+                     [l1l2, -(l1_squared + l3_squared), l2l3],
+                     [l1l3, l2l3, -(l1_squared + l2_squared)]])
+
+    return i - np.sin(angle_radians) * ll + (1 - np.cos(angle_radians)) * ll_2
+
+
+def get_position_from_transformations(group: h5py.Group,
+                                      root: [h5py.File, h5py.Group]):
+    transformations = []
+    try:
+        depends_on = group["depends_on"][...].item()
+    except KeyError:
+        depends_on = '.'
+    _get_transformations(depends_on, transformations, root, group.name)
+
+    total_transform_matrix = np.identity(4)
+    for transformation in transformations:
+        total_transform_matrix = np.matmul(transformation,
+                                           total_transform_matrix)
+
+    return np.matmul(total_transform_matrix, np.array([0, 0, 0, 1],
+                                                      dtype=float))[0:3]
+
+    # vertices = vertices.T
+    # Add fourth element of 1 to each vertex, indicating these are
+    # positions not direction vectors
+    # vertices = np.vstack((vertices, np.ones(vertices.shape[1])))
+    # vertices = do_transformations(transformations, vertices)
+    # Now the transformations are done we do not need the 4th element
+    # return vertices[:3, :].T
+
+
+def _get_transformations(depends_on: Union[str, bytes],
+                         transformations: List[np.ndarray],
+                         root: [h5py.File, h5py.Group], group_name: str):
+    """
+    Get all transformations in the depends_on chain
+
+    :param depends_on: The first depends_on path string
+    :param transformations: List of transformations to populate
+    :param root: root of the file, depends_on paths assumed to be
+      relative to this
+    """
+    transform_path = ensure_str(depends_on)
+    if transform_path != '.':
+        try:
+            transform = root[transform_path]
+        except KeyError:
+            raise TransformationError(
+                f"Non-existent depends_on path '{transform_path}' found "
+                f"in transformations chain for {group_name}")
+        next_depends_on = _append_transformation(transform, transformations)
+        _get_transformations(next_depends_on, transformations, root,
+                             group_name)
+
+
+def _append_transformation(transform: h5py.Dataset,
+                           transformations: List[np.ndarray]):
+    attributes = transform.attrs
+    offset = [0., 0., 0.]
+    if 'offset' in attributes:
+        offset = attributes['offset'].astype(float)
+    if attributes['transformation_type'] == 'translation':
+        _append_translation(attributes, offset, transform, transformations)
+    elif attributes['transformation_type'] == 'rotation':
+        _append_rotation(attributes, offset, transform, transformations)
+    else:
+        raise TransformationError(
+            f"Unknown transformation type "
+            f"'{attributes['transformation_type'].astype(str)}'"
+            f" at {transform.name}")
+    return attributes['depends_on']
+
+
+def _append_translation(attributes, offset, transform, transformations):
+    # TODO no assumptions about units (convert everything to metres?)
+    vector = attributes['vector'] * transform[...].astype(float)
+    matrix = np.array([[1., 0., 0., vector[0] + offset[0]],
+                       [0., 1., 0., vector[1] + offset[1]],
+                       [0., 0., 1., vector[2] + offset[2]], [0., 0., 0., 1.]])
+    transformations.append(matrix)
+
+
+def _append_rotation(attributes, offset, transform, transformations):
+    axis = attributes['vector']
+    unit_str = ensure_str(transform.attrs['units'])
+    unit_error = TransformationError(
+        f"Unit for rotation transformation must be radians "
+        f"or degrees but found '{unit_str}' at {transform.name}")
+    try:
+        units = sc.Unit(unit_str)
+    except RuntimeError:
+        raise unit_error
+    if units == sc.units.deg:
+        angle = np.deg2rad(transform[...])
+    elif units == sc.units.rad:
+        angle = transform[...]
+    else:
+        raise unit_error
+    rotation_matrix = _rotation_matrix_from_axis_and_angle(axis, angle)
+    # Make 4x4 matrix from our 3x3 rotation matrix to include
+    # possible "offset"
+    # TODO try using rotation_matrix.resize((4, 4))
+    matrix = np.array([[
+        rotation_matrix[0, 0], rotation_matrix[0, 1], rotation_matrix[0, 2],
+        offset[0]
+    ],
+                       [
+                           rotation_matrix[1, 0], rotation_matrix[1, 1],
+                           rotation_matrix[1, 2], offset[1]
+                       ],
+                       [
+                           rotation_matrix[2, 0], rotation_matrix[2, 1],
+                           rotation_matrix[2, 2], offset[2]
+                       ], [0., 0., 0., 1.]])
+    transformations.append(matrix)

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -186,7 +186,11 @@ def _get_transformation_magnitude_and_unit(
                 f"Encountered {transform.name} in transformation chain "
                 f"for {group_name} but it is a group without a value "
                 "dataset; not a valid transformation")
-        unit = _get_unit(transform["value"].attrs, transform.name)
+        try:
+            unit = _get_unit(transform["value"].attrs, transform.name)
+        except TransformationError:
+            # See if the value unit is on the NXLog itself instead
+            unit = _get_unit(transform.attrs, transform.name)
     else:
         magnitude = transform[...].astype(float).item()
         unit = _get_unit(transform.attrs, transform.name)

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -131,12 +131,12 @@ def _append_transformation(transform: h5py.Dataset,
     return attributes['depends_on']
 
 
-def normalise(vector: np.ndarray, transform: h5py.Dataset):
+def _normalise(vector: np.ndarray, transform: h5py.Dataset):
     norm = np.linalg.norm(vector)
     if isclose(norm, 0.):
         raise TransformationError(
             f"Magnitude of 'vector' attribute in transformation at "
-            f"{transform.name} has magnitude too close to zero")
+            f"{transform.name} is too close to zero")
     return vector / norm
 
 
@@ -150,8 +150,9 @@ def _append_translation(attributes: h5py.AttributeManager, offset: List[float],
         raise TransformationError(
             f"Missing 'vector' attribute in transformation at {transform.name}"
         )
-    vector = normalise(direction,
-                       transform) * transform[...].astype(float).item()
+    # -1 as describes passive transformation
+    vector = _normalise(direction,
+                        transform) * -1. * transform[...].astype(float).item()
     matrix = np.array([[1., 0., 0., vector[0] + offset[0]],
                        [0., 1., 0., vector[1] + offset[1]],
                        [0., 0., 1., vector[2] + offset[2]], [0., 0., 0., 1.]])

--- a/python/src/scippneutron/_loading_transformations.py
+++ b/python/src/scippneutron/_loading_transformations.py
@@ -49,17 +49,9 @@ def get_position_from_transformations(
     return np.matmul(total_transform_matrix, np.array([0, 0, 0, 1],
                                                       dtype=float))[0:3]
 
-    # vertices = vertices.T
-    # Add fourth element of 1 to each vertex, indicating these are
-    # positions not direction vectors
-    # vertices = np.vstack((vertices, np.ones(vertices.shape[1])))
-    # vertices = do_transformations(transformations, vertices)
-    # Now the transformations are done we do not need the 4th element
-    # return vertices[:3, :].T
 
-
-def get_full_transformation_matrix(
-        group: h5py.Group, root: [h5py.File, h5py.Group]) -> np.ndarray:
+def get_full_transformation_matrix(group: h5py.Group,
+                                   root: h5py.File) -> np.ndarray:
     """
     Get the 4x4 transformation matrix for a component, resulting
     from the full chain of transformations linked by "depends_on"
@@ -84,8 +76,8 @@ def get_full_transformation_matrix(
 
 
 def _get_transformations(depends_on: Union[str, bytes],
-                         transformations: List[np.ndarray],
-                         root: [h5py.File, h5py.Group], group_name: str):
+                         transformations: List[np.ndarray], root: h5py.File,
+                         group_name: str):
     """
     Get all transformations in the depends_on chain
 

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -39,11 +39,11 @@ def _add_string_data_as_attr(group: h5py.Group, dataset_name: str,
         pass
 
 
-def _add_instrument_name(instrument_group: h5py.Group, data: sc.Variable):
+def _load_instrument_name(instrument_group: h5py.Group, data: sc.Variable):
     _add_string_data_as_attr(instrument_group, "name", "instrument_name", data)
 
 
-def _add_title(entry_group: h5py.Group, data: sc.Variable):
+def _load_title(entry_group: h5py.Group, data: sc.Variable):
     _add_string_data_as_attr(entry_group, "title", "experiment_title", data)
 
 
@@ -66,8 +66,10 @@ def load_nexus(data_file: Union[str, h5py.File], root: str = "/", quiet=True):
         nx_log = "NXlog"
         nx_entry = "NXentry"
         nx_instrument = "NXinstrument"
+        nx_sample = "NXsample"
         groups = find_by_nx_class(
-            (nx_event_data, nx_log, nx_entry, nx_instrument), nexus_file[root])
+            (nx_event_data, nx_log, nx_entry, nx_instrument, nx_sample),
+            nexus_file[root])
 
         if len(groups[nx_entry]) > 1:
             # We can't sensibly load from multiple NXentry, for example each
@@ -88,10 +90,10 @@ def load_nexus(data_file: Union[str, h5py.File], root: str = "/", quiet=True):
         load_logs(loaded_data, groups[nx_log])
 
         if groups[nx_instrument]:
-            _add_instrument_name(groups[nx_instrument][0], loaded_data)
+            _load_instrument_name(groups[nx_instrument][0], loaded_data)
 
         if groups[nx_entry]:
-            _add_title(groups[nx_entry][0], loaded_data)
+            _load_title(groups[nx_entry][0], loaded_data)
 
     # Return None if we have an empty dataset at this point
     if no_event_data and not loaded_data.keys():

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -58,16 +58,23 @@ def _load_instrument_name(instrument_groups: List[h5py.Group],
                                     "instrument_name", data)
 
 
-def _load_sample(sample_groups: List[h5py.Group], data: sc.Variable):
+def _load_sample(sample_groups: List[h5py.Group], data: sc.Variable,
+                 file_root: h5py.File):
     load_position_of_unique_component(sample_groups,
                                       data,
                                       "sample",
                                       nx_sample,
+                                      file_root=file_root,
                                       default_position=np.array([0, 0, 0]))
 
 
-def _load_source(source_groups: List[h5py.Group], data: sc.Variable):
-    load_position_of_unique_component(source_groups, data, "source", nx_source)
+def _load_source(source_groups: List[h5py.Group], data: sc.Variable,
+                 file_root: h5py.File):
+    load_position_of_unique_component(source_groups,
+                                      data,
+                                      "source",
+                                      nx_source,
+                                      file_root=file_root)
 
 
 def _load_title(entry_group: h5py.Group, data: sc.Variable):
@@ -113,9 +120,9 @@ def load_nexus(data_file: Union[str, h5py.File], root: str = "/", quiet=True):
         load_logs(loaded_data, groups[nx_log])
 
         if groups[nx_sample]:
-            _load_sample(groups[nx_sample], loaded_data)
+            _load_sample(groups[nx_sample], loaded_data, nexus_file)
         if groups[nx_source]:
-            _load_source(groups[nx_source], loaded_data)
+            _load_source(groups[nx_source], loaded_data, nexus_file)
         if groups[nx_instrument]:
             _load_instrument_name(groups[nx_instrument], loaded_data)
         if groups[nx_entry]:

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -110,7 +110,8 @@ def load_nexus(data_file: Union[str, h5py.File], root: str = "/", quiet=True):
                 "to specify which to load data from, for example"
                 f"{__name__}('my_file.nxs', '/entry_2')")
 
-        loaded_data = load_detector_data(groups[nx_event_data], quiet)
+        loaded_data = load_detector_data(groups[nx_event_data], data_file,
+                                         quiet)
         if loaded_data is None:
             no_event_data = True
             loaded_data = sc.Dataset({})

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -110,7 +110,7 @@ def load_nexus(data_file: Union[str, h5py.File], root: str = "/", quiet=True):
                 "to specify which to load data from, for example"
                 f"{__name__}('my_file.nxs', '/entry_2')")
 
-        loaded_data = load_detector_data(groups[nx_event_data], data_file,
+        loaded_data = load_detector_data(groups[nx_event_data], nexus_file,
                                          quiet)
         if loaded_data is None:
             no_event_data = True

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -27,8 +27,8 @@ def _open_if_path(file_in: Union[str, h5py.File]):
         yield file_in
 
 
-def _add_string_data_as_attr(group: h5py.Group, dataset_name: str,
-                             attr_name: str, data: sc.Variable):
+def _add_string_attr_to_loaded_data(group: h5py.Group, dataset_name: str,
+                                    attr_name: str, data: sc.Variable):
     try:
         data = data.attrs
     except AttributeError:
@@ -44,7 +44,6 @@ def _add_string_data_as_attr(group: h5py.Group, dataset_name: str,
 def _add_attr_to_loaded_data(attr_name: str,
                              data: sc.Variable,
                              value: np.ndarray,
-                             time: Optional[np.ndarray] = None,
                              dtype: Optional[Any] = None):
     try:
         data = data.attrs
@@ -65,8 +64,8 @@ def _load_instrument_name(instrument_groups: List[h5py.Group],
     if len(instrument_groups) > 1:
         warn(f"More than one NXinstrument found in file, "
              f"loading name from {instrument_groups[0]} only")
-    _add_string_data_as_attr(instrument_groups[0], "name", "instrument_name",
-                             data)
+    _add_string_attr_to_loaded_data(instrument_groups[0], "name",
+                                    "instrument_name", data)
 
 
 def _load_sample(sample_groups: List[h5py.Group], data: sc.Variable):
@@ -81,7 +80,8 @@ def _load_sample(sample_groups: List[h5py.Group], data: sc.Variable):
 
 
 def _load_title(entry_group: h5py.Group, data: sc.Variable):
-    _add_string_data_as_attr(entry_group, "title", "experiment_title", data)
+    _add_string_attr_to_loaded_data(entry_group, "title", "experiment_title",
+                                    data)
 
 
 def load_nexus(data_file: Union[str, h5py.File], root: str = "/", quiet=True):

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -77,7 +77,12 @@ def _load_sample(sample_groups: List[h5py.Group], data: sc.Variable):
     sample_group = sample_groups[0]
     if "distance" in sample_group:
         position = np.array([0, 0, sample_group["distance"][...]])
-        units = sc.Unit(get_units(sample_group["distance"]))
+        unit_str = get_units(sample_group["distance"])
+        if not unit_str:
+            warn("'distance' dataset in NXsample is missing units attribute, "
+                 "skipping loading sample position")
+            return
+        units = sc.Unit(unit_str)
     else:
         position = np.array([0, 0, 0])
         units = sc.units.m

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -12,7 +12,8 @@ from typing import Union, List
 from contextlib import contextmanager
 from warnings import warn
 import numpy as np
-from ._loading_positions import load_position_of_unique_component
+from ._loading_positions import (load_position_of_unique_component,
+                                 load_positions_of_components)
 
 nx_event_data = "NXevent_data"
 nx_log = "NXlog"
@@ -60,12 +61,12 @@ def _load_instrument_name(instrument_groups: List[h5py.Group],
 
 def _load_sample(sample_groups: List[h5py.Group], data: sc.Variable,
                  file_root: h5py.File):
-    load_position_of_unique_component(sample_groups,
-                                      data,
-                                      "sample",
-                                      nx_sample,
-                                      file_root=file_root,
-                                      default_position=np.array([0, 0, 0]))
+    load_positions_of_components(sample_groups,
+                                 data,
+                                 "sample",
+                                 nx_sample,
+                                 file_root=file_root,
+                                 default_position=np.array([0, 0, 0]))
 
 
 def _load_source(source_groups: List[h5py.Group], data: sc.Variable,

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -67,7 +67,7 @@ class EventData:
 @dataclass
 class Log:
     name: str
-    value: np.ndarray
+    value: Optional[np.ndarray]
     time: Optional[np.ndarray] = None
     value_units: Optional[str] = None
     time_units: Optional[str] = None
@@ -115,7 +115,8 @@ def _add_detector_group_to_file(detector: Detector, parent_group: h5py.Group,
 
 def _add_log_group_to_file(log, parent_group):
     log_group = _create_nx_class(log.name, "NXlog", parent_group)
-    value_ds = log_group.create_dataset("value", data=log.value)
+    if log.value is not None:
+        value_ds = log_group.create_dataset("value", data=log.value)
     if log.value_units is not None:
         value_ds.attrs.create("units", data=log.value_units)
     if log.time is not None:

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -67,7 +67,7 @@ class Transformation:
     vector: np.ndarray
     value: Optional[np.ndarray]
     time: Optional[np.ndarray] = None
-    depends_on: Optional["Transformation"] = None
+    depends_on: Union["Transformation", str, None] = None
     offset: Optional[np.ndarray] = None
     value_units: Optional[str] = None
     time_units: Optional[str] = None
@@ -135,14 +135,16 @@ def _add_log_group_to_file(log: Log, parent_group: h5py.Group) -> h5py.Group:
 def _add_transformations_to_file(transform: Transformation,
                                  parent_group: h5py.Group) -> str:
     transform_chain = [transform]
-    while transform.depends_on is not None:
+    while transform.depends_on is not None and not isinstance(
+            transform.depends_on, str):
         transform_chain.append(transform.depends_on)
         transform = transform.depends_on
 
     transforms_group = _create_nx_class("transformations", "NXtransformations",
                                         parent_group)
     transform_chain.reverse()
-    depends_on_str = None
+    depends_on_str = transform.depends_on if isinstance(
+        transform.depends_on, str) else None
     for transform_number, transform in enumerate(transform_chain):
         if transform.time is not None:
             depends_on_str = _add_transformation_as_log(

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -191,7 +191,7 @@ class InMemoryNexusFileBuilder:
         self._logs: List[Log] = []
         self._instrument_name = None
         self._title = None
-        self._sample = None
+        self._sample = []
 
     def add_detector(self, detector: Detector):
         self._detectors.append(detector)
@@ -209,7 +209,7 @@ class InMemoryNexusFileBuilder:
         self._title = title
 
     def add_sample(self, sample: Sample):
-        self._sample = sample
+        self._sample.append(sample)
 
     @contextmanager
     def file(self) -> Iterator[h5py.File]:
@@ -237,16 +237,15 @@ class InMemoryNexusFileBuilder:
             nexus_file.close()
 
     def _write_sample(self, parent_group: h5py.Group):
-        if self._sample is not None:
-            sample_group = _create_nx_class(self._sample.name, "NXsample",
+        for sample in self._sample:
+            sample_group = _create_nx_class(sample.name, "NXsample",
                                             parent_group)
-            if self._sample.depends_on is not None:
+            if sample.depends_on is not None:
                 depends_on = _add_transformations_to_file(
-                    self._sample.depends_on, sample_group)
+                    sample.depends_on, sample_group)
                 sample_group.create_dataset("depends_on", data=depends_on)
-            if self._sample.distance is not None:
-                sample_group.create_dataset("distance",
-                                            data=self._sample.distance)
+            if sample.distance is not None:
+                sample_group.create_dataset("distance", data=sample.distance)
 
     def _write_instrument(self, parent_group: h5py.Group) -> h5py.Group:
         instrument_group = _create_nx_class("instrument", "NXinstrument",

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -296,6 +296,10 @@ class InMemoryNexusFileBuilder:
                                               detector_group, "events")
             if detector.log is not None:
                 _add_log_group_to_file(detector.log, detector_group)
+            if detector.depends_on is not None:
+                depends_on = _add_transformations_to_file(
+                    detector.depends_on, detector_group)
+                detector_group.create_dataset("depends_on", data=depends_on)
 
     def _write_event_data(self, parent_group: h5py.Group):
         for event_data_index, event_data in enumerate(self._event_data):

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -78,6 +78,7 @@ class Sample:
     name: str
     depends_on: Optional[Transformation] = None
     distance: Optional[float] = None
+    distance_units: Optional[str] = None
 
 
 def _add_event_data_group_to_file(data: EventData, parent_group: h5py.Group,
@@ -245,7 +246,10 @@ class InMemoryNexusFileBuilder:
                     sample.depends_on, sample_group)
                 sample_group.create_dataset("depends_on", data=depends_on)
             if sample.distance is not None:
-                sample_group.create_dataset("distance", data=sample.distance)
+                distance_ds = sample_group.create_dataset("distance",
+                                                          data=sample.distance)
+                if sample.distance_units is not None:
+                    distance_ds.attrs["units"] = sample.distance_units
 
     def _write_instrument(self, parent_group: h5py.Group) -> h5py.Group:
         instrument_group = _create_nx_class("instrument", "NXinstrument",

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -134,7 +134,7 @@ def _add_log_group_to_file(log: Log, parent_group: h5py.Group) -> h5py.Group:
 
 def _add_transformations_to_file(transform: Transformation,
                                  parent_group: h5py.Group) -> str:
-    transform_chain = []
+    transform_chain = [transform]
     while transform.depends_on is not None:
         transform_chain.append(transform.depends_on)
         transform = transform.depends_on

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -46,16 +46,6 @@ class Log:
     time_units: Optional[str] = None
 
 
-@dataclass
-class Detector:
-    detector_numbers: np.ndarray
-    event_data: Optional[EventData] = None
-    log: Optional[Log] = None
-    x_offsets: Optional[np.ndarray] = None
-    y_offsets: Optional[np.ndarray] = None
-    z_offsets: Optional[np.ndarray] = None
-
-
 class TransformationType(Enum):
     TRANSLATION = "translation"
     ROTATION = "rotation"
@@ -71,6 +61,17 @@ class Transformation:
     offset: Optional[np.ndarray] = None
     value_units: Optional[str] = None
     time_units: Optional[str] = None
+
+
+@dataclass
+class Detector:
+    detector_numbers: np.ndarray
+    event_data: Optional[EventData] = None
+    log: Optional[Log] = None
+    x_offsets: Optional[np.ndarray] = None
+    y_offsets: Optional[np.ndarray] = None
+    z_offsets: Optional[np.ndarray] = None
+    depends_on: Optional[Transformation] = None
 
 
 @dataclass

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -227,6 +227,14 @@ class InMemoryNexusFileBuilder:
     def add_source(self, source: Source):
         self._source.append(source)
 
+    def add_component(self, component: Union[Sample, Source]):
+        # This is a little ugly, but allows parametrisation
+        # of tests which should work for sample and source
+        if isinstance(component, Sample):
+            self.add_sample(component)
+        elif isinstance(component, Source):
+            self.add_source(component)
+
     @contextmanager
     def file(self) -> Iterator[h5py.File]:
         # "core" driver means file is "in-memory" not on disk.

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -3,6 +3,7 @@ from .nexus_helpers import (
     EventData,
     Detector,
     Log,
+    Sample,
     in_memory_hdf5_file_with_two_nxentry,
 )
 import numpy as np
@@ -560,9 +561,19 @@ def test_loads_sample_position_at_origin_if_not_explicit_in_file():
     # or "depends_on" pointing to NXtransformations then it should be
     # assumed to be at the origin
     builder = InMemoryNexusFileBuilder()
-    builder.add_sample(position=None)
+    builder.add_sample(Sample("sample"))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
 
     origin = np.array([0, 0, 0])
     assert np.allclose(loaded_data.attrs["sample_position"].values, origin)
+
+
+def test_skips_loading_sample_if_more_than_one_sample_in_file():
+    builder = InMemoryNexusFileBuilder()
+    builder.add_sample(Sample("sample_1"))
+    builder.add_sample(Sample("sample_2"))
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    assert loaded_data is None

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -577,3 +577,19 @@ def test_skips_loading_sample_if_more_than_one_sample_in_file():
         loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None
+
+
+def test_loads_sample_position_from_distance_dataset_if_no_depends_on():
+    # If the NXsample contains a "distance" dataset this gives the position
+    # on the z axis. If there was a depends_on pointing to transformations
+    # then we'll use that instead as it is likely to be more accurate; it
+    # can define position and orientation in 3D.
+    builder = InMemoryNexusFileBuilder()
+    distance = 4.2
+    builder.add_sample(Sample("sample", distance=distance))
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    expected_position = np.array([0, 0, distance])
+    assert np.allclose(loaded_data["sample_position"].values,
+                       expected_position)

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -578,7 +578,6 @@ def test_skips_loading_sample_if_more_than_one_sample_in_file():
     builder.add_sample(Sample("sample_2"))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
-
     assert loaded_data is None
 
 
@@ -589,10 +588,23 @@ def test_loads_sample_position_from_distance_dataset():
     # can define position and orientation in 3D.
     builder = InMemoryNexusFileBuilder()
     distance = 4.2
-    builder.add_sample(Sample("sample", distance=distance, distance_units="m"))
+    units = "m"
+    builder.add_sample(
+        Sample("sample", distance=distance, distance_units=units))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
 
     expected_position = np.array([0, 0, distance])
     assert np.allclose(loaded_data["sample_position"].values,
                        expected_position)
+    assert loaded_data["sample_position"].unit == sc.Unit(units)
+
+
+def test_skips_sample_position_from_distance_dataset_missing_unit():
+    builder = InMemoryNexusFileBuilder()
+    distance = 4.2
+    builder.add_sample(Sample("sample", distance=distance,
+                              distance_units=None))
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+    assert loaded_data is None

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -11,26 +11,26 @@ import scippneutron
 import scipp as sc
 
 
-def test_load_nexus_raises_exception_if_multiple_nxentry_in_file():
+def test_raises_exception_if_multiple_nxentry_in_file():
     with in_memory_hdf5_file_with_two_nxentry() as nexus_file:
         with pytest.raises(RuntimeError):
             scippneutron.load_nexus(nexus_file)
 
 
-def test_load_nexus_no_exception_if_single_nxentry_in_file():
+def test_no_exception_if_single_nxentry_in_file():
     builder = InMemoryNexusFileBuilder()
     with builder.file() as nexus_file:
         assert scippneutron.load_nexus(nexus_file) is None
 
 
-def test_load_nexus_no_exception_if_single_nxentry_found_below_root():
+def test_no_exception_if_single_nxentry_found_below_root():
     with in_memory_hdf5_file_with_two_nxentry() as nexus_file:
         # There are 2 NXentry in the file, but root is used
         # to specify which to load data from
         assert scippneutron.load_nexus(nexus_file, root='/entry_1') is None
 
 
-def test_load_nexus_loads_data_from_single_event_data_group():
+def test_loads_data_from_single_event_data_group():
     event_time_offsets = np.array([456, 743, 347, 345, 632])
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3]),
@@ -68,7 +68,7 @@ def test_load_nexus_loads_data_from_single_event_data_group():
                           expected_detector_ids)
 
 
-def test_load_nexus_loads_data_from_multiple_event_data_groups():
+def test_loads_data_from_multiple_event_data_groups():
     pulse_times = np.array([
         1600766730000000000, 1600766731000000000, 1600766732000000000,
         1600766733000000000
@@ -116,7 +116,7 @@ def test_load_nexus_loads_data_from_multiple_event_data_groups():
                           expected_detector_ids)
 
 
-def test_load_nexus_skips_event_data_group_with_non_integer_event_ids():
+def test_skips_event_data_group_with_non_integer_event_ids():
     event_time_offsets = np.array([456, 743, 347, 345, 632])
     event_data = EventData(
         event_id=np.array([1.1, 2.2, 3.3, 1.1, 3.1]),
@@ -138,7 +138,7 @@ def test_load_nexus_skips_event_data_group_with_non_integer_event_ids():
                                 "event data has non integer event ids"
 
 
-def test_load_nexus_skips_event_data_group_with_non_integer_detector_numbers():
+def test_skips_event_data_group_with_non_integer_detector_numbers():
     event_time_offsets = np.array([456, 743, 347, 345, 632])
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3]),
@@ -161,8 +161,7 @@ def test_load_nexus_skips_event_data_group_with_non_integer_detector_numbers():
                                 "detector has non integer detector numbers"
 
 
-def test_load_nexus_skips_data_with_event_id_and_detector_number_type_unequal(
-):
+def test_skips_data_with_event_id_and_detector_number_type_unequal():
     event_time_offsets = np.array([456, 743, 347, 345, 632])
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3], dtype=np.int64),
@@ -186,7 +185,7 @@ def test_load_nexus_skips_data_with_event_id_and_detector_number_type_unequal(
                                 "different types"
 
 
-def test_load_nexus_loads_data_from_single_log_with_no_units():
+def test_loads_data_from_single_log_with_no_units():
     values = np.array([1, 2, 3])
     times = np.array([4, 5, 6])
     name = "test_log"
@@ -202,7 +201,7 @@ def test_load_nexus_loads_data_from_single_log_with_no_units():
                           times)
 
 
-def test_load_nexus_loads_data_from_single_log_with_units():
+def test_loads_data_from_single_log_with_units():
     values = np.array([1.1, 2.2, 3.3])
     times = np.array([4.4, 5.5, 6.6])
     name = "test_log"
@@ -220,7 +219,7 @@ def test_load_nexus_loads_data_from_single_log_with_units():
     assert loaded_data[name].data.values.coords['time'].unit == sc.units.s
 
 
-def test_load_nexus_loads_data_from_multiple_logs():
+def test_loads_data_from_multiple_logs():
     builder = InMemoryNexusFileBuilder()
     log_1 = Log("test_log", np.array([1.1, 2.2, 3.3]),
                 np.array([4.4, 5.5, 6.6]))
@@ -242,7 +241,7 @@ def test_load_nexus_loads_data_from_multiple_logs():
         loaded_data[log_2.name].data.values.coords['time'].values, log_2.time)
 
 
-def test_load_nexus_loads_logs_with_non_supported_int_types():
+def test_loads_logs_with_non_supported_int_types():
     builder = InMemoryNexusFileBuilder()
     log_int8 = Log("test_log_int8",
                    np.array([1, 2, 3]).astype(np.int8),
@@ -270,7 +269,7 @@ def test_load_nexus_loads_logs_with_non_supported_int_types():
                            log.time)
 
 
-def test_load_nexus_skips_multidimensional_log():
+def test_skips_multidimensional_log():
     # Loading NXlogs with more than 1 dimension is not yet implemented
     # We need to come up with a sensible approach to labelling the dimensions
 
@@ -285,7 +284,7 @@ def test_load_nexus_skips_multidimensional_log():
     assert loaded_data is None
 
 
-def test_load_nexus_skips_log_with_no_value_dataset():
+def test_skips_log_with_no_value_dataset():
     name = "test_log"
     builder = InMemoryNexusFileBuilder()
     builder.add_log(Log(name, None, np.array([4, 5, 6])))
@@ -296,7 +295,7 @@ def test_load_nexus_skips_log_with_no_value_dataset():
     assert loaded_data is None
 
 
-def test_load_nexus_skips_log_with_empty_value_and_time_datasets():
+def test_skips_log_with_empty_value_and_time_datasets():
     empty_values = np.array([]).astype(np.int32)
     empty_times = np.array([]).astype(np.int32)
     name = "test_log"
@@ -309,7 +308,7 @@ def test_load_nexus_skips_log_with_empty_value_and_time_datasets():
     assert loaded_data is None
 
 
-def test_load_nexus_skips_log_with_mismatched_value_and_time():
+def test_skips_log_with_mismatched_value_and_time():
     values = np.array([1, 2, 3]).astype(np.int32)
     times = np.array([1, 2, 3, 4]).astype(np.int32)
     name = "test_log"
@@ -322,7 +321,7 @@ def test_load_nexus_skips_log_with_mismatched_value_and_time():
     assert loaded_data is None
 
 
-def test_load_nexus_loads_data_from_non_timeseries_log():
+def test_loads_data_from_non_timeseries_log():
     values = np.array([1.1, 2.2, 3.3])
     name = "test_log"
     builder = InMemoryNexusFileBuilder()
@@ -334,7 +333,7 @@ def test_load_nexus_loads_data_from_non_timeseries_log():
     assert np.allclose(loaded_data[name].data.values.values, values)
 
 
-def test_load_nexus_loads_data_from_multiple_logs_with_same_name():
+def test_loads_data_from_multiple_logs_with_same_name():
     values_1 = np.array([1.1, 2.2, 3.3])
     values_2 = np.array([4, 5, 6])
     name = "test_log"
@@ -386,7 +385,7 @@ def test_load_experiment_title():
     assert loaded_data['experiment_title'].values == title
 
 
-def test_load_nexus_loads_event_and_log_data_from_single_file():
+def test_loads_event_and_log_data_from_single_file():
     event_time_offsets = np.array([456, 743, 347, 345, 632])
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3]),
@@ -444,7 +443,7 @@ def test_load_nexus_loads_event_and_log_data_from_single_file():
         loaded_data.attrs[log_2.name].values.coords['time'].values, log_2.time)
 
 
-def test_load_nexus_loads_pixel_positions_with_event_data():
+def test_loads_pixel_positions_with_event_data():
     pulse_times = np.array([
         1600766730000000000, 1600766731000000000, 1600766732000000000,
         1600766733000000000
@@ -501,7 +500,7 @@ def test_load_nexus_loads_pixel_positions_with_event_data():
                        expected_pixel_positions)
 
 
-def test_load_nexus_does_not_load_pixel_positions_with_non_matching_shape():
+def test_does_not_load_pixel_positions_with_non_matching_shape():
     pulse_times = np.array([
         1600766730000000000, 1600766731000000000, 1600766732000000000,
         1600766733000000000
@@ -552,3 +551,18 @@ def test_load_nexus_does_not_load_pixel_positions_with_non_matching_shape():
     # Even though detector_1's offsets and ids are matches in size, we do not
     # load them as the "position" coord would not have positions for all
     # the detector ids (loading event data from all detectors is prioritised)
+
+
+def test_loads_sample_position_at_origin_if_not_explicit_in_file():
+    # The sample position is the origin of the coordinate
+    # system in NeXus files
+    # If there is an NXsample in the file, but it has no "distance" dataset
+    # or "depends_on" pointing to NXtransformations then it should be
+    # assumed to be at the origin
+    builder = InMemoryNexusFileBuilder()
+    builder.add_sample(position=None)
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    origin = np.array([0, 0, 0])
+    assert np.allclose(loaded_data.attrs["sample_position"].values, origin)

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -54,17 +54,17 @@ def test_load_nexus_loads_data_from_single_event_data_group():
     assert np.array_equal(
         np.sort(
             loaded_data.bins.concatenate(
-                'detector-id').values.coords['tof'].values),
+                'detector_id').values.coords['tof'].values),
         np.sort(event_time_offsets))
 
     counts_on_detectors = loaded_data.bins.sum()
-    # No detector_number dataset in file so expect detector-id to be
-    # binned according to whatever detector-ids are present in event_id
+    # No detector_number dataset in file so expect detector_id to be
+    # binned according to whatever detector_ids are present in event_id
     # dataset: 2 on det 1, 1 on det 2, 2 on det 3
     expected_counts = np.array([2, 1, 2])
     assert np.array_equal(counts_on_detectors.data.values, expected_counts)
     expected_detector_ids = np.array([1, 2, 3])
-    assert np.array_equal(loaded_data.coords['detector-id'].values,
+    assert np.array_equal(loaded_data.coords['detector_id'].values,
                           expected_detector_ids)
 
 
@@ -103,16 +103,16 @@ def test_load_nexus_loads_data_from_multiple_event_data_groups():
     assert np.array_equal(
         np.sort(
             loaded_data.bins.concatenate(
-                'detector-id').values.coords['tof'].values),
+                'detector_id').values.coords['tof'].values),
         np.sort(np.concatenate((event_time_offsets_1, event_time_offsets_2))))
 
     counts_on_detectors = loaded_data.bins.sum()
     # There are detector_number datasets in the NXdetector for each
-    # NXevent_data, these are used for detector-id binning
+    # NXevent_data, these are used for detector_id binning
     expected_counts = np.array([0, 2, 1, 2, 2, 1, 2, 0])
     assert np.array_equal(counts_on_detectors.data.values, expected_counts)
     expected_detector_ids = np.concatenate((detector_1_ids, detector_2_ids))
-    assert np.array_equal(loaded_data.coords['detector-id'].values,
+    assert np.array_equal(loaded_data.coords['detector_id'].values,
                           expected_detector_ids)
 
 
@@ -417,17 +417,17 @@ def test_load_nexus_loads_event_and_log_data_from_single_file():
     assert np.allclose(
         np.sort(
             loaded_data.bins.concatenate(
-                'detector-id').values.coords['tof'].values),
+                'detector_id').values.coords['tof'].values),
         np.sort(event_time_offsets))
 
     counts_on_detectors = loaded_data.bins.sum()
-    # No detector_number dataset in file so expect detector-id to be
-    # binned from the min to the max detector-id recorded in event_id
+    # No detector_number dataset in file so expect detector_id to be
+    # binned from the min to the max detector_id recorded in event_id
     # dataset: 2 on det 1, 1 on det 2, 2 on det 3
     expected_counts = np.array([2, 1, 2])
     assert np.allclose(counts_on_detectors.data.values, expected_counts)
     expected_detector_ids = np.array([1, 2, 3])
-    assert np.allclose(loaded_data.coords['detector-id'].values,
+    assert np.allclose(loaded_data.coords['detector_id'].values,
                        expected_detector_ids)
     assert "position" not in loaded_data.coords.keys(
     ), "The NXdetectors had no pixel position datasets so we " \

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -551,15 +551,15 @@ def test_does_not_load_pixel_positions_with_non_matching_shape():
        "size of its detector ids so we should not find 'position' coord"
     # Even though detector_1's offsets and ids are matches in size, we do not
     # load them as the "position" coord would not have positions for all
-    # the detector ids (loading event data from all detectors is prioritised)
+    # the detector ids (loading event data from all detectors is prioritised).
 
 
 def test_loads_sample_position_at_origin_if_not_explicit_in_file():
     # The sample position is the origin of the coordinate
-    # system in NeXus files
+    # system in NeXus files.
     # If there is an NXsample in the file, but it has no "distance" dataset
     # or "depends_on" pointing to NXtransformations then it should be
-    # assumed to be at the origin
+    # assumed to be at the origin.
     builder = InMemoryNexusFileBuilder()
     builder.add_sample(Sample("sample"))
     with builder.file() as nexus_file:
@@ -570,6 +570,9 @@ def test_loads_sample_position_at_origin_if_not_explicit_in_file():
 
 
 def test_skips_loading_sample_if_more_than_one_sample_in_file():
+    # More than one sample is a serious error in the file, so load_nexus
+    # will display a warning and skip loading any sample rather than guessing
+    # which is the "correct" one.
     builder = InMemoryNexusFileBuilder()
     builder.add_sample(Sample("sample_1"))
     builder.add_sample(Sample("sample_2"))
@@ -579,14 +582,14 @@ def test_skips_loading_sample_if_more_than_one_sample_in_file():
     assert loaded_data is None
 
 
-def test_loads_sample_position_from_distance_dataset_if_no_depends_on():
+def test_loads_sample_position_from_distance_dataset():
     # If the NXsample contains a "distance" dataset this gives the position
-    # on the z axis. If there was a depends_on pointing to transformations
-    # then we'll use that instead as it is likely to be more accurate; it
+    # along the z axis. If there was a "depends_on" pointing to transformations
+    # then we'd use that instead as it is likely to be more accurate; it
     # can define position and orientation in 3D.
     builder = InMemoryNexusFileBuilder()
     distance = 4.2
-    builder.add_sample(Sample("sample", distance=distance))
+    builder.add_sample(Sample("sample", distance=distance, distance_units="m"))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
 

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -273,8 +273,8 @@ def test_loads_logs_with_non_supported_int_types():
     # Expect a sc.Dataset with log names as keys
     for log in logs:
         assert np.allclose(loaded_data[log.name].data.values.values, log.value)
-        assert np.allclose(loaded_data[log.name].data.values.coords['time'],
-                           log.time)
+        assert np.allclose(
+            loaded_data[log.name].data.values.coords['time'].values, log.time)
 
 
 def test_skips_multidimensional_log():

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -566,7 +566,7 @@ def test_loads_sample_position_at_origin_if_not_explicit_in_file():
         loaded_data = scippneutron.load_nexus(nexus_file)
 
     origin = np.array([0, 0, 0])
-    assert np.allclose(loaded_data.attrs["sample_position"].values, origin)
+    assert np.allclose(loaded_data["sample_position"].values, origin)
 
 
 def test_skips_loading_sample_if_more_than_one_sample_in_file():

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -613,11 +613,10 @@ def test_skips_sample_position_from_distance_dataset_missing_unit():
 
 def test_loads_sample_position_from_single_transformation():
     builder = InMemoryNexusFileBuilder()
-    transformation = Transformation(
-        TransformationType.TRANSLATION,
-        np.ndarray([0, 0, 1]),  # -1
-        np.array([230]),
-        value_units="cm")
+    transformation = Transformation(TransformationType.TRANSLATION,
+                                    vector=np.array([0, 0, -1]),
+                                    value=np.array([230]),
+                                    value_units="cm")
     builder.add_sample(Sample("sample", depends_on=transformation))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
@@ -641,14 +640,14 @@ def test_loads_sample_position_prefers_transformation_over_distance_dataset():
     # can define position and orientation in 3D.
     builder = InMemoryNexusFileBuilder()
     transformation = Transformation(TransformationType.TRANSLATION,
-                                    np.ndarray([0, 0, -1]),
+                                    np.array([0, 0, -1]),
                                     np.array([2.3]),
                                     value_units="m")
     builder.add_sample(
         Sample("sample",
                depends_on=transformation,
                distance=4.2,
-               distance_units=sc.Unit("m")))
+               distance_units="m"))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
 
@@ -658,10 +657,20 @@ def test_loads_sample_position_prefers_transformation_over_distance_dataset():
     assert loaded_data["sample_position"].unit == sc.Unit("m")
 
 
-def test_skips_sample_position_from_transformation_missing_unit():
+def test_skips_sample_position_from_translation_missing_unit():
     builder = InMemoryNexusFileBuilder()
     transformation = Transformation(TransformationType.TRANSLATION,
-                                    np.ndarray([0, 0, -1]), np.array([2.3]))
+                                    np.array([0, 0, -1]), np.array([2.3]))
+    builder.add_sample(Sample("sample", depends_on=transformation))
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+    assert loaded_data is None
+
+
+def test_skips_sample_position_from_rotation_missing_unit():
+    builder = InMemoryNexusFileBuilder()
+    transformation = Transformation(TransformationType.ROTATION,
+                                    np.array([0, 0, -1]), np.array([45.]))
     builder.add_sample(Sample("sample", depends_on=transformation))
     with builder.file() as nexus_file:
         loaded_data = scippneutron.load_nexus(nexus_file)
@@ -671,11 +680,11 @@ def test_skips_sample_position_from_transformation_missing_unit():
 def test_loads_sample_position_from_multiple_transformations():
     builder = InMemoryNexusFileBuilder()
     transformation_1 = Transformation(TransformationType.ROTATION,
-                                      np.ndarray([0, 1, 0]),
+                                      np.array([0, 1, 0]),
                                       np.array([90]),
                                       value_units="deg")
     transformation_2 = Transformation(TransformationType.TRANSLATION,
-                                      np.ndarray([0, 0, -1]),
+                                      np.array([0, 0, -1]),
                                       np.array([2.3]),
                                       value_units="m",
                                       depends_on=transformation_1)

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -242,6 +242,34 @@ def test_load_nexus_loads_data_from_multiple_logs():
         loaded_data[log_2.name].data.values.coords['time'].values, log_2.time)
 
 
+def test_load_nexus_loads_logs_with_non_supported_int_types():
+    builder = InMemoryNexusFileBuilder()
+    log_int8 = Log("test_log_int8",
+                   np.array([1, 2, 3]).astype(np.int8),
+                   np.array([4.4, 5.5, 6.6]))
+    log_int16 = Log("test_log_int16",
+                    np.array([123, 253, 756]).astype(np.int16),
+                    np.array([246, 1235, 2369]))
+    log_uint8 = Log("test_log_uint8",
+                    np.array([1, 2, 3]).astype(np.uint8),
+                    np.array([4.4, 5.5, 6.6]))
+    log_uint16 = Log("test_log_uint16",
+                     np.array([123, 253, 756]).astype(np.uint16),
+                     np.array([246, 1235, 2369]))
+    logs = (log_int8, log_int16, log_uint8, log_uint16)
+    for log in logs:
+        builder.add_log(log)
+
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    # Expect a sc.Dataset with log names as keys
+    for log in logs:
+        assert np.allclose(loaded_data[log.name].data.values.values, log.value)
+        assert np.allclose(loaded_data[log.name].data.values.coords['time'],
+                           log.time)
+
+
 def test_load_nexus_skips_multidimensional_log():
     # Loading NXlogs with more than 1 dimension is not yet implemented
     # We need to come up with a sensible approach to labelling the dimensions

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -137,7 +137,8 @@ def test_skips_event_data_group_with_non_integer_event_ids():
     builder.add_event_data(event_data)
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None, "Expected no data to be loaded as " \
                                 "event data has non integer event ids"
@@ -160,7 +161,8 @@ def test_skips_event_data_group_with_non_integer_detector_numbers():
     builder.add_detector(Detector(detector_numbers, event_data))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None, "Expected no data to be loaded as " \
                                 "detector has non integer detector numbers"
@@ -183,7 +185,8 @@ def test_skips_data_with_event_id_and_detector_number_type_unequal():
     builder.add_detector(Detector(detector_numbers, event_data))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None, "Expected no data to be loaded as event " \
                                 "ids and detector numbers are of " \
@@ -284,7 +287,8 @@ def test_skips_multidimensional_log():
     builder.add_log(Log(name, multidim_values, np.array([4, 5, 6])))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None
 
@@ -295,7 +299,8 @@ def test_skips_log_with_no_value_dataset():
     builder.add_log(Log(name, None, np.array([4, 5, 6])))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None
 
@@ -308,7 +313,8 @@ def test_skips_log_with_empty_value_and_time_datasets():
     builder.add_log(Log(name, empty_values, empty_times))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None
 
@@ -321,7 +327,8 @@ def test_skips_log_with_mismatched_value_and_time():
     builder.add_log(Log(name, values, times))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert loaded_data is None
 
@@ -505,7 +512,7 @@ def test_loads_pixel_positions_with_event_data():
                        expected_pixel_positions)
 
 
-def test_does_not_load_pixel_positions_with_non_matching_shape():
+def test_skips_loading_pixel_positions_with_non_matching_shape():
     pulse_times = np.array([
         1600766730000000000, 1600766731000000000, 1600766732000000000,
         1600766733000000000
@@ -548,7 +555,8 @@ def test_does_not_load_pixel_positions_with_non_matching_shape():
                  y_offsets=y_pixel_offset_2))
 
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert "position" not in loaded_data.coords.keys(
     ), "One of the NXdetectors pixel positions arrays did not match the " \
@@ -585,7 +593,8 @@ def test_skips_loading_component_if_more_than_one_in_file(
     builder.add_component(component_class(f"{component_name}_1"))
     builder.add_component(component_class(f"{component_name}_2"))
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
     assert loaded_data is None
 
 
@@ -600,7 +609,8 @@ def test_skips_component_position_from_distance_dataset_missing_unit(
         component_class(component_name, distance=distance,
                         distance_units=None))
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
     assert loaded_data is None
 
 
@@ -684,7 +694,8 @@ def test_skips_component_position_with_multi_value_log_transformation(
     builder.add_component(
         component_class(component_name, depends_on=transformation))
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
 
     # Loading component position from transformations recorded as
     # NXlogs with multiple values is not yet implemented
@@ -735,7 +746,8 @@ def test_skips_component_position_from_transformation_missing_unit(
     builder.add_component(
         component_class(component_name, depends_on=transformation))
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
     assert loaded_data is None
 
 
@@ -760,7 +772,8 @@ def test_skips_component_position_with_transformation_with_small_vector(
     builder.add_component(
         component_class(component_name, depends_on=transformation))
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
     assert loaded_data is None
 
 
@@ -800,7 +813,8 @@ def test_skips_source_position_if_not_given_in_file():
     builder = InMemoryNexusFileBuilder()
     builder.add_source(Source("source"))
     with builder.file() as nexus_file:
-        loaded_data = scippneutron.load_nexus(nexus_file)
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
     assert loaded_data is None
 
 

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -355,10 +355,10 @@ def test_load_nexus_loads_data_from_multiple_logs_with_same_name():
     if np.allclose(loaded_data[name].data.values.values, values_1):
         # Then the other log should be
         assert np.allclose(
-            loaded_data[f"detector_1-{name}"].data.values.values, values_2)
+            loaded_data[f"detector_1_{name}"].data.values.values, values_2)
     elif np.allclose(loaded_data[name].data.values.values, values_2):
         # Then the other log should be
-        assert np.allclose(loaded_data[f"entry-{name}"].data.values.values,
+        assert np.allclose(loaded_data[f"entry_{name}"].data.values.values,
                            values_1)
     else:
         assert False

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -285,6 +285,43 @@ def test_load_nexus_skips_multidimensional_log():
     assert loaded_data is None
 
 
+def test_load_nexus_skips_log_with_no_value_dataset():
+    name = "test_log"
+    builder = InMemoryNexusFileBuilder()
+    builder.add_log(Log(name, None, np.array([4, 5, 6])))
+
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    assert loaded_data is None
+
+
+def test_load_nexus_skips_log_with_empty_value_and_time_datasets():
+    empty_values = np.array([]).astype(np.int32)
+    empty_times = np.array([]).astype(np.int32)
+    name = "test_log"
+    builder = InMemoryNexusFileBuilder()
+    builder.add_log(Log(name, empty_values, empty_times))
+
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    assert loaded_data is None
+
+
+def test_load_nexus_skips_log_with_mismatched_value_and_time():
+    values = np.array([1, 2, 3]).astype(np.int32)
+    times = np.array([1, 2, 3, 4]).astype(np.int32)
+    name = "test_log"
+    builder = InMemoryNexusFileBuilder()
+    builder.add_log(Log(name, values, times))
+
+    with builder.file() as nexus_file:
+        loaded_data = scippneutron.load_nexus(nexus_file)
+
+    assert loaded_data is None
+
+
 def test_load_nexus_loads_data_from_non_timeseries_log():
     values = np.array([1.1, 2.2, 3.3])
     name = "test_log"

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -582,7 +582,7 @@ def test_sample_position_at_origin_if_not_explicit_in_file():
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 def test_skips_loading_component_if_more_than_one_in_file(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str):
@@ -599,7 +599,7 @@ def test_skips_loading_component_if_more_than_one_in_file(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 def test_skips_component_position_from_distance_dataset_missing_unit(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str):
@@ -618,8 +618,8 @@ def test_skips_component_position_from_distance_dataset_missing_unit(
                          [(Sample, "sample"), (Source, "source")])
 @pytest.mark.parametrize(
     "transform_type,value,value_units,expected_position",
-    [(TransformationType.ROTATION, 0.27, "rad", [0, 0, 0]),
-     (TransformationType.TRANSLATION, 230, "cm", [0, 0, 2.3])])
+    ((TransformationType.ROTATION, 0.27, "rad", [0, 0, 0]),
+     (TransformationType.TRANSLATION, 230, "cm", [0, 0, 2.3])))
 def test_loads_component_position_from_single_transformation(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str, transform_type: TransformationType, value: float,
@@ -642,11 +642,11 @@ def test_loads_component_position_from_single_transformation(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 @pytest.mark.parametrize(
     "transform_type,value,value_units,expected_position",
-    [(TransformationType.ROTATION, 0.27, "rad", [0, 0, 0]),
-     (TransformationType.TRANSLATION, 230, "cm", [0, 0, 2.3])])
+    ((TransformationType.ROTATION, 0.27, "rad", [0, 0, 0]),
+     (TransformationType.TRANSLATION, 230, "cm", [0, 0, 2.3])))
 def test_loads_component_position_from_log_transformation(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str, transform_type: TransformationType, value: float,
@@ -673,10 +673,10 @@ def test_loads_component_position_from_log_transformation(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 @pytest.mark.parametrize("transform_type,value,value_units",
-                         [(TransformationType.ROTATION, [26, 73], "deg"),
-                          (TransformationType.TRANSLATION, [230, 310], "cm")])
+                         ((TransformationType.ROTATION, [26, 73], "deg"),
+                          (TransformationType.TRANSLATION, [230, 310], "cm")))
 def test_skips_component_position_with_multi_value_log_transformation(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str, transform_type: TransformationType,
@@ -705,7 +705,33 @@ def test_skips_component_position_with_multi_value_log_transformation(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
+@pytest.mark.parametrize("transform_type,value_units",
+                         ((TransformationType.ROTATION, "deg"),
+                          (TransformationType.TRANSLATION, "cm")))
+def test_skips_component_position_with_empty_value_log_transformation(
+        component_class: Union[Type[Source],
+                               Type[Sample]], component_name: str,
+        transform_type: TransformationType, value_units: str):
+    builder = InMemoryNexusFileBuilder()
+    empty_value = np.array([])
+    transformation = Transformation(transform_type,
+                                    vector=np.array([0, 0, -1]),
+                                    value=empty_value,
+                                    time=np.array([1.3, 6.4]),
+                                    time_units="s",
+                                    value_units=value_units)
+    builder.add_component(
+        component_class(component_name, depends_on=transformation))
+    with builder.file() as nexus_file:
+        with pytest.warns(UserWarning):
+            loaded_data = scippneutron.load_nexus(nexus_file)
+
+    assert loaded_data is None
+
+
+@pytest.mark.parametrize("component_class,component_name",
+                         ((Sample, "sample"), (Source, "source")))
 def test_load_component_position_prefers_transform_over_distance(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str):
@@ -733,10 +759,10 @@ def test_load_component_position_prefers_transform_over_distance(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 @pytest.mark.parametrize(
     "transform_type",
-    [TransformationType.ROTATION, TransformationType.TRANSLATION])
+    (TransformationType.ROTATION, TransformationType.TRANSLATION))
 def test_skips_component_position_from_transformation_missing_unit(
         component_class: Union[Type[Source], Type[Sample]],
         component_name: str, transform_type: TransformationType):
@@ -752,10 +778,10 @@ def test_skips_component_position_from_transformation_missing_unit(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 @pytest.mark.parametrize("transform_type,value_units",
-                         [(TransformationType.ROTATION, "deg"),
-                          (TransformationType.TRANSLATION, "m")])
+                         ((TransformationType.ROTATION, "deg"),
+                          (TransformationType.TRANSLATION, "m")))
 def test_skips_component_position_with_transformation_with_small_vector(
         component_class: Union[Type[Source],
                                Type[Sample]], component_name: str,
@@ -778,7 +804,7 @@ def test_skips_component_position_with_transformation_with_small_vector(
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 def test_loads_component_position_from_multiple_transformations(
     component_class: Union[Type[Source], Type[Sample]],
     component_name: str,
@@ -819,7 +845,7 @@ def test_skips_source_position_if_not_given_in_file():
 
 
 @pytest.mark.parametrize("component_class,component_name",
-                         [(Sample, "sample"), (Source, "source")])
+                         ((Sample, "sample"), (Source, "source")))
 def test_loads_component_position_from_distance_dataset(
     component_class: Union[Type[Source], Type[Sample]],
     component_name: str,

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -736,10 +736,10 @@ def test_loads_sample_position_from_multiple_transformations():
 
     # Transformations in NeXus are "passive transformations", so in this
     # test case the coordinate system is rotated 90 degrees anticlockwise
-    # around the y axis and then shifted -2.3m in the z direction. In
+    # around the y axis and then shifted 2.3m in the z direction. In
     # the lab reference frame this corresponds to
-    # setting the sample position to 2.3m in the x direction.
-    expected_position = np.array([transformation_2.value[0], 0, 0])
+    # setting the sample position to -2.3m in the x direction.
+    expected_position = np.array([-transformation_2.value[0], 0, 0])
     assert np.allclose(loaded_data["sample_position"].values,
                        expected_position)
     assert loaded_data["sample_position"].unit == sc.Unit("m")


### PR DESCRIPTION
Closes #19

Add support for parsing chains of transformations from NeXus. This allows loading source, sample and pixel positions.
Only ~200 added lines are the implementation, ~900 lines added to test code to cover the many edge cases.

This does not yet cover the case that a transformation has multiple values (scanned motion axis), #34.

I'm pretty sure `np.einsum` or similar could be used to apply the transformation to pixel positions more efficiently, let me know if you have an idea, but time taken appears to be small in comparison to loading event data anyway.