### PR TITLE
Fix comparisons of scipp vars with numpy arrays

### DIFF
--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -198,7 +198,8 @@ def test_load_nexus_loads_data_from_single_log_with_no_units():
 
     # Expect a sc.Dataset with log names as keys
     assert np.array_equal(loaded_data[name].data.values.values, values)
-    assert np.array_equal(loaded_data[name].data.values.coords['time'], times)
+    assert np.array_equal(loaded_data[name].data.values.coords['time'].values,
+                          times)
 
 
 def test_load_nexus_loads_data_from_single_log_with_units():
@@ -213,7 +214,8 @@ def test_load_nexus_loads_data_from_single_log_with_units():
 
     # Expect a sc.Dataset with log names as keys
     assert np.allclose(loaded_data[name].data.values.values, values)
-    assert np.allclose(loaded_data[name].data.values.coords['time'], times)
+    assert np.allclose(loaded_data[name].data.values.coords['time'].values,
+                       times)
     assert loaded_data[name].data.values.unit == sc.units.m
     assert loaded_data[name].data.values.coords['time'].unit == sc.units.s
 
@@ -232,12 +234,12 @@ def test_load_nexus_loads_data_from_multiple_logs():
 
     # Expect a sc.Dataset with log names as keys
     assert np.allclose(loaded_data[log_1.name].data.values.values, log_1.value)
-    assert np.allclose(loaded_data[log_1.name].data.values.coords['time'],
-                       log_1.time)
+    assert np.allclose(
+        loaded_data[log_1.name].data.values.coords['time'].values, log_1.time)
     assert np.array_equal(loaded_data[log_2.name].data.values.values,
                           log_2.value)
-    assert np.array_equal(loaded_data[log_2.name].data.values.coords['time'],
-                          log_2.time)
+    assert np.array_equal(
+        loaded_data[log_2.name].data.values.coords['time'].values, log_2.time)
 
 
 def test_load_nexus_skips_multidimensional_log():
@@ -369,12 +371,12 @@ def test_load_nexus_loads_event_and_log_data_from_single_file():
     # Logs should have been added to the DataArray as attributes
     assert np.allclose(loaded_data.attrs[log_1.name].values.values,
                        log_1.value)
-    assert np.allclose(loaded_data.attrs[log_1.name].values.coords['time'],
-                       log_1.time)
+    assert np.allclose(
+        loaded_data.attrs[log_1.name].values.coords['time'].values, log_1.time)
     assert np.allclose(loaded_data.attrs[log_2.name].values.values,
                        log_2.value)
-    assert np.allclose(loaded_data.attrs[log_2.name].values.coords['time'],
-                       log_2.time)
+    assert np.allclose(
+        loaded_data.attrs[log_2.name].values.coords['time'].values, log_2.time)
 
 
 def test_load_nexus_loads_pixel_positions_with_event_data():

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -458,8 +458,8 @@ class TestMantidConversion(unittest.TestCase):
         assert len(mtd) == 0, f"Workspaces present: {mtd.getObjectNames()}"
 
         for i in range(expected_number_spectra):
-            np.testing.assert_array_equal(ws.readX(i), x['spectrum', i])
-            np.testing.assert_array_equal(ws.readY(i), y['spectrum', i])
+            np.testing.assert_array_equal(ws.readX(i), x['spectrum', i].values)
+            np.testing.assert_array_equal(ws.readY(i), y['spectrum', i].values)
             np.testing.assert_array_equal(ws.readE(i),
                                           np.sqrt(y['spectrum', i].values))
 
@@ -703,8 +703,8 @@ def test_to_workspace_2d(param_dim):
     assert len(mtd) == 0, f"Workspaces present: {mtd.getObjectNames()}"
 
     for i in range(expected_number_spectra):
-        np.testing.assert_array_equal(ws.readX(i), x['spectrum', i])
-        np.testing.assert_array_equal(ws.readY(i), y['spectrum', i])
+        np.testing.assert_array_equal(ws.readX(i), x['spectrum', i].values)
+        np.testing.assert_array_equal(ws.readY(i), y['spectrum', i].values)
         np.testing.assert_array_equal(ws.readE(i),
                                       np.sqrt(y['spectrum', i].variances))
 


### PR DESCRIPTION
No longer possible to directly compare scipp variable with a numpy array due to removal of `buffer_protocol` support from `VariableView`: https://github.com/scipp/scipp/pull/1766