### PR TITLE
Add data streaming interface to Scipp

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,9 +19,6 @@ requirements:
     - python {{ python }}
     - scipp
     - h5py
-    - pip:
-        - confluent-kafka
-        - ess-streaming-data-types
 
 test:
   imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,8 +19,8 @@ requirements:
     - python {{ python }}
     - scipp
     - h5py
-    - python-confluent-kafka
     - pip:
+        - confluent-kafka
         - ess-streaming-data-types
 
 test:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - scipp
     - h5py
     - python-confluent-kafka
+    - pip:
+        - ess-streaming-data-types
 
 test:
   imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python {{ python }}
     - scipp
     - h5py
+    - python-confluent-kafka
 
 test:
   imports:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,6 +33,7 @@ test:
     - matplotlib-base
     - psutil
     - pytest
+    - pytest-asyncio
     - pythreejs
     - Pillow
     - mantid-framework [not win]

--- a/docs/environments/scippneutron-latest.yml
+++ b/docs/environments/scippneutron-latest.yml
@@ -17,3 +17,6 @@ dependencies:
   - nodejs
   - pythreejs
   - scippneutron
+  - pip:
+      - confluent-kafka
+      - ess-streaming-data-types

--- a/docs/environments/scippneutron.yml
+++ b/docs/environments/scippneutron.yml
@@ -17,3 +17,6 @@ dependencies:
   - nodejs
   - pythreejs
   - scippneutron
+  - pip:
+      - confluent-kafka
+      - ess-streaming-data-types

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -64,6 +64,11 @@ For a more up-to-date version, the `scipp/label/dev` channel can be used instead
 After installation the modules ``scipp`` and ``scippneutron`` can be imported in Python.
 Note that only the bare essential dependencies are installed.
 If you wish to use plotting functionality you will also need to install ``matplotlib`` and ``ipywidgets``.
+If you wish to use the live data functionality you will need to install ``confluent-kafka`` and ``ess-streaming-data-types`` from the PyPi:
+
+.. code-block:: sh
+
+   $ pip install confluent-kafka ess-streaming-data-types
 
 To update or remove ``scippneutron`` use `conda update <https://docs.conda.io/projects/conda/en/latest/commands/update.html>`_ and `conda remove <https://docs.conda.io/projects/conda/en/latest/commands/remove.html>`_.
 

--- a/python/src/scippneutron/__init__.py
+++ b/python/src/scippneutron/__init__.py
@@ -11,4 +11,4 @@ from ._scippneutron import position, source_position, sample_position, incident_
 from .mantid import from_mantid, to_mantid, load, fit
 from .instrument_view import instrument_view
 from .load_nexus import load_nexus
-from .data_stream import data_stream
+from .data_stream import data_stream, start_stream

--- a/python/src/scippneutron/__init__.py
+++ b/python/src/scippneutron/__init__.py
@@ -11,3 +11,4 @@ from ._scippneutron import position, source_position, sample_position, incident_
 from .mantid import from_mantid, to_mantid, load, fit
 from .instrument_view import instrument_view
 from .load_nexus import load_nexus
+from .data_stream import data_stream

--- a/python/src/scippneutron/_streaming_consumer.py
+++ b/python/src/scippneutron/_streaming_consumer.py
@@ -15,8 +15,10 @@ class KafkaConsumer:
         self._reached_eop = False
         self._cancelled = False
         self._consume_data: Optional[asyncio.Task] = None
+        self.stopped = True
 
     def start(self):
+        self.stopped = False
         self._cancelled = False
         self._consume_data = asyncio.create_task(self._consume_loop())
 
@@ -41,6 +43,7 @@ class KafkaConsumer:
             if self._consume_data is not None:
                 self._consume_data.cancel()
             self._consumer.close()
