### PR TITLE
If duplicates, rename to avoid name clashes

### DIFF
--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -547,7 +547,7 @@ def convert_monitors_ws(ws, converter, **ignored):
             del single_monitor.coords['detector_info']
         del single_monitor.attrs['sample']
         name = comp_info.name(det_index)
-        if det_index != comp_info.indexOfAny(name):
+        if not comp_info.uniqueName(name):
             name = f'{name}_{number}'
         monitors.append((name, single_monitor))
     return monitors

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -546,7 +546,10 @@ def convert_monitors_ws(ws, converter, **ignored):
         if 'detector_info' in single_monitor.coords:
             del single_monitor.coords['detector_info']
         del single_monitor.attrs['sample']
-        monitors.append((comp_info.name(det_index), single_monitor))
+        name = comp_info.name(det_index)
+        if det_index != comp_info.indexOfAny(name):
+            name = f'{name}_{det_index}'
+        monitors.append((name, single_monitor))
     return monitors
 
 

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -526,9 +526,9 @@ def convert_monitors_ws(ws, converter, **ignored):
     spec_info = spec_info = ws.spectrumInfo()
     comp_info = ws.componentInfo()
     monitors = []
-    indexes = (ws.getIndexFromSpectrumNumber(int(i))
-               for i in spec_coord.values)
-    for index in indexes:
+    spec_indices = ((ws.getIndexFromSpectrumNumber(int(i)), i)
+                    for i in spec_coord.values)
+    for index, number in spec_indices:
         definition = spec_info.getSpectrumDefinition(index)
         if not definition.size() == 1:
             raise RuntimeError("Cannot deal with grouped monitor detectors")
@@ -548,7 +548,7 @@ def convert_monitors_ws(ws, converter, **ignored):
         del single_monitor.attrs['sample']
         name = comp_info.name(det_index)
         if det_index != comp_info.indexOfAny(name):
-            name = f'{name}_{det_index}'
+            name = f'{name}_{number}'
         monitors.append((name, single_monitor))
     return monitors
 

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -929,5 +929,18 @@ def test_EventWorkspace_with_pulse_times():
                   [0].to_datetime64()))
 
 
+@pytest.mark.skipif(not mantid_is_available(),
+                    reason='Mantid framework is unavailable')
+def test_duplicate_monitor_names():
+    from mantid.simpleapi import LoadEmptyInstrument
+    ws = LoadEmptyInstrument(
+        InstrumentName='POLARIS',
+        StoreInADS=False)  # Has many monitors named 'monitor'
+    da = scn.mantid.from_mantid(ws)
+    assert da.attrs['monitor_0'].value.attrs['spectrum'].value == 1
+    assert da.attrs['monitor_12'].value.attrs['spectrum'].value == 13
+    assert da.attrs['monitor'].value.attrs['spectrum'].value == 14
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -937,8 +937,8 @@ def test_duplicate_monitor_names():
         InstrumentName='POLARIS',
         StoreInADS=False)  # Has many monitors named 'monitor'
     da = scn.mantid.from_mantid(ws)
-    assert da.attrs['monitor_0'].value.attrs['spectrum'].value == 1
-    assert da.attrs['monitor_12'].value.attrs['spectrum'].value == 13
+    assert da.attrs['monitor_1'].value.attrs['spectrum'].value == 1
+    assert da.attrs['monitor_13'].value.attrs['spectrum'].value == 13
     assert da.attrs['monitor'].value.attrs['spectrum'].value == 14
 
 

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -939,7 +939,7 @@ def test_duplicate_monitor_names():
     da = scn.mantid.from_mantid(ws)
     assert da.attrs['monitor_1'].value.attrs['spectrum'].value == 1
     assert da.attrs['monitor_13'].value.attrs['spectrum'].value == 13
-    assert da.attrs['monitor'].value.attrs['spectrum'].value == 14
+    assert da.attrs['monitor_14'].value.attrs['spectrum'].value == 14
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #48 

Solution uses `uniqueName` added to Mantid's ComponentInfo, and therefore needs packages produced from [1.0.3](https://github.com/scipp/mantid_framework_conda_recipe/tree/1.0.3) of the mantid-framework recipe, which has been used to create a new `mantid-framework` version `6.0.20210412.0948` for all platforms. Following this, developers will need to regenerate their `scippneutron-developer` environments to collect the updated mantid-framework package.

Solution uses https://github.com/mantidproject/mantid/pull/31097