### PR TITLE
Get live data dependencies from conda

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -42,7 +42,7 @@ stages:
               conda config --set always_yes yes --set changeps1 no
             displayName: 'Conda configuration'
           - bash: |
-              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp/label/dev --label dev --python="$PYTHON_VERSION" ./conda
+              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp/label/dev --channel ess-dmsc --label dev --python="$PYTHON_VERSION" ./conda
             env:
               ANACONDA_TOKEN: $(anaconda_token_secret)
             displayName: 'Package build'
@@ -78,7 +78,7 @@ stages:
               conda config --set always_yes yes --set changeps1 no
             displayName: 'Conda configuration'
           - bash: |
-              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp/label/dev --label dev ./conda
+              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp/label/dev --channel ess-dmsc --label dev ./conda
             env:
               ANACONDA_TOKEN: $(anaconda_token_secret)
             displayName: 'Package build'

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -37,7 +37,7 @@ stages:
               conda config --set always_yes yes --set changeps1 no
             displayName: 'Conda configuration'
           - bash: |
-              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp --python="$PYTHON_VERSION" ./conda
+              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp --channel ess-dmsc --python="$PYTHON_VERSION" ./conda
             env:
               ANACONDA_TOKEN: $(anaconda_token_secret)
             displayName: 'Package build'
@@ -73,7 +73,7 @@ stages:
               conda config --set always_yes yes --set changeps1 no
             displayName: 'Conda configuration'
           - bash: |
-              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp ./conda
+              conda build --user scipp --token "$ANACONDA_TOKEN" --channel conda-forge --channel scipp --channel ess-dmsc ./conda
             env:
               ANACONDA_TOKEN: $(anaconda_token_secret)
             displayName: 'Package build'

--- a/.azure-pipelines/templates/test_can_install_and_import.yml
+++ b/.azure-pipelines/templates/test_can_install_and_import.yml
@@ -36,7 +36,7 @@ jobs:
           set -ex
           conda create -c conda-forge -n test python=3.7
           source activate test
-          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev scippneutron
+          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev -c ess-dmsc scippneutron
         displayName: 'Install Conda package'
       - bash: |
           set -ex
@@ -85,7 +85,7 @@ jobs:
           set -ex
           conda create -c conda-forge -n test python=3.7
           source activate test
-          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev scippneutron
+          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev -c ess-dmsc scippneutron
         displayName: 'Install Conda package'
       - bash: |
           set -ex

--- a/.azure-pipelines/templates/test_can_install_and_import.yml
+++ b/.azure-pipelines/templates/test_can_install_and_import.yml
@@ -36,7 +36,7 @@ jobs:
           set -ex
           conda create -c conda-forge -n test python=3.7
           source activate test
-          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev -c ess-dmsc scippneutron
+          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev scippneutron
         displayName: 'Install Conda package'
       - bash: |
           set -ex
@@ -85,7 +85,7 @@ jobs:
           set -ex
           conda create -c conda-forge -n test python=3.7
           source activate test
-          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev -c ess-dmsc scippneutron
+          conda install -c "$(packages_dir)" -c conda-forge -c scipp/label/dev scippneutron
         displayName: 'Install Conda package'
       - bash: |
           set -ex

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,9 +34,8 @@ test:
     - pythreejs
     - Pillow
     - mantid-framework [not win]
-    - pip:
-        - confluent-kafka
-        - ess-streaming-data-types
+    - python-confluent-kafka [not win]
+    - ess-streaming-data-types [not win]
   source_files:
     - python/tests/
     - neutron/

--- a/docs/environments/scippneutron-latest.yml
+++ b/docs/environments/scippneutron-latest.yml
@@ -3,7 +3,6 @@ name: scippneutron
 channels:
   - conda-forge
   - scipp/label/dev
-  - ess-dmsc
 
 dependencies:
   - h5py
@@ -19,4 +18,4 @@ dependencies:
   - pythreejs
   - scippneutron
   - python-confluent-kafka