+            self.stopped = True
 
 
 def create_consumers(

--- a/python/src/scippneutron/_streaming_consumer.py
+++ b/python/src/scippneutron/_streaming_consumer.py
@@ -1,0 +1,87 @@
+from confluent_kafka import Consumer, TopicPartition, KafkaError
+from typing import Callable, List, Dict, Optional
+import asyncio
+from warnings import warn
+
+
+class KafkaConsumer:
+    def __init__(self, topic_partitions: List[TopicPartition], conf: Dict,
+                 callback: Callable, stop_at_end_of_partition: bool):
+        conf['enable.partition.eof'] = True
+        self._consumer = Consumer(**conf)
+        self._consumer.assign(topic_partitions)
+        self._callback = callback
+        self._stop_at_end_of_partition = stop_at_end_of_partition
+        self._reached_eop = False
+        self._cancelled = False
+        self._consume_data: Optional[asyncio.Task] = None
+
+    def start(self):
+        self._cancelled = False
+        self._consume_data = asyncio.create_task(self._consume_loop())
+
+    async def _consume_loop(self):
+        while not self._cancelled:
+            msg = self._consumer.poll(timeout=0.)
+            if msg is None:
+                await asyncio.sleep(0.2)
+                continue
+            if msg.error():
+                if self._stop_at_end_of_partition and msg.error(
+                ) == KafkaError._PARTITION_EOF:
+                    self._reached_eop = True
+                    break
+                warn(f"Message error in consumer: {msg.error()}")
+                break
+            await self._callback(msg.value())
+
+    def stop(self):
+        if not self._cancelled:
+            self._cancelled = True
+            if self._consume_data is not None:
+                self._consume_data.cancel()
+            self._consumer.close()
+
+
+def create_consumers(
+        start_time_ms: int,
+        topics: List[str],
+        conf: Dict,
+        callback: Callable,
+        stop_at_end_of_partition: bool = False) -> List[KafkaConsumer]:
+    """
+    Creates one consumer per TopicPartition that start consuming
+    at specified timestamp
+
+    Having each consumer only be responsible for one partition
+    greatly simplifies the logic around stopping at the end of
+    the stream (making use of "end of partition" event)
+    """
+    consumer = Consumer(**conf)
+
+    topic_partitions = []
+    for topic in topics:
+        metadata = consumer.list_topics(topic)
+        topic_partitions.extend([
+            TopicPartition(topic, partition[1].id, offset=start_time_ms)
+            for partition in metadata.topics[topic].partitions.items()
+        ])
+    topic_partitions = consumer.offsets_for_times(topic_partitions)
+
+    consumers = []
+    for topic_partition in topic_partitions:
+        consumers.append(
+            KafkaConsumer([topic_partition], conf, callback,
+                          stop_at_end_of_partition))
+
+    return consumers
+
+
+def start_consumers(consumers: List[KafkaConsumer]):
+    for consumer in consumers:
+        consumer.start()
+
+
+def stop_consumers(consumers: List[KafkaConsumer]):
+    for consumer in consumers:
+        consumer.stop()

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -93,15 +93,15 @@ class StreamedDataBuffer:
                 if self._current_event + message_size > self._buffer_size:
                     await self._emit_data()
                 async with self._buffer_mutex:
-                    self._events_buffer.coords['detector_id'][
-                        'event', self._current_event:self._current_event +
-                        message_size] = deserialised_data.detector_id
-                    self._events_buffer.coords['tof'][
-                        'event', self._current_event:self._current_event +
-                        message_size] = deserialised_data.time_of_flight
-                    self._events_buffer.coords['pulse_time'][
-                        'event', self._current_event:self._current_event +
-                        message_size] = deserialised_data.pulse_time * \
+                    frame = self._events_buffer[
+                        'event',
+                        self._current_event:self._current_event + message_size]
+                    frame.coords[
+                        'detector_id'].values = deserialised_data.detector_id
+                    frame.coords[
+                        'tof'].values = deserialised_data.time_of_flight
+                    frame.coords['pulse_time'].values = \
+                        deserialised_data.pulse_time * \
                         np.ones_like(deserialised_data.time_of_flight)
                     self._current_event += message_size
                 return

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -1,7 +1,6 @@
 import scipp as sc
 import numpy as np
 import asyncio
-from scipp.detail import move_to_data_array
 from streaming_data_types.eventdata_ev42 import deserialise_ev42
 from streaming_data_types.exceptions import WrongSchemaException
 from typing import Optional
@@ -36,15 +35,11 @@ class StreamedDataBuffer:
                               unit=sc.units.one,
                               values=np.ones(buffer_size, dtype=np.float32),
                               variances=np.ones(buffer_size, dtype=np.float32))
-        proto_events = {
-            'data': weights,
-            'coords': {
-                'tof': tof_buffer,
-                'detector_id': id_buffer,
-                'pulse_time': pulse_times
-            }
-        }
-        self._events_buffer = move_to_data_array(**proto_events)
+        self._events_buffer = sc.DataArray(weights, {
+            'tof': tof_buffer,
+            'detector_id': id_buffer,
+            'pulse_time': pulse_times
+        })
         self._current_event = 0
         self._cancelled = False
         self._unrecognised_fb_id_count = 0

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -44,8 +44,8 @@ class StreamedDataBuffer:
         proto_events = {
             'data': weights,
             'coords': {
-                'Tof': tof_buffer,
-                'id': id_buffer,
+                'tof': tof_buffer,
+                'detector_id': id_buffer,
                 'pulse_time': pulse_times
             }
         }
@@ -72,7 +72,7 @@ class StreamedDataBuffer:
             async with self._buffer_mutex:
                 if self._current_event == 0:
                     return
