### PR TITLE
Trigger main when scipp main completes

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -5,7 +5,7 @@ pr: none
 
 resources:
   pipelines:
-  - pipeline: upstream_scipp_release
+  - pipeline: upstream_scipp_main
     project: scipp
     source: Main
 

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -3,6 +3,12 @@ trigger:
 
 pr: none
 
+resources:
+  pipelines:
+  - pipeline: upstream_scipp_release
+    project: scipp
+    source: Main
+
 stages:
   - template: templates/code_quality_checks.yml
 


### PR DESCRIPTION
scipp **project**, Main **pipeline** is upstream trigger.

Help identify upstream builds that break things in scipp-neutron. This should be replaced/incorporated into the wider CI overhaul underway by @nvaytet 

**Tester**

It is possible to test these changes prior to merging, but it's convoluted, not worth the effort IMHO.