-  - ess-streaming-data-types
+  - ess-dmsc::ess-streaming-data-types

--- a/docs/environments/scippneutron-latest.yml
+++ b/docs/environments/scippneutron-latest.yml
@@ -3,6 +3,7 @@ name: scippneutron
 channels:
   - conda-forge
   - scipp/label/dev
+  - ess-dmsc
 
 dependencies:
   - h5py
@@ -17,6 +18,5 @@ dependencies:
   - nodejs
   - pythreejs
   - scippneutron
-  - pip:
-      - confluent-kafka
-      - ess-streaming-data-types
+  - python-confluent-kafka
+  - ess-streaming-data-types

--- a/docs/environments/scippneutron.yml
+++ b/docs/environments/scippneutron.yml
@@ -3,6 +3,7 @@ name: scippneutron
 channels:
   - conda-forge
   - scipp
+  - ess-dmsc
 
 dependencies:
   - h5py
@@ -17,6 +18,5 @@ dependencies:
   - nodejs
   - pythreejs
   - scippneutron
-  - pip:
-      - confluent-kafka
-      - ess-streaming-data-types
+  - python-confluent-kafka
+  - ess-streaming-data-types

--- a/docs/environments/scippneutron.yml
+++ b/docs/environments/scippneutron.yml
@@ -3,7 +3,6 @@ name: scippneutron
 channels:
   - conda-forge
   - scipp
-  - ess-dmsc
 
 dependencies:
   - h5py
@@ -19,4 +18,4 @@ dependencies:
   - pythreejs
   - scippneutron
   - python-confluent-kafka
-  - ess-streaming-data-types
+  - ess-dmsc::ess-streaming-data-types

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -49,13 +49,13 @@ To create a new conda environment with scippneutron:
 
 .. code-block:: sh
 
-   $ conda create -n env_with_scipp -c conda-forge -c scipp scippneutron
+   $ conda create -n env_with_scipp -c conda-forge -c scipp -c ess-dmsc scippneutron
 
 For a more up-to-date version, the `scipp/label/dev` channel can be used instead:
 
 .. code-block:: sh
 
-   $ conda install -c conda-forge -c scipp/label/dev scippneutron
+   $ conda install -c conda-forge -c scipp/label/dev -c ess-dmsc scippneutron
 
 .. note::
    Instaling ``scippneutron`` on Windows requires ``Microsoft Visual Studio 2019 C++ Runtime`` installed.
@@ -64,7 +64,7 @@ For a more up-to-date version, the `scipp/label/dev` channel can be used instead
 After installation the modules ``scipp`` and ``scippneutron`` can be imported in Python.
 Note that only the bare essential dependencies are installed.
 If you wish to use plotting functionality you will also need to install ``matplotlib`` and ``ipywidgets``.
-If you wish to use the live data functionality you will need to install ``confluent-kafka`` and ``ess-streaming-data-types`` from the PyPi:
+If you wish to use the live data functionality you will need to install ``conda-forge::python-confluent-kafka`` and ``ess-dmsc::ess-streaming-data-types`` with conda, or on Windows install ``confluent-kafka`` and ``ess-streaming-data-types`` from the PyPI:
 
 .. code-block:: sh
 

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -1,44 +1,27 @@
-from ._streaming_consumer import (create_consumers, start_consumers)
-from ._streaming_data_buffer import StreamedDataBuffer
 import time
 from typing import List, Generator, Callable
-from ._streaming_consumer import KafkaConsumer
 import asyncio
 import scipp as sc
+"""
+Some type names are included as strings as imports are done in
+function scope to avoid optional dependencies being imported
+by the top level __init__.py
+"""
 
 
-def _consumers_all_stopped(consumers: List[KafkaConsumer]):
+def _consumers_all_stopped(consumers: List["KafkaConsumer"]):  # noqa: F821
     for consumer in consumers:
         if not consumer.stopped:
             return False
     return True
 
 