-                new_data = self._events_buffer.coords['id'][
+                new_data = self._events_buffer[
                     'event', :self._current_event].copy()
                 self._current_event = 0
                 if self._unrecognised_fb_id_count:
@@ -105,10 +105,10 @@ class StreamedDataBuffer:
                 if self._current_event + message_size > self._buffer_size:
                     await self._emit_data()
                 async with self._buffer_mutex:
-                    self._events_buffer.coords['id'][
+                    self._events_buffer.coords['detector_id'][
                         'event', self._current_event:self._current_event +
                         message_size] = deserialised_data.detector_id
-                    self._events_buffer.coords['Tof'][
+                    self._events_buffer.coords['tof'][
                         'event', self._current_event:self._current_event +
                         message_size] = deserialised_data.time_of_flight
                     self._events_buffer.coords['pulse_time'][

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -1,0 +1,132 @@
+import scipp as sc
+import numpy as np
+import asyncio
+from scipp.detail import move_to_data_array
+from streaming_data_types.eventdata_ev42 import deserialise_ev42
+from streaming_data_types.logdata_f142 import deserialise_f142
+from streaming_data_types.exceptions import WrongSchemaException
+from typing import Optional, Callable
+from warnings import warn
+
+
+class StreamedDataBuffer:
+    """
+    This owns the buffer for data consumed from Kafka.
+    It periodically emits accumulated data to a processing pipeline
+    and resets the buffer. If the buffer fills up within the emit time
+    interval then data is emitted more frequently.
+    """
+    def __init__(self,
+                 data_callback: Optional[Callable] = None,
+                 interval_s=2.,
+                 buffer_size=1048576):
+        # 1048576 events is around 24 MB (with pulse_time, id, weights, etc)
+        self._buffer_mutex = asyncio.Lock()
+        self._interval = interval_s
+        self._buffer_size = buffer_size
+        tof_buffer = sc.Variable(dims=['event'],
+                                 shape=[buffer_size],
+                                 unit=sc.units.ns,
+                                 dtype=sc.dtype.int32)
+        id_buffer = sc.Variable(dims=['event'],
+                                shape=[buffer_size],
+                                unit=sc.units.one,
+                                dtype=sc.dtype.int32)
+        pulse_times = sc.Variable(dims=['event'],
+                                  shape=[buffer_size],
+                                  unit=sc.units.ns,
+                                  dtype=sc.dtype.int64)
+        weights = sc.Variable(dims=['event'],
+                              unit=sc.units.one,
+                              values=np.ones(buffer_size, dtype=np.float32),
+                              variances=np.ones(buffer_size, dtype=np.float32))
+        # TODO tof + pulse-time
+        proto_events = {
+            'data': weights,
+            'coords': {
+                'Tof': tof_buffer,
+                'id': id_buffer,
+                'pulse_time': pulse_times
+            }
+        }
+        self._events_buffer = move_to_data_array(**proto_events)
+        self._current_event = 0
+        self._cancelled = False
+        self._unrecognised_fb_id_count = 0
+        self._data_callback = data_callback
+        self._periodic_emit: Optional[asyncio.Task] = None
+
+    def start(self):
+        self._current_event = 0
+        self._cancelled = False
+        self._unrecognised_fb_id_count = 0
+        self._periodic_emit = asyncio.create_task(self._emit_loop())
+
+    def stop(self):
+        self._cancelled = True
+        if self._periodic_emit is not None:
+            self._periodic_emit.cancel()
+
+    async def _emit_data(self):
+        try:
+            async with self._buffer_mutex:
+                if self._current_event == 0:
+                    return
+                new_data = self._events_buffer.coords['id'][
+                    'event', :self._current_event].copy()
+                self._current_event = 0
+                if self._unrecognised_fb_id_count:
+                    warn(f"Accumulator received "
+                         f"{self._unrecognised_fb_id_count}"
+                         " messages with unrecognised FlatBuffer ids")
+                    self._unrecognised_fb_id_count = 0
+            if self._data_callback is not None:
+                await self._data_callback(new_data)
+        except Exception as e:
+            print(e)
+
+    async def _emit_loop(self):
+        while not self._cancelled:
+            await asyncio.sleep(self._interval)
+            await self._emit_data()
+
+    async def new_data(self, new_data: bytes):
+        try:
+            # Are they event data?
+            try:
+                deserialised_data = deserialise_ev42(new_data)
+                message_size = deserialised_data.detector_id.size
+                if message_size > self._buffer_size:
+                    print("Single message would overflow NewDataBuffer, "
+                          "please restart with a larger buffer_size:\n"
+                          f"message_size: {message_size}, buffer_size:"
+                          f" {self._buffer_size}")
+                # If new data would overfill buffer then emit data
+                # currently in buffer first
+                if self._current_event + message_size > self._buffer_size:
+                    await self._emit_data()
+                async with self._buffer_mutex:
+                    self._events_buffer.coords['id'][
+                        'event', self._current_event:self._current_event +
+                        message_size] = deserialised_data.detector_id
+                    self._events_buffer.coords['Tof'][
+                        'event', self._current_event:self._current_event +
+                        message_size] = deserialised_data.time_of_flight
+                    self._events_buffer.coords['pulse_time'][
+                        'event', self._current_event:self._current_event +
+                        message_size] = deserialised_data.pulse_time * \
+                        np.ones_like(deserialised_data.time_of_flight)
+                    self._current_event += message_size
+                return
+            except WrongSchemaException:
+                pass
+            # Are they log data?
+            try:
+                _ = deserialise_f142(new_data)
+                async with self._buffer_mutex:
+                    pass  # TODO append to DataArray with matching source name
+                return
+            except WrongSchemaException:
+                self._unrecognised_fb_id_count += 1
+        except Exception as e:
+            print(e)

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -67,16 +67,15 @@ class StreamedDataBuffer:
     async def _emit_data(self):
         try:
             async with self._buffer_mutex:
+                if self._unrecognised_fb_id_count:
+                    warn(f"Received {self._unrecognised_fb_id_count}"
+                         " messages with unrecognised FlatBuffer ids")
+                    self._unrecognised_fb_id_count = 0
                 if self._current_event == 0:
                     return
                 new_data = self._events_buffer[
                     'event', :self._current_event].copy()
                 self._current_event = 0
-                if self._unrecognised_fb_id_count:
-                    warn(f"Accumulator received "
-                         f"{self._unrecognised_fb_id_count}"
-                         " messages with unrecognised FlatBuffer ids")
-                    self._unrecognised_fb_id_count = 0
             self._emit_queue.put_nowait(new_data)
         except Exception as e:
             print(e)

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -19,22 +19,19 @@ class StreamedDataBuffer:
         self._buffer_mutex = asyncio.Lock()
         self._interval_s = sc.to_unit(interval, 's').value
         self._buffer_size = buffer_size
-        tof_buffer = sc.Variable(dims=['event'],
-                                 shape=[buffer_size],
-                                 unit=sc.units.ns,
-                                 dtype=sc.dtype.int32)
-        id_buffer = sc.Variable(dims=['event'],
-                                shape=[buffer_size],
-                                unit=sc.units.one,
-                                dtype=sc.dtype.int32)
-        pulse_times = sc.Variable(dims=['event'],
-                                  shape=[buffer_size],
-                                  unit=sc.units.ns,
-                                  dtype=sc.dtype.int64)
-        weights = sc.Variable(dims=['event'],
-                              unit=sc.units.one,
-                              values=np.ones(buffer_size, dtype=np.float32),
-                              variances=np.ones(buffer_size, dtype=np.float32))
+        tof_buffer = sc.zeros(dims=['event'],
+                              shape=[buffer_size],
+                              unit=sc.units.ns,
+                              dtype=sc.dtype.int32)
+        id_buffer = sc.zeros(dims=['event'],
+                             shape=[buffer_size],
+                             unit=sc.units.one,
+                             dtype=sc.dtype.int32)
+        pulse_times = sc.zeros(dims=['event'],
+                               shape=[buffer_size],
+                               unit=sc.units.ns,
+                               dtype=sc.dtype.int64)
+        weights = sc.ones(dims=['event'], shape=[buffer_size], variances=True)
         self._events_buffer = sc.DataArray(weights, {
             'tof': tof_buffer,
             'detector_id': id_buffer,

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -54,20 +54,17 @@ class StreamedDataBuffer:
             self._periodic_emit.cancel()
 
     async def _emit_data(self):
-        try:
-            async with self._buffer_mutex:
-                if self._unrecognised_fb_id_count:
-                    warn(f"Received {self._unrecognised_fb_id_count}"
-                         " messages with unrecognised FlatBuffer ids")
-                    self._unrecognised_fb_id_count = 0
-                if self._current_event == 0:
-                    return
-                new_data = self._events_buffer[
-                    'event', :self._current_event].copy()
-                self._current_event = 0
-            self._emit_queue.put_nowait(new_data)
-        except Exception as e:
-            print(e)
+        async with self._buffer_mutex:
+            if self._unrecognised_fb_id_count:
+                warn(f"Received {self._unrecognised_fb_id_count}"
+                     " messages with unrecognised FlatBuffer ids")
+                self._unrecognised_fb_id_count = 0
+            if self._current_event == 0:
+                return
+            new_data = self._events_buffer[
+                'event', :self._current_event].copy()
+            self._current_event = 0
+        self._emit_queue.put_nowait(new_data)
 
     async def _emit_loop(self):
         while not self._cancelled:
@@ -75,34 +72,32 @@ class StreamedDataBuffer:
             await self._emit_data()
 
     async def new_data(self, new_data: bytes):
+        # Are they event data?
         try:
-            # Are they event data?
-            try:
-                deserialised_data = deserialise_ev42(new_data)
-                message_size = deserialised_data.detector_id.size
-                if message_size > self._buffer_size:
-                    warn("Single message would overflow NewDataBuffer, "
-                         "please restart with a larger buffer_size:\n"
-                         f"message_size: {message_size}, buffer_size:"
-                         f" {self._buffer_size}")
-                # If new data would overfill buffer then emit data
-                # currently in buffer first
-                if self._current_event + message_size > self._buffer_size:
-                    await self._emit_data()
-                async with self._buffer_mutex:
-                    frame = self._events_buffer[
-                        'event',
-                        self._current_event:self._current_event + message_size]
-                    frame.coords[
-                        'detector_id'].values = deserialised_data.detector_id
-                    frame.coords[
-                        'tof'].values = deserialised_data.time_of_flight
-                    frame.coords['pulse_time'].values = \
-                        deserialised_data.pulse_time * \
-                        np.ones_like(deserialised_data.time_of_flight)
-                    self._current_event += message_size
+            deserialised_data = deserialise_ev42(new_data)
+            message_size = deserialised_data.detector_id.size
+            if message_size > self._buffer_size:
+                warn("Single message would overflow NewDataBuffer, "
+                     "please restart with a larger buffer_size:\n"
+                     f"message_size: {message_size}, buffer_size:"
+                     f" {self._buffer_size}. These data have been "
+                     f"skipped!")
                 return
-            except WrongSchemaException:
-                self._unrecognised_fb_id_count += 1
-        except Exception as e:
-            print(e)
+            # If new data would overfill buffer then emit data
+            # currently in buffer first
+            if self._current_event + message_size > self._buffer_size:
+                await self._emit_data()
+            async with self._buffer_mutex:
+                frame = self._events_buffer[
+                    'event',
+                    self._current_event:self._current_event + message_size]
+                frame.coords[
+                    'detector_id'].values = deserialised_data.detector_id
+                frame.coords['tof'].values = deserialised_data.time_of_flight
+                frame.coords['pulse_time'].values = \
+                    deserialised_data.pulse_time * \
+                    np.ones_like(deserialised_data.time_of_flight)
+                self._current_event += message_size
+            return
+        except WrongSchemaException:
+            self._unrecognised_fb_id_count += 1

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -15,12 +15,10 @@ class StreamedDataBuffer:
     and resets the buffer. If the buffer fills up within the emit time
     interval then data is emitted more frequently.
     """
-    def __init__(self,
-                 queue: asyncio.Queue,
-                 buffer_size: int,
-                 interval_s: float = 2.):
+    def __init__(self, queue: asyncio.Queue, buffer_size: int,
+                 interval: sc.Variable):
         self._buffer_mutex = asyncio.Lock()
-        self._interval = interval_s
+        self._interval_s = sc.to_unit(interval, 's').value
         self._buffer_size = buffer_size
         tof_buffer = sc.Variable(dims=['event'],
                                  shape=[buffer_size],
@@ -81,7 +79,7 @@ class StreamedDataBuffer:
 
     async def _emit_loop(self):
         while not self._cancelled:
-            await asyncio.sleep(self._interval)
+            await asyncio.sleep(self._interval_s)
             await self._emit_data()
 
     async def new_data(self, new_data: bytes):

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -57,7 +57,6 @@ class StreamedDataBuffer:
         self._emit_queue = queue
 
     def start(self):
-        self._current_event = 0
         self._cancelled = False
         self._unrecognised_fb_id_count = 0
         self._periodic_emit = asyncio.create_task(self._emit_loop())

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -17,9 +17,8 @@ class StreamedDataBuffer:
     """
     def __init__(self,
                  queue: asyncio.Queue,
-                 interval_s: float = 2.,
-                 buffer_size: int = 1048576):
-        # 1048576 events is around 24 MB (with pulse_time, id, weights, etc)
+                 buffer_size: int,
+                 interval_s: float = 2.):
         self._buffer_mutex = asyncio.Lock()
         self._interval = interval_s
         self._buffer_size = buffer_size

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -1,7 +1,7 @@
 from ._streaming_consumer import (create_consumers, start_consumers)
 from ._streaming_data_buffer import StreamedDataBuffer
 import time
-from typing import List, Generator
+from typing import List, Generator, Callable
 from ._streaming_consumer import KafkaConsumer
 import asyncio
 import scipp as sc
@@ -40,7 +40,7 @@ async def data_stream(
                                  topics,
                                  config,
                                  buffer.new_data,
-                                 stop_at_end_of_partition=True)
+                                 stop_at_end_of_partition=False)
 
     start_consumers(consumers)
     buffer.start()
@@ -55,6 +55,11 @@ async def data_stream(
                                               timeout=2 * interval_s)
             yield new_data
         except asyncio.TimeoutError:
-            pass
+            print("timed out waiting for new data")
 
+    print("All consumers stopped")
     buffer.stop()
+
+
+def start_stream(user_function: Callable) -> asyncio.Task:
+    return asyncio.create_task(user_function())

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -14,25 +14,28 @@ def _consumers_all_stopped(consumers: List[KafkaConsumer]):
     return True
 
 
-async def stream_data(
+async def data_stream(
+        kafka_broker: str,
+        topics: List[str],
         interval_s: float = 2.) -> Generator[sc.Variable, None, None]:
     """
     Periodically yields accumulated data from stream.
     If the buffer fills up more frequently than the set interval
     then data is yielded more frequently.
+    :param kafka_broker: Address of the Kafka broker to stream data from
+    :param topics: Kafka topics to consume data from
     :param interval_s: interval between yielding any new data
       collected from stream
     """
     queue = asyncio.Queue()
     buffer = StreamedDataBuffer(queue, interval_s=interval_s)
     config = {
-        "bootstrap.servers": "localhost:9092",
+        "bootstrap.servers": kafka_broker,
         "group.id": "consumer_group_name",
         "auto.offset.reset": "latest",
         "enable.auto.commit": False,
     }
     time_now_ms = int(time.time() * 1000)
-    topics = ["ISIS_Kafka_Event_events"]
     consumers = create_consumers(time_now_ms,
                                  topics,
                                  config,

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -44,18 +44,21 @@ async def _data_stream(
 async def data_stream(
         kafka_broker: str,
         topics: List[str],
+        buffer_size: int = 1048576,
         interval_s: float = 2.) -> Generator[sc.Variable, None, None]:
     """
     Periodically yields accumulated data from stream.
     If the buffer fills up more frequently than the set interval
     then data is yielded more frequently.
+    1048576 event buffer is around 24 MB (with pulse_time, id, weights, etc)
     :param kafka_broker: Address of the Kafka broker to stream data from
     :param topics: Kafka topics to consume data from
+    :param buffer_size: Size of buffer to accumulate data in
     :param interval_s: interval between yielding any new data
       collected from stream
     """
     queue = asyncio.Queue()
-    buffer = StreamedDataBuffer(queue, interval_s=interval_s)
+    buffer = StreamedDataBuffer(queue, buffer_size, interval_s=interval_s)
     config = {
         "bootstrap.servers": kafka_broker,
         "group.id": "consumer_group_name",

--- a/python/src/scippneutron/stream_data.py
+++ b/python/src/scippneutron/stream_data.py
@@ -42,10 +42,10 @@ async def stream_data(
     start_consumers(consumers)
     buffer.start()
 
-    # If we wait twice the expected interval and haven't got
+    # If we wait twice the expected interval and have not got
     # any new data in the queue then check if it is because all
     # the consumers have stopped, if so, we are done. Otherwise
-    # it could just be that we have received any new data.
+    # it could just be that we have not received any new data.
     while not _consumers_all_stopped(consumers):
         try:
             new_data = await asyncio.wait_for(queue.get(),

--- a/python/src/scippneutron/stream_data.py
+++ b/python/src/scippneutron/stream_data.py
@@ -1,0 +1,38 @@
+from ._streaming_consumer import (create_consumers, start_consumers,
+                                  stop_consumers)
+from ._streaming_data_buffer import StreamedDataBuffer
+import time
+
+
+def stream_data(interval_s=2.):
+    """
+    It periodically yields accumulated data and resets the buffer.
+    If the buffer fills up within the emit time
+    interval then data is emitted more frequently.
+    :param interval_s:
+    :return:
+    """
+    buffer = StreamedDataBuffer()
+    config = {
+        "bootstrap.servers": "localhost:9092",
+        "group.id": "consumer_group_name",
+        "auto.offset.reset": "latest",
+        "enable.auto.commit": False,
+    }
+    # Real implementation would get the last "run start" message
+    # to get the start timestamp and what other topics to consume from
+    time_now_ms = int(time.time() * 1000)
+    topics = ["ISIS_Kafka_Event_events"]
+    consumers = create_consumers(time_now_ms,
+                                 topics,
+                                 config,
+                                 buffer.new_data,
+                                 stop_at_end_of_partition=True)
+
+    start_consumers(consumers)
+    buffer.start()
+
+    time.sleep(10)
+
+    stop_consumers(consumers)
+    buffer.stop()

--- a/python/src/scippneutron/stream_data.py
+++ b/python/src/scippneutron/stream_data.py
@@ -1,26 +1,36 @@
-from ._streaming_consumer import (create_consumers, start_consumers,
-                                  stop_consumers)
+from ._streaming_consumer import (create_consumers, start_consumers)
 from ._streaming_data_buffer import StreamedDataBuffer
 import time
+from typing import List, Generator
+from ._streaming_consumer import KafkaConsumer
+import asyncio
+import scipp as sc
 
 
-def stream_data(interval_s=2.):
+def _consumers_all_stopped(consumers: List[KafkaConsumer]):
+    for consumer in consumers:
+        if not consumer.stopped:
+            return False
+    return True
+
+
+async def stream_data(
+        interval_s: float = 2.) -> Generator[sc.Variable, None, None]:
     """
-    It periodically yields accumulated data and resets the buffer.
-    If the buffer fills up within the emit time
-    interval then data is emitted more frequently.
-    :param interval_s:
-    :return:
+    Periodically yields accumulated data from stream.
+    If the buffer fills up more frequently than the set interval
+    then data is yielded more frequently.
+    :param interval_s: interval between yielding any new data
+      collected from stream
     """
-    buffer = StreamedDataBuffer()
+    queue = asyncio.Queue()
+    buffer = StreamedDataBuffer(queue, interval_s=interval_s)
     config = {
         "bootstrap.servers": "localhost:9092",
         "group.id": "consumer_group_name",
         "auto.offset.reset": "latest",
         "enable.auto.commit": False,
     }
-    # Real implementation would get the last "run start" message
-    # to get the start timestamp and what other topics to consume from
     time_now_ms = int(time.time() * 1000)
     topics = ["ISIS_Kafka_Event_events"]
     consumers = create_consumers(time_now_ms,
@@ -32,7 +42,16 @@ def stream_data(interval_s=2.):
     start_consumers(consumers)
     buffer.start()
 
-    time.sleep(10)
+    # If we wait twice the expected interval and haven't got
+    # any new data in the queue then check if it is because all
+    # the consumers have stopped, if so, we are done. Otherwise
+    # it could just be that we have received any new data.
+    while not _consumers_all_stopped(consumers):
+        try:
+            new_data = await asyncio.wait_for(queue.get(),
+                                              timeout=2 * interval_s)
+            yield new_data
+        except asyncio.TimeoutError:
+            pass
 
-    stop_consumers(consumers)
     buffer.stop()

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -120,6 +120,8 @@ async def test_warn_on_buffer_size_exceeded_by_single_message():
     test_message = serialise_ev42("detector", 0, 0, time_of_flight,
                                   detector_ids)
 
+    # User is warned to try again with a larger buffer size,
+    # and informed what message size was encountered
     with pytest.warns(UserWarning):
         await buffer.new_data(test_message)
 

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -30,8 +30,8 @@ def stop_consumers(consumers: List[FakeConsumer]):
 
 
 # Short time to use for buffer emit and data_stream interval in tests
-# ensure they pass or fail fast!
-SHORT_TEST_INTERVAL = 0.005  # 5 ms
+# pass or fail fast!
+SHORT_TEST_INTERVAL = 0.001  # 1 ms
 
 
 @pytest.mark.asyncio
@@ -41,20 +41,19 @@ async def test_data_stream_returns_data_from_single_event_message():
     consumers = [FakeConsumer()]
     time_of_flight = np.array([1., 2., 3.])
     detector_ids = np.array([4, 5, 6])
-    fake_message = serialise_ev42("detector", 0, 0, time_of_flight,
+    test_message = serialise_ev42("detector", 0, 0, time_of_flight,
                                   detector_ids)
-    await buffer.new_data(fake_message)
+    await buffer.new_data(test_message)
 
-    collected_data = None
-    async for data in _data_stream(buffer,
-                                   queue,
-                                   consumers,
-                                   interval_s=SHORT_TEST_INTERVAL):
-        collected_data = data
+    async for data in _data_stream(
+            buffer,
+            queue,
+            consumers,  # type: ignore
+            interval_s=SHORT_TEST_INTERVAL):
+        assert np.allclose(data.coords['tof'].values, time_of_flight)
+
+        # Cause the data_stream generator to stop and exit the "async for"
         stop_consumers(consumers)
-
-    assert collected_data is not None
-    assert np.allclose(collected_data.coords['tof'].values, time_of_flight)
 
 
 @pytest.mark.asyncio
@@ -64,23 +63,40 @@ async def test_data_stream_returns_data_from_multiple_event_messages():
     consumers = [FakeConsumer()]
     first_tof = np.array([1., 2., 3.])
     first_detector_ids = np.array([4, 5, 6])
-    first_fake_message = serialise_ev42("detector", 0, 0, first_tof,
+    first_test_message = serialise_ev42("detector", 0, 0, first_tof,
                                         first_detector_ids)
     second_tof = np.array([1., 2., 3.])
     second_detector_ids = np.array([4, 5, 6])
-    second_fake_message = serialise_ev42("detector", 0, 0, second_tof,
+    second_test_message = serialise_ev42("detector", 0, 0, second_tof,
                                          second_detector_ids)
-    await buffer.new_data(first_fake_message)
-    await buffer.new_data(second_fake_message)
+    await buffer.new_data(first_test_message)
+    await buffer.new_data(second_test_message)
 
-    collected_data = None
-    async for data in _data_stream(buffer,
-                                   queue,
-                                   consumers,
-                                   interval_s=SHORT_TEST_INTERVAL):
-        collected_data = data
+    async for data in _data_stream(
+            buffer,
+            queue,
+            consumers,  # type: ignore
+            interval_s=SHORT_TEST_INTERVAL):
+        expected_tofs = np.concatenate((first_tof, second_tof))
+        assert np.allclose(data.coords['tof'].values, expected_tofs)
+
         stop_consumers(consumers)
 
-    assert collected_data is not None
-    expected_tofs = np.concatenate((first_tof, second_tof))
-    assert np.allclose(collected_data.coords['tof'].values, expected_tofs)
+
+@pytest.mark.asyncio
+async def test_warn_on_data_emit_if_unrecognised_message_was_encountered():
+    queue = asyncio.Queue()
+    buffer = StreamedDataBuffer(queue, interval_s=SHORT_TEST_INTERVAL)
+    # First 4 bytes of the message payload are the FlatBuffer schema identifier
+    # "abcd" does not correspond to a FlatBuffer schema for data
+    # that scipp is interested in
+    test_message = b"abcd0000"
+    await buffer.new_data(test_message)
+
+    with pytest.warns(UserWarning):
+        await buffer._emit_data()
+
+
+# TODO tests for:
+#  exceed buffer size with multiple messages
+#  exceed buffer size with single message

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -1,0 +1,86 @@
+from scippneutron.data_stream import _data_stream
+from scippneutron._streaming_data_buffer import StreamedDataBuffer
+import asyncio
+import pytest
+from typing import List
+from streaming_data_types import serialise_ev42
+import numpy as np
+
+
+class FakeConsumer:
+    """
+    Use in place of KafkaConsumer to avoid having to do
+    network IO in unit tests. Does not need to supply
+    fake messages as the new_data method on the
+    StreamedDataBuffer can be called manually instead.
+    """
+    def __init__(self):
+        self.stopped = True
+
+    def start(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+def stop_consumers(consumers: List[FakeConsumer]):
+    for consumer in consumers:
+        consumer.stop()
+
+
+# Short time to use for buffer emit and data_stream interval in tests
+# ensure they pass or fail fast!
+SHORT_TEST_INTERVAL = 0.005  # 5 ms
+
+
+@pytest.mark.asyncio
+async def test_data_stream_returns_data_from_single_event_message():
+    queue = asyncio.Queue()
+    buffer = StreamedDataBuffer(queue, interval_s=SHORT_TEST_INTERVAL)
+    consumers = [FakeConsumer()]
+    time_of_flight = np.array([1., 2., 3.])
+    detector_ids = np.array([4, 5, 6])
+    fake_message = serialise_ev42("detector", 0, 0, time_of_flight,
+                                  detector_ids)
+    await buffer.new_data(fake_message)
+
+    collected_data = None
+    async for data in _data_stream(buffer,
+                                   queue,
+                                   consumers,
+                                   interval_s=SHORT_TEST_INTERVAL):
+        collected_data = data
+        stop_consumers(consumers)
+
+    assert collected_data is not None
+    assert np.allclose(collected_data.coords['tof'].values, time_of_flight)
+
+
+@pytest.mark.asyncio
+async def test_data_stream_returns_data_from_multiple_event_messages():
+    queue = asyncio.Queue()
+    buffer = StreamedDataBuffer(queue, interval_s=SHORT_TEST_INTERVAL)
+    consumers = [FakeConsumer()]
+    first_tof = np.array([1., 2., 3.])
+    first_detector_ids = np.array([4, 5, 6])
+    first_fake_message = serialise_ev42("detector", 0, 0, first_tof,
+                                        first_detector_ids)
+    second_tof = np.array([1., 2., 3.])
+    second_detector_ids = np.array([4, 5, 6])
+    second_fake_message = serialise_ev42("detector", 0, 0, second_tof,
+                                         second_detector_ids)
+    await buffer.new_data(first_fake_message)
+    await buffer.new_data(second_fake_message)
+
+    collected_data = None
+    async for data in _data_stream(buffer,
+                                   queue,
+                                   consumers,
+                                   interval_s=SHORT_TEST_INTERVAL):
+        collected_data = data
+        stop_consumers(consumers)
+
+    assert collected_data is not None
+    expected_tofs = np.concatenate((first_tof, second_tof))
+    assert np.allclose(collected_data.coords['tof'].values, expected_tofs)

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -29,8 +29,8 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
-  - python-confluent-kafka
   - pip:
+      - confluent-kafka
       - ess-streaming-data-types
 
   # Test

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -30,6 +30,8 @@ dependencies:
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
   - python-confluent-kafka
+  - pip:
+      - ess-streaming-data-types
 
   # Test
   - psutil

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -29,6 +29,7 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
+  - python-confluent-kafka
 
   # Test
   - psutil

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -36,6 +36,7 @@ dependencies:
   # Test
   - psutil
   - pytest
+  - pytest-asyncio
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -29,8 +29,8 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
-  - python-confluent-kafka
   - pip:
+      - confluent-kafka
       - ess-streaming-data-types
 
   # Test

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -30,6 +30,8 @@ dependencies:
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
   - python-confluent-kafka
+  - pip:
+      - ess-streaming-data-types
 
   # Test
   - psutil

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -29,6 +29,7 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
+  - python-confluent-kafka
 
   # Test
   - psutil

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -36,6 +36,7 @@ dependencies:
   # Test
   - psutil
   - pytest
+  - pytest-asyncio
 
   # Formatting & static analysis
   - pre-commit


### PR DESCRIPTION
Closes https://github.com/scipp/scipp/issues/1448

Intentionally not documented yet, but can be used like this (assuming there is a Kafka broker running on `localhost` with a topic called "event_data"):
```python
import asyncio

async def my_stream_func():
    async for data in scn.data_stream('localhost:9092', ['event_data'], interval_s=3.):
        print(data)
    
streaming_task = asyncio.create_task(my_stream_func())
```

In this first step of the implementation only event data are consumed from Kafka. Behaviour if any other data types are encountered is documented in the unit tests.

Three dependencies were added:
- `confluent-kafka` is the Kafka client library, there are other python implementations but this is the one used in ECDC software such as https://github.com/ess-dmsc/forwarder/
- `ess-streaming-data-types` implements serialisation and deserialisation of the data formats used in the ESS data streaming system
- `pytest-asyncio` is a plugin for pytest to facilitate testing async code

I could provide a `docker-compose` script that would launch a Kafka broker and populate it with event data if anyone wants to test on their machine.
