### PR TITLE
Set unit on pixel positions in load_nexus

### DIFF
--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -50,13 +50,11 @@ def _iso8601_to_datetime(iso8601: str) -> Optional[datetime]:
 
 
 def _convert_array_to_metres(array: np.ndarray, unit: str) -> np.ndarray:
-    if sc.Unit(unit) != sc.units.m:
         return sc.to_unit(
             sc.Variable(["temporary_variable"],
                         values=array,
                         unit=unit,
                         dtype=np.float64), "m").values
-    return array
 
 
 def _load_pixel_positions(detector_group: h5py.Group, detector_ids_size: int,

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -50,11 +50,11 @@ def _iso8601_to_datetime(iso8601: str) -> Optional[datetime]:
 
 
 def _convert_array_to_metres(array: np.ndarray, unit: str) -> np.ndarray:
-        return sc.to_unit(
-            sc.Variable(["temporary_variable"],
-                        values=array,
-                        unit=unit,
-                        dtype=np.float64), "m").values
+    return sc.to_unit(
+        sc.Variable(["temporary_variable"],
+                    values=array,
+                    unit=unit,
+                    dtype=np.float64), "m").values
 
 
 def _load_pixel_positions(detector_group: h5py.Group, detector_ids_size: int,

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -71,6 +71,7 @@ class Detector:
     x_offsets: Optional[np.ndarray] = None
     y_offsets: Optional[np.ndarray] = None
     z_offsets: Optional[np.ndarray] = None
+    offsets_unit: Optional[str] = None
     depends_on: Optional[Transformation] = None
 
 
@@ -108,15 +109,14 @@ def _add_detector_group_to_file(detector: Detector, parent_group: h5py.Group,
     detector_group = _create_nx_class(group_name, "NXdetector", parent_group)
     detector_group.create_dataset("detector_number",
                                   data=detector.detector_numbers)
-    if detector.x_offsets is not None:
-        detector_group.create_dataset("x_pixel_offset",
-                                      data=detector.x_offsets)
-    if detector.y_offsets is not None:
-        detector_group.create_dataset("y_pixel_offset",
-                                      data=detector.y_offsets)
-    if detector.z_offsets is not None:
-        detector_group.create_dataset("z_pixel_offset",
-                                      data=detector.z_offsets)
+    for dataset_name, array in (("x_pixel_offset", detector.x_offsets),
+                                ("y_pixel_offset", detector.y_offsets),
+                                ("z_pixel_offset", detector.z_offsets)):
+        if array is not None:
+            offsets_ds = detector_group.create_dataset(dataset_name,
+                                                       data=array)
+            if detector.offsets_unit is not None:
+                offsets_ds.attrs["units"] = detector.offsets_unit
     return detector_group
 
 

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -486,7 +486,7 @@ def test_loads_pixel_positions_with_event_data():
     y_pixel_offset_2 = np.array([[0.1, 0.1], [0.2, 0.2]])
 
     builder = InMemoryNexusFileBuilder()
-    offsets_units = "m"
+    offsets_units = "mm"
     builder.add_detector(
         Detector(detector_1_ids,
                  event_data_1,
@@ -510,10 +510,12 @@ def test_loads_pixel_positions_with_event_data():
         np.concatenate((x_pixel_offset_1, x_pixel_offset_2.flatten())),
         np.concatenate((y_pixel_offset_1, y_pixel_offset_2.flatten())),
         np.concatenate((z_pixel_offset_1, z_pixel_offset_2.flatten()))
-    ]).T
+    ]).T / 1_000  # Divide by 1000 for mm to metres
     assert np.allclose(loaded_data.coords['position'].values,
                        expected_pixel_positions)
-    assert loaded_data.coords['position'].unit == sc.Unit(offsets_units)
+    assert loaded_data.coords[
+        'position'].unit == sc.units.m, "Expected positions " \
+                                        "to be converted to metres"
 
 
 def test_skips_loading_pixel_positions_with_non_matching_shape():
@@ -603,43 +605,6 @@ def test_skips_loading_pixel_positions_with_no_units():
             loaded_data = scippneutron.load_nexus(nexus_file)
 
     assert "position" not in loaded_data.coords.keys()
-
-
-def test_skips_loading_pixel_positions_with_units_which_are_not_metres():
-    pulse_times = np.array([
-        1600766730000000000, 1600766731000000000, 1600766732000000000,
-        1600766733000000000
-    ])
-    event_time_offsets = np.array([456, 743, 347, 345, 632])
-    event_data = EventData(
-        event_id=np.array([1, 2, 3, 1, 3]),
-        event_time_offset=event_time_offsets,
-        event_time_zero=pulse_times,
-        event_index=np.array([0, 3, 3, 5]),
-    )
-    detector_ids = np.array([0, 1, 2, 3])
-    x_pixel_offset = np.array([0.1, 0.2, 0.1, 0.2])
-    y_pixel_offset = np.array([0.1, 0.1, 0.2, 0.2])
-    z_pixel_offset = np.array([0.1, 0.2, 0.3, 0.4])
-
-    builder = InMemoryNexusFileBuilder()
-    offsets_units = "mm"
-    builder.add_detector(
-        Detector(detector_ids,
-                 event_data,
-                 x_offsets=x_pixel_offset,
-                 y_offsets=y_pixel_offset,
-                 z_offsets=z_pixel_offset,
-                 offsets_unit=offsets_units))
-
-    with builder.file() as nexus_file:
-        with pytest.warns(UserWarning):
-            loaded_data = scippneutron.load_nexus(nexus_file)
-
-    assert "position" not in loaded_data.coords.keys(), \
-        f"Expected positions to be missing as units of " \
-        f"{offsets_units} are not yet supported for " \
-        f"pixel offset datasets"
 
 
 def test_sample_position_at_origin_if_not_explicit_in_file():


### PR DESCRIPTION
Closes #42 

Units for pixel positions were not being checked in file or set in the scipp datastructure during `load_nexus()`.

Changes:
- Loading pixel positions is skipped and a warning output if the "units" attribute is missing.
- Units are checked and offsets are converted to metres if they are not already in metres. Conversion to metres is done to ensure consistent units are used for transformation calculations.
- New behaviour is covered by unit tests.