-async def _data_stream(
-        buffer: StreamedDataBuffer, queue: asyncio.Queue,
-        consumers: List[KafkaConsumer],
-        interval: sc.Variable) -> Generator[sc.Variable, None, None]:
-    """
-    Main implementation of data stream is extracted to this function so that
-    fake consumers can be injected for unit tests
-    """
-    start_consumers(consumers)
-    buffer.start()
-    interval_s = sc.to_unit(interval, 's').value
-
-    # If we wait twice the expected interval and have not got
-    # any new data in the queue then check if it is because all
-    # the consumers have stopped, if so, we are done. Otherwise
-    # it could just be that we have not received any new data.
-    while not _consumers_all_stopped(consumers):
-        try:
-            new_data = await asyncio.wait_for(queue.get(),
-                                              timeout=2 * interval_s)
-            yield new_data
-        except asyncio.TimeoutError:
-            pass
-
-    buffer.stop()
+_missing_dependency_message = (
+    "Confluent Kafka Python library and/or serialisation library"
+    "not found, please install confluent-kafka and "
+    "ess-streaming-data-types as detailed in the "
+    "installation instructions (https://scipp.github.io/"
+    "scippneutron/getting-started/installation.html)")
 
 
 async def data_stream(
@@ -58,6 +41,12 @@ async def data_stream(
     :param interval: interval between yielding any new data
       collected from stream
     """
+    try:
+        from ._streaming_consumer import create_consumers
+        from ._streaming_data_buffer import StreamedDataBuffer
+    except ImportError:
+        raise ImportError(_missing_dependency_message)
+
     queue = asyncio.Queue()
     buffer = StreamedDataBuffer(queue, buffer_size, interval)
     config = {
@@ -77,6 +66,39 @@ async def data_stream(
     # https://www.python.org/dev/peps/pep-0525/#asynchronous-yield-from
     async for v in _data_stream(buffer, queue, consumers, interval):
         yield v
+
+
+async def _data_stream(
+        buffer: "StreamedDataBuffer",  # noqa: F821
+        queue: asyncio.Queue,
+        consumers: List["KafkaConsumer"],  # noqa: F821
+        interval: sc.Variable) -> Generator[sc.Variable, None, None]:
+    """
+    Main implementation of data stream is extracted to this function so that
+    fake consumers can be injected for unit tests
+    """
+    try:
+        from ._streaming_consumer import start_consumers
+    except ImportError:
+        raise ImportError(_missing_dependency_message)
+
+    start_consumers(consumers)
+    buffer.start()
+    interval_s = sc.to_unit(interval, 's').value
+
+    # If we wait twice the expected interval and have not got
+    # any new data in the queue then check if it is because all
+    # the consumers have stopped, if so, we are done. Otherwise
+    # it could just be that we have not received any new data.
+    while not _consumers_all_stopped(consumers):
+        try:
+            new_data = await asyncio.wait_for(queue.get(),
+                                              timeout=2 * interval_s)
+            yield new_data
+        except asyncio.TimeoutError:
+            pass
+
+    buffer.stop()
 
 
 def start_stream(user_function: Callable) -> asyncio.Task:

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -19,8 +19,9 @@ def run_mantid_alg(alg, *args, **kwargs):
     except ImportError:
         raise ImportError(
             "Mantid Python API was not found, please install Mantid framework "
-            "as detailed in the installation instructions (https://scipp."
-            "github.io/getting-started/installation.html)")
+            "as detailed in the installation instructions ("
+            "https://scipp.github.io/scippneutron/getting-started/"
+            "installation.html)")
     # Deal with multiple calls to this function, which may have conflicting
     # names in the global AnalysisDataService by using uuid.
     ws_name = f'scipp.run_mantid_alg.{uuid.uuid4()}'

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -14,12 +14,7 @@ def kafka_and_deserialisation_are_available():
         return False
 
 
-"""
-NB, we have to use this magic variable to skip if the dependencies
-are not available because, due to the way the asyncio
-pytest plugin injects the asyncio event loop, we cannot use
-a test class that inherits from unittest.TestCase
-"""
+# Skip entire test module if the dependencies are not available
 pytestmark = pytest.mark.skipif(
     not kafka_and_deserialisation_are_available(),
     reason='Kafka or Serialisation module is unavailable')

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -4,25 +4,16 @@ import asyncio
 from typing import List
 import numpy as np
 
-
-def kafka_and_deserialisation_are_available():
-    try:
-        import streaming_data_types  # noqa: F401
-        import confluent_kafka  # noqa: F401
-        return True
-    except ImportError:
-        return False
-
-
-# Skip entire test module if the dependencies are not available
-pytestmark = pytest.mark.skipif(
-    not kafka_and_deserialisation_are_available(),
-    reason='Kafka or Serialisation module is unavailable')
-
-from scippneutron.data_stream import _data_stream  # noqa: E402
-from scippneutron._streaming_data_buffer import \
-    StreamedDataBuffer  # noqa: E402
-from streaming_data_types import serialise_ev42  # noqa: E402
+try:
+    import streaming_data_types  # noqa: F401
+    import confluent_kafka  # noqa: F401
+    from scippneutron.data_stream import _data_stream  # noqa: E402
+    from scippneutron._streaming_data_buffer import \
+        StreamedDataBuffer  # noqa: E402
+    from streaming_data_types import serialise_ev42  # noqa: E402
+except ImportError:
+    pytest.skip("Kafka or Serialisation module is unavailable",
+                allow_module_level=True)
 
 
 class FakeConsumer:

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -1,11 +1,23 @@
-from scippneutron.data_stream import _data_stream
-from scippneutron._streaming_data_buffer import StreamedDataBuffer
 import scipp as sc
 import asyncio
 import pytest
 from typing import List
-from streaming_data_types import serialise_ev42
 import numpy as np
+"""
+NB, we have to use @pytest.mark.skipif and include the imports
+in each separate test case because, due to the way the asyncio
+pytest plugin injects the asyncio event loop, we cannot use
+a test class that inherits from unittest.TestCase
+"""
+
+
+def kafka_and_deserialisation_are_available():
+    try:
+        import streaming_data_types  # noqa: F401
+        import confluent_kafka  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
 
 class FakeConsumer:
@@ -37,8 +49,15 @@ SHORT_TEST_INTERVAL = 1. * sc.Unit('milliseconds')
 TEST_BUFFER_SIZE = 20
 
 
+@pytest.mark.skipif(not kafka_and_deserialisation_are_available(),
+                    reason='Kafka or Serialisation module is unavailable')
 @pytest.mark.asyncio
 async def test_data_stream_returns_data_from_single_event_message():
+    from scippneutron.data_stream import _data_stream  # noqa: F401
+    from scippneutron._streaming_data_buffer import \
+        StreamedDataBuffer  # noqa: F401
+    from streaming_data_types import serialise_ev42  # noqa: F401
+
     queue = asyncio.Queue()
     buffer = StreamedDataBuffer(queue, TEST_BUFFER_SIZE, SHORT_TEST_INTERVAL)
     consumers = [FakeConsumer()]
@@ -59,8 +78,15 @@ async def test_data_stream_returns_data_from_single_event_message():
         stop_consumers(consumers)
 
 
+@pytest.mark.skipif(not kafka_and_deserialisation_are_available(),
+                    reason='Kafka or Serialisation module is unavailable')
 @pytest.mark.asyncio
 async def test_data_stream_returns_data_from_multiple_event_messages():
+    from scippneutron.data_stream import _data_stream  # noqa: F401
+    from scippneutron._streaming_data_buffer import \
+        StreamedDataBuffer  # noqa: F401
+    from streaming_data_types import serialise_ev42  # noqa: F401
+
     queue = asyncio.Queue()
     buffer = StreamedDataBuffer(queue, TEST_BUFFER_SIZE, SHORT_TEST_INTERVAL)
     consumers = [FakeConsumer()]
@@ -89,8 +115,13 @@ async def test_data_stream_returns_data_from_multiple_event_messages():
         stop_consumers(consumers)
 
 
+@pytest.mark.skipif(not kafka_and_deserialisation_are_available(),
+                    reason='Kafka or Serialisation module is unavailable')
 @pytest.mark.asyncio
 async def test_warn_on_data_emit_if_unrecognised_message_was_encountered():
+    from scippneutron._streaming_data_buffer import \
+        StreamedDataBuffer  # noqa: F401
+
     queue = asyncio.Queue()
     buffer = StreamedDataBuffer(queue, TEST_BUFFER_SIZE, SHORT_TEST_INTERVAL)
     # First 4 bytes of the message payload are the FlatBuffer schema identifier
@@ -103,8 +134,14 @@ async def test_warn_on_data_emit_if_unrecognised_message_was_encountered():
         await buffer._emit_data()
 
 
+@pytest.mark.skipif(not kafka_and_deserialisation_are_available(),
+                    reason='Kafka or Serialisation module is unavailable')
 @pytest.mark.asyncio
 async def test_warn_on_buffer_size_exceeded_by_single_message():
+    from scippneutron._streaming_data_buffer import \
+        StreamedDataBuffer  # noqa: F401
+    from streaming_data_types import serialise_ev42  # noqa: F401
+
     queue = asyncio.Queue()
     buffer_size_2_events = 2
     buffer = StreamedDataBuffer(queue,
@@ -121,8 +158,14 @@ async def test_warn_on_buffer_size_exceeded_by_single_message():
         await buffer.new_data(test_message)
 
 
+@pytest.mark.skipif(not kafka_and_deserialisation_are_available(),
+                    reason='Kafka or Serialisation module is unavailable')
 @pytest.mark.asyncio
 async def test_buffer_size_exceeded_by_messages_causes_early_data_emit():
+    from scippneutron._streaming_data_buffer import \
+        StreamedDataBuffer  # noqa: F401
+    from streaming_data_types import serialise_ev42  # noqa: F401
+
     queue = asyncio.Queue()
     buffer_size_5_events = 5
     buffer = StreamedDataBuffer(queue,

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -29,9 +29,8 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
-  - pip:
-      - confluent-kafka
-      - ess-streaming-data-types
+  - python-confluent-kafka
+  - ess-dmsc::ess-streaming-data-types
 
   # Test
   - psutil

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -1,6 +1,8 @@
 # This is used for incremental CI builds and local development.
 # All dependencies should be installed here (i.e. the union of build, run, test and documentation build dependencies).
-# This file is identical to scipp-developer.yml but does not include Mantid (for platforms Mantid has yet to be packaged for).
+# This file is identical to scipp-developer.yml but does not include Mantid or Kafka+Serialisation libraries
+# (for platforms these have yet to be packaged for)
+# or
 # See https://scipp.github.io/developer/dependencies.html
 
 name: scippneutron-developer
@@ -29,8 +31,6 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
-  - python-confluent-kafka
-  - ess-dmsc::ess-streaming-data-types
 
   # Test
   - psutil

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -29,9 +29,8 @@ dependencies:
   - tbb
   - traitlets=4.3.3 # see https://github.com/jupyter-widgets/pythreejs/issues/334
   - h5py
-  - pip:
-      - confluent-kafka
-      - ess-streaming-data-types
+  - python-confluent-kafka
+  - ess-dmsc::ess-streaming-data-types
 
   # Test
   - psutil


### PR DESCRIPTION
Will need to be updated after #52 is merged (change required in  `scippneutron-developer-release.yml`)

The ESS serialisation lib is now on conda. The Kafka library is also on conda but not for Windows, so I've handled this dependency in the same way as we do for Mantid.

Perhaps it would be better to use the `ess-dmsc::ess-streaming-data-types` syntax rather than adding the extra channel everywhere for a single dependency?