### PR TITLE
Load pixel positions without events

### DIFF
--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -333,7 +333,9 @@ def _create_empty_event_data(event_data: List[DetectorData]):
             detector_id_dtype = data.detector_ids.dtype
     if empty_events is None:
         if detector_id_dtype is None:
-            # Create empty data array with types matching streamed event data
+            # Create empty data array with types/unit matching streamed event
+            # data, this avoids need to convert to concatenate with event data
+            # arriving from stream
             empty_events = _create_events_data_array(np.int64, "ns", np.int32)
         else:
             # If detector_ids were loaded then match the type used for those

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -128,24 +128,24 @@ class DetectorData:
     pixel_positions: Optional[sc.Variable] = None
 
 
-def _create_events_data_array(
+def _create_empty_events_data_array(
         tof_dtype: Any = np.int64,
         tof_unit: Union[str, sc.Unit] = "ns",
         detector_id_dtype: Any = np.int32) -> sc.DataArray:
-    return sc.DataArray(data=sc.Variable(dims=[_event_dimension],
-                                         values=[],
-                                         variances=[],
-                                         dtype=np.float32),
+    return sc.DataArray(data=sc.empty(dims=[_event_dimension],
+                                      shape=[0],
+                                      variances=True,
+                                      dtype=np.float32),
                         coords={
                             _time_of_flight:
-                            sc.Variable(dims=[_event_dimension],
-                                        values=[],
-                                        dtype=tof_dtype,
-                                        unit=tof_unit),
+                            sc.empty(dims=[_event_dimension],
+                                     shape=[0],
+                                     dtype=tof_dtype,
+                                     unit=tof_unit),
                             _detector_dimension:
-                            sc.Variable(dims=[_event_dimension],
-                                        values=[],
-                                        dtype=detector_id_dtype)
+                            sc.empty(dims=[_event_dimension],
+                                     shape=[0],
+                                     dtype=detector_id_dtype)
                         })
 
 
@@ -327,7 +327,7 @@ def _create_empty_event_data(event_data: List[DetectorData]):
             # array with the same data types
             tof_dtype = data.events.coords[_time_of_flight].dtype
             tof_unit = data.events.coords[_time_of_flight].unit
-            empty_events = _create_events_data_array(
+            empty_events = _create_empty_events_data_array(
                 tof_dtype, tof_unit,
                 data.events.coords[_detector_dimension].dtype)
             break
@@ -338,11 +338,12 @@ def _create_empty_event_data(event_data: List[DetectorData]):
             # Create empty data array with types/unit matching streamed event
             # data, this avoids need to convert to concatenate with event data
             # arriving from stream
-            empty_events = _create_events_data_array(np.int64, "ns", np.int32)
+            empty_events = _create_empty_events_data_array(
+                np.int64, "ns", np.int32)
         else:
             # If detector_ids were loaded then match the type used for those
-            empty_events = _create_events_data_array(np.int64, "ns",
-                                                     detector_id_dtype)
+            empty_events = _create_empty_events_data_array(
+                np.int64, "ns", detector_id_dtype)
     for data in event_data:
         if data.events is None:
             data.events = empty_events

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -351,8 +351,11 @@ def _load_data_from_each_nx_event_data(detector_data: Dict,
         try:
             new_event_data = _load_event_group(
                 group, file_root, nexus,
-                detector_data.pop(parent_path, DetectorData()), quiet)
+                detector_data.get(parent_path, DetectorData()), quiet)
             event_data.append(new_event_data)
+            # Only pop from dictionary if we did not raise an
+            # exception when loading events
+            detector_data.pop(parent_path, DetectorData())
         except BadSource as e:
             warn(f"Skipped loading {group.path} due to:\n{e}")
     for _, remaining_data in detector_data.items():

--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -134,6 +134,7 @@ def _create_events_data_array(
         detector_id_dtype: Any = np.int32) -> sc.DataArray:
     return sc.DataArray(data=sc.Variable(dims=[_event_dimension],
                                          values=[],
+                                         variances=[],
                                          dtype=np.float32),
                         coords={
                             _time_of_flight:
@@ -205,7 +206,8 @@ def _load_event_group(group: Group, file_root: h5py.File, nexus: LoadFromNexus,
     # Weights are not stored in NeXus, so use 1s
     weights = sc.ones(dims=[_event_dimension],
                       shape=event_id.shape,
-                      dtype=np.float32)
+                      dtype=np.float32,
+                      variances=True)
 
     if detector_data.detector_ids is None:
         # If detector ids were not found in an associated detector group

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -25,6 +25,7 @@ nx_entry = "NXentry"
 nx_instrument = "NXinstrument"
 nx_sample = "NXsample"
 nx_source = "NXsource"
+nx_detector = "NXdetector"
 
 
 @contextmanager
@@ -117,8 +118,8 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
     else:
         root_node = nexus_file
     groups = nexus.find_by_nx_class(
-        (nx_event_data, nx_log, nx_entry, nx_instrument, nx_sample, nx_source),
-        root_node)
+        (nx_event_data, nx_log, nx_entry, nx_instrument, nx_sample, nx_source,
+         nx_detector), root_node)
     if len(groups[nx_entry]) > 1:
         # We can't sensibly load from multiple NXentry, for example each
         # could could contain a description of the same detector bank
@@ -127,7 +128,8 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
             f"More than one {nx_entry} group in file, use 'root' argument "
             "to specify which to load data from, for example"
             f"{__name__}('my_file.nxs', '/entry_2')")
-    loaded_data = load_detector_data(groups[nx_event_data], nexus_file, nexus,
+    loaded_data = load_detector_data(groups[nx_event_data],
+                                     groups[nx_detector], nexus_file, nexus,
                                      quiet)
     if loaded_data is None:
         no_event_data = True

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -34,7 +34,7 @@ def in_memory_hdf5_file_with_two_nxentry() -> Iterator[h5py.File]:
 @dataclass
 class EventData:
     event_id: np.ndarray
-    event_time_offset: np.ndarray
+    event_time_offset: Optional[np.ndarray]
     event_time_zero: np.ndarray
     event_index: np.ndarray
 
@@ -534,9 +534,10 @@ class NexusBuilder:
         event_group = self._create_nx_class(group_name, "NXevent_data",
                                             parent_group)
         self._writer.add_dataset(event_group, "event_id", data=data.event_id)
-        event_time_offset_ds = self._writer.add_dataset(
-            event_group, "event_time_offset", data=data.event_time_offset)
-        self._writer.add_attribute(event_time_offset_ds, "units", "ns")
+        if data.event_time_offset is not None:
+            event_time_offset_ds = self._writer.add_dataset(
+                event_group, "event_time_offset", data=data.event_time_offset)
+            self._writer.add_attribute(event_time_offset_ds, "units", "ns")
         event_time_zero_ds = self._writer.add_dataset(
             event_group, "event_time_zero", data=data.event_time_zero)
         self._writer.add_attribute(event_time_zero_ds, "units", "ns")

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -67,7 +67,7 @@ class Transformation:
 
 @dataclass
 class Detector:
-    detector_numbers: np.ndarray
+    detector_numbers: Optional[np.ndarray] = None
     event_data: Optional[EventData] = None
     log: Optional[Log] = None
     x_offsets: Optional[np.ndarray] = None
@@ -620,8 +620,9 @@ class NexusBuilder:
                                     group_name: str) -> h5py.Group:
         detector_group = self._create_nx_class(group_name, "NXdetector",
                                                parent_group)
-        self._writer.add_dataset(detector_group, "detector_number",
-                                 detector.detector_numbers)
+        if detector.detector_numbers is not None:
+            self._writer.add_dataset(detector_group, "detector_number",
+                                     detector.detector_numbers)
         for dataset_name, array in (("x_pixel_offset", detector.x_offsets),
                                     ("y_pixel_offset", detector.y_offsets),
                                     ("z_pixel_offset", detector.z_offsets)):

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -363,8 +363,7 @@ def test_loads_data_from_multiple_logs_with_same_name(load_function: Callable):
     # both have the same group name
     builder = NexusBuilder()
     builder.add_log(Log(name, values_1))
-    builder.add_detector(Detector(np.array([1, 2, 3]), log=Log(name,
-                                                               values_2)))
+    builder.add_detector(Detector(log=Log(name, values_2)))
 
     loaded_data = load_function(builder)
 

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -522,6 +522,50 @@ def test_loads_pixel_positions_with_event_data(load_function: Callable):
                                         "to be converted to metres"
 
 
+def test_loads_pixel_positions_without_event_data(load_function: Callable):
+    """
+    This is important in the live-data feature as geometry and event data
+    are streamed separately
+    """
+    detector_1_ids = np.array([0, 1, 2, 3])
+    x_pixel_offset_1 = np.array([0.1, 0.2, 0.1, 0.2])
+    y_pixel_offset_1 = np.array([0.1, 0.1, 0.2, 0.2])
+    z_pixel_offset_1 = np.array([0.1, 0.2, 0.3, 0.4])
+
+    detector_2_ids = np.array([[4, 5], [6, 7]])
+    x_pixel_offset_2 = np.array([[1.1, 1.2], [1.1, 1.2]])
+    y_pixel_offset_2 = np.array([[0.1, 0.1], [0.2, 0.2]])
+
+    builder = NexusBuilder()
+    offsets_units = "mm"
+    builder.add_detector(
+        Detector(detector_numbers=detector_1_ids,
+                 x_offsets=x_pixel_offset_1,
+                 y_offsets=y_pixel_offset_1,
+                 z_offsets=z_pixel_offset_1,
+                 offsets_unit=offsets_units))
+    builder.add_detector(
+        Detector(detector_numbers=detector_2_ids,
+                 x_offsets=x_pixel_offset_2,
+                 y_offsets=y_pixel_offset_2,
+                 offsets_unit=offsets_units))
+
+    loaded_data = load_function(builder)
+
+    # If z offsets are missing they should be zero
+    z_pixel_offset_2 = np.array([[0., 0.], [0., 0.]])
+    expected_pixel_positions = np.array([
+        np.concatenate((x_pixel_offset_1, x_pixel_offset_2.flatten())),
+        np.concatenate((y_pixel_offset_1, y_pixel_offset_2.flatten())),
+        np.concatenate((z_pixel_offset_1, z_pixel_offset_2.flatten()))
+    ]).T / 1_000  # Divide by 1000 for mm to metres
+    assert np.allclose(loaded_data.coords['position'].values,
+                       expected_pixel_positions)
+    assert loaded_data.coords[
+               'position'].unit == sc.units.m, "Expected positions " \
+                                               "to be converted to metres"
+
+
 def test_skips_loading_pixel_positions_with_non_matching_shape(
         load_function: Callable):
     pulse_times = np.array([

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -618,6 +618,71 @@ def test_loads_pixel_positions_when_event_data_is_missing_field(
                                                "to be converted to metres"
 
 
+def test_loads_event_data_when_missing_from_some_detectors(
+        load_function: Callable):
+    pulse_times = np.array([
+        1600766730000000000, 1600766731000000000, 1600766732000000000,
+        1600766733000000000
+    ])
+    event_time_offsets = np.array([456, 743, 347, 345, 632])
+    event_data_missing_event_time_offsets = EventData(
+        event_id=np.array([1, 2, 3, 1, 3]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=pulse_times,
+        event_index=np.array([0, 3, 3, 5]),
+    )
+    detector_1_ids = np.array([0, 1, 2, 3])
+
+    x_pixel_offset_1 = np.array([0.1, 0.2, 0.1, 0.2])
+    y_pixel_offset_1 = np.array([0.1, 0.1, 0.2, 0.2])
+    z_pixel_offset_1 = np.array([0.1, 0.2, 0.3, 0.4])
+
+    detector_2_ids = np.array([[4, 5], [6, 7]])
+    x_pixel_offset_2 = np.array([[1.1, 1.2], [1.1, 1.2]])
+    y_pixel_offset_2 = np.array([[0.1, 0.1], [0.2, 0.2]])
+
+    # There is one detector with event data, detector ids
+    # and pixel offsets, and another detector with only
+    # detector ids and pixel offsets
+    builder = NexusBuilder()
+    offsets_units = "mm"
+    builder.add_detector(
+        Detector(detector_numbers=detector_1_ids,
+                 event_data=event_data_missing_event_time_offsets,
+                 x_offsets=x_pixel_offset_1,
+                 y_offsets=y_pixel_offset_1,
+                 z_offsets=z_pixel_offset_1,
+                 offsets_unit=offsets_units))
+    builder.add_detector(
+        Detector(detector_numbers=detector_2_ids,
+                 x_offsets=x_pixel_offset_2,
+                 y_offsets=y_pixel_offset_2,
+                 offsets_unit=offsets_units))
+
+    loaded_data = load_function(builder)
+
+    # If z offsets are missing they should be zero
+    z_pixel_offset_2 = np.array([[0., 0.], [0., 0.]])
+    expected_pixel_positions = np.array([
+        np.concatenate((x_pixel_offset_1, x_pixel_offset_2.flatten())),
+        np.concatenate((y_pixel_offset_1, y_pixel_offset_2.flatten())),
+        np.concatenate((z_pixel_offset_1, z_pixel_offset_2.flatten()))
+    ]).T / 1_000  # Divide by 1000 for mm to metres
+    assert np.allclose(loaded_data.coords['position'].values,
+                       expected_pixel_positions)
+    assert loaded_data.coords[
+               'position'].unit == sc.units.m, "Expected positions " \
+                                               "to be converted to metres"
+
+    # The event data from detector_1 has been loaded
+    counts_on_detectors = loaded_data.bins.sum()
+    expected_counts = np.array([0, 2, 1, 2, 0, 0, 0, 0])
+    assert np.allclose(counts_on_detectors.data.values, expected_counts)
+    assert np.allclose(
+        loaded_data.coords['detector_id'].values,
+        np.concatenate((detector_1_ids, detector_2_ids.flatten())))
+
+
 def test_skips_loading_pixel_positions_with_non_matching_shape(
         load_function: Callable):
     pulse_times = np.array([


### PR DESCRIPTION
Closes #61 

Added tests and changes so that detector ids and pixel positions are loaded even if there are no event data, or no valid event data, associated with them. This is important for data streaming where the "run start" message usually contains geometry information but no events.