### PR TITLE
Parse run start message in live data

### DIFF
--- a/python/src/scippneutron/_loading_detector_data.py
+++ b/python/src/scippneutron/_loading_detector_data.py
@@ -8,7 +8,6 @@ from typing import Optional, List, Any, Dict, Union
 import numpy as np
 from ._loading_common import (BadSource, MissingDataset, Group)
 import scipp as sc
-from datetime import datetime
 from warnings import warn
 from itertools import groupby
 from ._loading_transformations import get_full_transformation_matrix
@@ -40,16 +39,6 @@ def _check_for_missing_fields(group: GroupObject, nexus: LoadFromNexus) -> str:
         if not found:
             return msg
     return ""
-
-
-def _iso8601_to_datetime(iso8601: str) -> Optional[datetime]:
-    try:
-        return datetime.strptime(
-            iso8601.translate(str.maketrans('', '', ':-Z')),
-            "%Y%m%dT%H%M%S.%f")
-    except ValueError:
-        # Did not understand the format of the input string
-        return None
 
 
 def _convert_array_to_metres(array: np.ndarray, unit: str) -> np.ndarray:

--- a/python/src/scippneutron/_loading_json_nexus.py
+++ b/python/src/scippneutron/_loading_json_nexus.py
@@ -6,7 +6,6 @@ from typing import Tuple, Dict, List, Optional, Any, Union
 import scipp as sc
 import numpy as np
 from ._loading_common import Group, MissingDataset, MissingAttribute
-import dateutil.parser
 
 _nexus_class = "NX_class"
 _nexus_units = "units"
@@ -319,17 +318,3 @@ class LoadFromJson:
 def get_topics_from_streams(root: Dict) -> List[str]:
     found_streams = _find_by_type(_nexus_stream, root)
     return [stream["stream"]["topic"] for stream in found_streams]
-
-
-def get_start_time(root: Dict) -> Optional[sc.Variable]:
-    nexus = LoadFromJson(root)
-    entry_class = "NXentry"
-    entry_groups = nexus.find_by_nx_class((entry_class, ), root)[entry_class]
-    if len(entry_groups) < 1:
-        return
-    start_time_iso8601 = nexus.get_dataset_from_group(entry_groups[0].group,
-                                                      "start_time")
-    if start_time_iso8601 is None:
-        return
-    parsed_time = dateutil.parser.parse(start_time_iso8601[_nexus_values])
-    return int(parsed_time.timestamp() * 1000.0) * sc.Unit("milliseconds")

--- a/python/src/scippneutron/_loading_json_nexus.py
+++ b/python/src/scippneutron/_loading_json_nexus.py
@@ -6,6 +6,7 @@ from typing import Tuple, Dict, List, Optional, Any, Union
 import scipp as sc
 import numpy as np
 from ._loading_common import Group, MissingDataset, MissingAttribute
+import dateutil.parser
 
 _nexus_class = "NX_class"
 _nexus_units = "units"
@@ -318,3 +319,17 @@ class LoadFromJson:
 def get_topics_from_streams(root: Dict) -> List[str]:
     found_streams = _find_by_type(_nexus_stream, root)
     return [stream["stream"]["topic"] for stream in found_streams]
+
+
+def get_start_time(root: Dict) -> Optional[sc.Variable]:
+    nexus = LoadFromJson(root)
+    entry_class = "NXentry"
+    entry_groups = nexus.find_by_nx_class((entry_class, ), root)[entry_class]
+    if len(entry_groups) < 1:
+        return
+    start_time_iso8601 = nexus.get_dataset_from_group(entry_groups[0].group,
+                                                      "start_time")
+    if start_time_iso8601 is None:
+        return
+    parsed_time = dateutil.parser.parse(start_time_iso8601[_nexus_values])
+    return int(parsed_time.timestamp() * 1000.0) * sc.Unit("milliseconds")

--- a/python/src/scippneutron/_streaming_consumer.py
+++ b/python/src/scippneutron/_streaming_consumer.py
@@ -1,9 +1,26 @@
 from confluent_kafka import Consumer, TopicPartition, KafkaError
-from typing import Callable, List, Dict, Optional
+from typing import Callable, List, Dict, Optional, Tuple
 import asyncio
 from warnings import warn
 from streaming_data_types.run_start_pl72 import deserialise_pl72
 from streaming_data_types.exceptions import WrongSchemaException
+"""
+This module uses the confluent-kafka-python implementation of the
+Kafka Client API to communicate with Kafka servers (brokers)
+
+The Kafka documentation gives a useful brief introduction you may
+want to read:
+https://kafka.apache.org/documentation/#gettingStarted
+
+The following Kafka terminology is used extensively in the code:
+- A "topic" is a named data stream, messages are published to, or
+  consumed from, a topic.
+- A "partition" is a logfile of messages on the broker, each topic
+  comprises one or more partitions.
+- The "offset" is the index of the message in a partition on the
+  Kafka broker. Old messages are deleted from the partition, so the
+  first available message may not be at offset 0.
+"""
 
 
 class KafkaConsumer:
@@ -11,6 +28,10 @@ class KafkaConsumer:
                  callback: Callable, stop_at_end_of_partition: bool):
         conf['enable.partition.eof'] = stop_at_end_of_partition
         self._consumer = Consumer(conf)
+        # To consume messages the consumer must "subscribe" to one
+        # or more topics or "assign" specific topic partitions, the
+        # latter allows us to start consuming at an offset specified
+        # in the TopicPartition
         self._consumer.assign(topic_partitions)
         self._callback = callback
         self._stop_at_end_of_partition = stop_at_end_of_partition
@@ -47,6 +68,58 @@ class KafkaConsumer:
                 self._consume_data.cancel()
         self._consumer.close()
         self.stopped = True
+
+
+class KafkaQueryConsumer:
+    """
+    Wraps Kafka library consumer methods which query the
+    broker for metadata and poll for single messages.
+    It is a thin wrapper but allows a fake to be used
+    in unit tests.
+    """
+    def __init__(self, broker: str):
+        # Set "queued.min.messages" to 1 as we will consume backwards through
+        # the partition one message at a time; we do not want to retrieve
+        # multiple messages in the forward direction each time we step
+        # backwards by 1 offset
+        conf = {
+            "bootstrap.servers": broker,
+            "group.id": "consumer_group_name",
+            "auto.offset.reset": "latest",
+            "enable.auto.commit": False,
+            "queued.min.messages": 1
+        }
+        self._consumer = Consumer(**conf)
+
+    def get_topic_partitions(self, topic: str):
+        metadata = self._consumer.list_topics(topic)
+        return [
+            TopicPartition(topic, partition[1].id, offset=-1)
+            for partition in metadata.topics[topic].partitions.items()
+        ]
+
+    def seek(self, partition: TopicPartition):
+        """
+        Set offset in partition, the consumer will seek to that offset
+        """
+        self._consumer.seek(partition)
+
+    def poll(self, timeout=2.):
+        """
+        Poll for a message from Kafka
+        """
+        return self._consumer.poll(timeout=timeout)
+
+    def get_watermark_offsets(self,
+                              partition: TopicPartition) -> Tuple[int, int]:
+        """
+        Get the offset of the first and last available
+        message in the given partition
+        """
+        return self._consumer.get_watermark_offsets(partition, cached=False)
+
+    def assign(self, partitions: List[TopicPartition]):
+        self._consumer.assign(partitions)
 
 
 def create_consumers(
@@ -93,37 +166,21 @@ def stop_consumers(consumers: List[KafkaConsumer]):
         consumer.stop()
 
 
-def get_run_start_message(topic: str, broker: str):
+def get_run_start_message(topic: str, query_consumer: KafkaQueryConsumer):
     """
     Get the last run start message on the given topic
     """
-    # Set "queued.min.messages" to 1 as we will consume backwards through
-    # the partition one message at a time; we do not want to retrieve
-    # multiple messages in the forward direction each time we step
-    # backwards by 1 offset
-    conf = {
-        "bootstrap.servers": broker,
-        "group.id": "consumer_group_name",
-        "auto.offset.reset": "latest",
-        "enable.auto.commit": False,
-        "queued.min.messages": 1
-    }
-    consumer = Consumer(**conf)
-    metadata = consumer.list_topics(topic)
-    topic_partitions = [
-        TopicPartition(topic, partition[1].id, offset=-1)
-        for partition in metadata.topics[topic].partitions.items()
-    ]
+    topic_partitions = query_consumer.get_topic_partitions(topic)
     n_partitions = len(topic_partitions)
     if n_partitions != 1:
         raise RuntimeError(
             f"Expected run start topic to contain exactly one partition, "
             f"the specified topic '{topic}' has {n_partitions} partitions.")
     partition = topic_partitions[0]
-    low_watermark_offset, current_offset = consumer.get_watermark_offsets(
-        partition, cached=False)
+    low_watermark_offset, current_offset = \
+        query_consumer.get_watermark_offsets(partition)
     partition.offset = current_offset
-    consumer.assign([partition])
+    query_consumer.assign([partition])
 
     # Consume backwards from the end of the partition
     # until we find a run start message or reach the
@@ -131,13 +188,14 @@ def get_run_start_message(topic: str, broker: str):
     while current_offset > low_watermark_offset:
         current_offset -= 1
         partition.offset = current_offset
-        consumer.seek(partition)
-        message = consumer.poll(timeout=2.)
+        query_consumer.seek(partition)
+        message = query_consumer.poll(timeout=2.)
         if message is None:
             raise RuntimeError(
                 "Timed out when trying to retrieve run start message")
         elif message.error():
-            raise RuntimeError(f"Message error in consumer: {message.error()}")
+            raise RuntimeError(f"Error encountered consuming run start "
+                               f"message: {message.error()}")
         try:
             return deserialise_pl72(message.value())
         except WrongSchemaException:

--- a/python/src/scippneutron/_streaming_consumer.py
+++ b/python/src/scippneutron/_streaming_consumer.py
@@ -23,6 +23,10 @@ The following Kafka terminology is used extensively in the code:
 """
 
 
+class RunStartError(Exception):
+    pass
+
+
 class KafkaConsumer:
     def __init__(self, topic_partitions: List[TopicPartition], conf: Dict,
                  callback: Callable, stop_at_end_of_partition: bool):
@@ -191,15 +195,15 @@ def get_run_start_message(topic: str, query_consumer: KafkaQueryConsumer):
         query_consumer.seek(partition)
         message = query_consumer.poll(timeout=2.)
         if message is None:
-            raise RuntimeError(
+            raise RunStartError(
                 "Timed out when trying to retrieve run start message")
         elif message.error():
-            raise RuntimeError(f"Error encountered consuming run start "
-                               f"message: {message.error()}")
+            raise RunStartError(f"Error encountered consuming run start "
+                                f"message: {message.error()}")
         try:
             return deserialise_pl72(message.value())
         except WrongSchemaException:
             # Not a run start message, keep trying
             pass
 
-    raise RuntimeError(f"Run start message not found in topic '{topic}'")
+    raise RunStartError(f"Run start message not found in topic '{topic}'")

--- a/python/src/scippneutron/_streaming_consumer.py
+++ b/python/src/scippneutron/_streaming_consumer.py
@@ -159,6 +159,8 @@ def create_consumers(
         "group.id": "consumer_group_name",
         "auto.offset.reset": "latest",
         "enable.auto.commit": False,
+        "message.max.bytes": 100_000_000,
+        "fetch.message.max.bytes": 100_000_000,
     }
     consumers = []
     for topic_partition in topic_partitions:

--- a/python/src/scippneutron/_streaming_data_buffer.py
+++ b/python/src/scippneutron/_streaming_data_buffer.py
@@ -5,6 +5,18 @@ from streaming_data_types.eventdata_ev42 import deserialise_ev42
 from streaming_data_types.exceptions import WrongSchemaException
 from typing import Optional
 from warnings import warn
+"""
+The ESS data streaming system uses Google FlatBuffers to serialise
+data to transmit in the Kafka message payload. FlatBuffers uses schemas
+to define the data structure to serialise:
+https://github.com/ess-dmsc/streaming-data-types/
+The ess-streaming-data-types library provides convenience "serialise"
+and "deserialise" functions for each schema.
+Each schema is identified by a 4 character string which is included in:
+- the filename of the schema,
+- the serialised buffer as the first 4 bytes,
+- the module name in ess-streaming-data-types.
+"""
 
 
 class StreamedDataBuffer:

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -98,7 +98,12 @@ async def _data_stream(
     start_time = time.time() * sc.units.s
     if run_info_topic is not None:
         run_start_info = get_run_start_message(run_info_topic, query_consumer)
-        loaded_data, _, _ = _load_nexus_json(run_start_info.nexus_structure)
+        if topics is None:
+            loaded_data, _, topics = _load_nexus_json(
+                run_start_info.nexus_structure, get_start_info=True)
+        else:
+            loaded_data, _, _ = _load_nexus_json(
+                run_start_info.nexus_structure, get_start_info=False)
         yield loaded_data
 
     consumers = create_consumers(start_time,

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -28,7 +28,7 @@ _missing_dependency_message = (
 
 async def data_stream(
     kafka_broker: str,
-    topics: List[str],
+    topics: Optional[List[str]] = None,
     buffer_size: int = 1048576,
     interval: sc.Variable = 2. * sc.units.s,
     run_info_topic: Optional[str] = None
@@ -44,7 +44,8 @@ async def data_stream(
     :param interval: interval between yielding any new data
       collected from stream
     :param run_info_topic: If provided, the first data batch returned by
-    data_stream will be from the last available run start message in the topic
+      data_stream will be from the last available run start message in
+      the topic
     """
     try:
         from ._streaming_data_buffer import StreamedDataBuffer
@@ -65,7 +66,7 @@ async def _data_stream(
     buffer: "StreamedDataBuffer",  # noqa: F821
     queue: asyncio.Queue,
     kafka_broker: str,
-    topics: List[str],
+    topics: Optional[List[str]],
     interval: sc.Variable,
     run_info_topic: Optional[str] = None,
     query_consumer: Optional["KafkaQueryConsumer"] = None,  # noqa: F821
@@ -82,6 +83,10 @@ async def _data_stream(
                                           KafkaQueryConsumer, KafkaConsumer)
     except ImportError:
         raise ImportError(_missing_dependency_message)
+
+    if topics is None and run_info_topic is None:
+        raise ValueError("At least one of 'topics' and 'run_info_topic'"
+                         " must be specified")
 
     # These are defaulted to None in the function signature
     # to avoid them having to be imported

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -31,7 +31,7 @@ async def data_stream(
     buffer_size: int = 1048576,
     interval: sc.Variable = 2. * sc.units.s,
     run_info_topic: Optional[str] = None
-) -> Generator[sc.Variable, None, None]:
+) -> Generator[sc.DataArray, None, None]:
     """
     Periodically yields accumulated data from stream.
     If the buffer fills up more frequently than the set interval
@@ -68,10 +68,10 @@ async def data_stream(
 
     # Use "async for" as "yield from" cannot be used in an async function, see
     # https://www.python.org/dev/peps/pep-0525/#asynchronous-yield-from
-    async for v in _data_stream(buffer, queue, consumers,
-                                interval, run_info_topic,
-                                KafkaQueryConsumer(kafka_broker)):
-        yield v
+    async for data_chunk in _data_stream(buffer, queue, consumers, interval,
+                                         run_info_topic,
+                                         KafkaQueryConsumer(kafka_broker)):
+        yield data_chunk
 
 
 async def _data_stream(
@@ -81,7 +81,7 @@ async def _data_stream(
     interval: sc.Variable,
     run_info_topic: Optional[str] = None,
     query_consumer: Optional["KafkaQueryConsumer"] = None  # noqa: F821
-) -> Generator[sc.Variable, None, None]:
+) -> Generator[sc.DataArray, None, None]:
     """
     Main implementation of data stream is extracted to this function so that
     fake consumers can be injected for unit tests

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Generator, Callable, Optional, Any
+from typing import List, Generator, Callable, Optional
 import asyncio
 import scipp as sc
 from .load_nexus import _load_nexus_json
@@ -46,7 +46,7 @@ async def data_stream(
     data_stream will be from the last available run start message in the topic
     """
     try:
-        from ._streaming_consumer import create_consumers
+        from ._streaming_consumer import create_consumers, KafkaQueryConsumer
         from ._streaming_data_buffer import StreamedDataBuffer
     except ImportError:
         raise ImportError(_missing_dependency_message)
@@ -68,39 +68,33 @@ async def data_stream(
 
     # Use "async for" as "yield from" cannot be used in an async function, see
     # https://www.python.org/dev/peps/pep-0525/#asynchronous-yield-from
-    async for v in _data_stream(buffer, queue, consumers, interval,
-                                kafka_broker, run_info_topic):
+    async for v in _data_stream(buffer, queue, consumers,
+                                interval, run_info_topic,
+                                KafkaQueryConsumer(kafka_broker)):
         yield v
 
 
 async def _data_stream(
-        buffer: "StreamedDataBuffer",  # noqa: F821
-        queue: asyncio.Queue,
-        consumers: List["KafkaConsumer"],  # noqa: F821
-        interval: sc.Variable,
-        kafka_broker: str,
-        run_info_topic: Optional[str] = None,
-        get_run_start_message_func: Optional[Callable] = None,
-        consumer_type: Any = None) -> Generator[sc.Variable, None, None]:
+    buffer: "StreamedDataBuffer",  # noqa: F821
+    queue: asyncio.Queue,
+    consumers: List["KafkaConsumer"],  # noqa: F821
+    interval: sc.Variable,
+    run_info_topic: Optional[str] = None,
+    query_consumer: Optional["KafkaQueryConsumer"] = None  # noqa: F821
+) -> Generator[sc.Variable, None, None]:
     """
     Main implementation of data stream is extracted to this function so that
     fake consumers can be injected for unit tests
     """
     try:
-        from ._streaming_consumer import (start_consumers, KafkaConsumer,
+        from ._streaming_consumer import (start_consumers,
                                           get_run_start_message)
     except ImportError:
         raise ImportError(_missing_dependency_message)
 
     if run_info_topic is not None:
-        if get_run_start_message_func is None:
-            get_run_start_message_func = get_run_start_message
-        run_start_info = get_run_start_message_func(run_info_topic,
-                                                    kafka_broker)
+        run_start_info = get_run_start_message(run_info_topic, query_consumer)
         yield _load_nexus_json(run_start_info.nexus_structure)
-
-    if consumer_type is None:
-        consumer_type = KafkaConsumer
 
     start_consumers(consumers)
     buffer.start()

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -107,15 +107,15 @@ async def _data_stream(
     if run_info_topic is not None:
         run_start_info = get_run_start_message(run_info_topic, query_consumer)
         if topics is None:
-            loaded_data, run_start_time, topics = _load_nexus_json(
+            loaded_data, topics = _load_nexus_json(
                 run_start_info.nexus_structure, get_start_info=True)
         else:
-            loaded_data, run_start_time, _ = _load_nexus_json(
-                run_start_info.nexus_structure, get_start_info=False)
+            loaded_data, _ = _load_nexus_json(run_start_info.nexus_structure,
+                                              get_start_info=False)
         yield loaded_data
 
     if start_at == StartTime.start_of_run:
-        start_time = run_start_time
+        start_time = run_start_info.start_time * sc.Unit("milliseconds")
     else:
         start_time = time.time() * sc.units.s
 

--- a/python/src/scippneutron/data_stream.py
+++ b/python/src/scippneutron/data_stream.py
@@ -1,5 +1,6 @@
+import numpy as np
 import time
-from typing import List, Generator, Callable, Optional
+from typing import List, Generator, Callable, Optional, Type
 import asyncio
 import scipp as sc
 from .load_nexus import _load_nexus_json
@@ -46,68 +47,78 @@ async def data_stream(
     data_stream will be from the last available run start message in the topic
     """
     try:
-        from ._streaming_consumer import create_consumers, KafkaQueryConsumer
         from ._streaming_data_buffer import StreamedDataBuffer
     except ImportError:
         raise ImportError(_missing_dependency_message)
 
     queue = asyncio.Queue()
     buffer = StreamedDataBuffer(queue, buffer_size, interval)
-    config = {
-        "bootstrap.servers": kafka_broker,
-        "group.id": "consumer_group_name",
-        "auto.offset.reset": "latest",
-        "enable.auto.commit": False,
-    }
-    time_now_ms = int(time.time() * 1000)
-    consumers = create_consumers(time_now_ms,
-                                 topics,
-                                 config,
-                                 buffer.new_data,
-                                 stop_at_end_of_partition=False)
 
     # Use "async for" as "yield from" cannot be used in an async function, see
     # https://www.python.org/dev/peps/pep-0525/#asynchronous-yield-from
-    async for data_chunk in _data_stream(buffer, queue, consumers, interval,
-                                         run_info_topic,
-                                         KafkaQueryConsumer(kafka_broker)):
+    async for data_chunk in _data_stream(buffer, queue, kafka_broker, topics,
+                                         interval, run_info_topic):
         yield data_chunk
 
 
 async def _data_stream(
     buffer: "StreamedDataBuffer",  # noqa: F821
     queue: asyncio.Queue,
-    consumers: List["KafkaConsumer"],  # noqa: F821
+    kafka_broker: str,
+    topics: List[str],
     interval: sc.Variable,
     run_info_topic: Optional[str] = None,
-    query_consumer: Optional["KafkaQueryConsumer"] = None  # noqa: F821
+    query_consumer: Optional["KafkaQueryConsumer"] = None,  # noqa: F821
+    consumer_type: Optional[Type["KafkaConsumer"]] = None,  # noqa: F821
+    max_iterations: int = np.iinfo(np.int32).max  # for testability
 ) -> Generator[sc.DataArray, None, None]:
     """
     Main implementation of data stream is extracted to this function so that
     fake consumers can be injected for unit tests
     """
     try:
-        from ._streaming_consumer import (start_consumers,
-                                          get_run_start_message)
+        from ._streaming_consumer import (start_consumers, create_consumers,
+                                          get_run_start_message,
+                                          KafkaQueryConsumer, KafkaConsumer)
     except ImportError:
         raise ImportError(_missing_dependency_message)
 
+    # These are defaulted to None in the function signature
+    # to avoid them having to be imported
+    if query_consumer is None:
+        query_consumer = KafkaQueryConsumer(kafka_broker)
+    if consumer_type is None:
+        consumer_type = KafkaConsumer
+
+    start_time = time.time() * sc.units.s
     if run_info_topic is not None:
         run_start_info = get_run_start_message(run_info_topic, query_consumer)
-        yield _load_nexus_json(run_start_info.nexus_structure)
+        loaded_data, _, _ = _load_nexus_json(run_start_info.nexus_structure)
+        yield loaded_data
+
+    consumers = create_consumers(start_time,
+                                 topics,
+                                 kafka_broker,
+                                 query_consumer,
+                                 consumer_type,
+                                 buffer.new_data,
+                                 stop_at_end_of_partition=False)
 
     start_consumers(consumers)
     buffer.start()
-    interval_s = sc.to_unit(interval, 's').value
 
     # If we wait twice the expected interval and have not got
     # any new data in the queue then check if it is because all
     # the consumers have stopped, if so, we are done. Otherwise
     # it could just be that we have not received any new data.
-    while not _consumers_all_stopped(consumers):
+    iterations = 0
+    while not _consumers_all_stopped(
+            consumers) and iterations < max_iterations:
         try:
             new_data = await asyncio.wait_for(queue.get(),
-                                              timeout=2 * interval_s)
+                                              timeout=2 *
+                                              sc.to_unit(interval, 's').value)
+            iterations += 1
             yield new_data
         except asyncio.TimeoutError:
             pass

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -8,7 +8,7 @@ from ._loading_common import Group, MissingDataset
 from ._loading_detector_data import load_detector_data
 from ._loading_log_data import load_logs
 from ._loading_hdf5_nexus import LoadFromHdf5
-from ._loading_json_nexus import LoadFromJson
+from ._loading_json_nexus import LoadFromJson, get_topics_from_streams
 from ._loading_nexus import LoadFromNexus, GroupObject, ScippData
 import h5py
 from timeit import default_timer as timer
@@ -164,7 +164,7 @@ def _load_nexus_json(
     topics = None
     start_time = None
     if get_start_info:
-        topics = None
+        topics = get_topics_from_streams(loaded_json)
         start_time = None
     return _load_data(loaded_json, None, LoadFromJson(loaded_json),
                       True), start_time, topics

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -174,5 +174,5 @@ def _load_nexus_json(
 def load_nexus_json(json_filename: str) -> Optional[ScippData]:
     with open(json_filename, 'r') as json_file:
         json_string = json_file.read()
-    loaded_data, _ = _load_nexus_json(json_string)
+    loaded_data, _, _ = _load_nexus_json(json_string)
     return loaded_data

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -12,7 +12,7 @@ from ._loading_json_nexus import LoadFromJson
 from ._loading_nexus import LoadFromNexus, GroupObject, ScippData
 import h5py
 from timeit import default_timer as timer
-from typing import Union, List, Optional, Dict
+from typing import Union, List, Optional, Dict, Tuple
 from contextlib import contextmanager
 from warnings import warn
 import numpy as np
@@ -151,17 +151,27 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
     return loaded_data
 
 
-def _load_nexus_json(json_template: str) -> Optional[ScippData]:
+def _load_nexus_json(
+    json_template: str,
+    get_start_info: bool = False
+) -> Tuple[Optional[ScippData], Optional[int], Optional[List[str]]]:
     """
     Use this function for testing so that file io is not required
     """
     # We do not use cls to convert value lists to sc.Variable at this
     # point because we do not know what dimension names to use here
     loaded_json = json.loads(json_template)
-    return _load_data(loaded_json, None, LoadFromJson(loaded_json), True)
+    topics = None
+    start_time = None
+    if get_start_info:
+        topics = None
+        start_time = None
+    return _load_data(loaded_json, None, LoadFromJson(loaded_json),
+                      True), start_time, topics
 
 
 def load_nexus_json(json_filename: str) -> Optional[ScippData]:
     with open(json_filename, 'r') as json_file:
         json_string = json_file.read()
-    return _load_nexus_json(json_string)
+    loaded_data, _ = _load_nexus_json(json_string)
+    return loaded_data

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -8,8 +8,7 @@ from ._loading_common import Group, MissingDataset
 from ._loading_detector_data import load_detector_data
 from ._loading_log_data import load_logs
 from ._loading_hdf5_nexus import LoadFromHdf5
-from ._loading_json_nexus import (LoadFromJson, get_topics_from_streams,
-                                  get_start_time)
+from ._loading_json_nexus import LoadFromJson, get_topics_from_streams
 from ._loading_nexus import LoadFromNexus, GroupObject, ScippData
 import h5py
 from timeit import default_timer as timer
@@ -163,16 +162,14 @@ def _load_nexus_json(
     # point because we do not know what dimension names to use here
     loaded_json = json.loads(json_template)
     topics = None
-    start_time = None
     if get_start_info:
         topics = get_topics_from_streams(loaded_json)
-        start_time = get_start_time(loaded_json)
     return _load_data(loaded_json, None, LoadFromJson(loaded_json),
-                      True), start_time, topics
+                      True), topics
 
 
 def load_nexus_json(json_filename: str) -> Optional[ScippData]:
     with open(json_filename, 'r') as json_file:
         json_string = json_file.read()
-    loaded_data, _, _ = _load_nexus_json(json_string)
+    loaded_data, _ = _load_nexus_json(json_string)
     return loaded_data

--- a/python/src/scippneutron/load_nexus.py
+++ b/python/src/scippneutron/load_nexus.py
@@ -8,7 +8,8 @@ from ._loading_common import Group, MissingDataset
 from ._loading_detector_data import load_detector_data
 from ._loading_log_data import load_logs
 from ._loading_hdf5_nexus import LoadFromHdf5
-from ._loading_json_nexus import LoadFromJson, get_topics_from_streams
+from ._loading_json_nexus import (LoadFromJson, get_topics_from_streams,
+                                  get_start_time)
 from ._loading_nexus import LoadFromNexus, GroupObject, ScippData
 import h5py
 from timeit import default_timer as timer
@@ -154,7 +155,7 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
 def _load_nexus_json(
     json_template: str,
     get_start_info: bool = False
-) -> Tuple[Optional[ScippData], Optional[int], Optional[List[str]]]:
+) -> Tuple[Optional[ScippData], Optional[sc.Variable], Optional[List[str]]]:
     """
     Use this function for testing so that file io is not required
     """
@@ -165,7 +166,7 @@ def _load_nexus_json(
     start_time = None
     if get_start_info:
         topics = get_topics_from_streams(loaded_json)
-        start_time = None
+        start_time = get_start_time(loaded_json)
     return _load_data(loaded_json, None, LoadFromJson(loaded_json),
                       True), start_time, topics
 

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import List
 import numpy as np
 from .nexus_helpers import NexusBuilder
-from streaming_data_types.run_start_pl72 import serialise_pl72
 
 try:
     import streaming_data_types  # noqa: F401
@@ -14,7 +13,11 @@ try:
     from scippneutron.data_stream import _data_stream  # noqa: E402
     from scippneutron._streaming_data_buffer import \
         StreamedDataBuffer  # noqa: E402
-    from streaming_data_types import serialise_ev42  # noqa: E402
+    from streaming_data_types.eventdata_ev42 import \
+        serialise_ev42  # noqa: E402
+    from streaming_data_types.run_start_pl72 import (serialise_pl72,
+                                                     deserialise_pl72,
+                                                     RunStartInfo)
 except ImportError:
     pytest.skip("Kafka or Serialisation module is unavailable",
                 allow_module_level=True)
@@ -42,7 +45,7 @@ def stop_consumers(consumers: List[FakeConsumer]):
         consumer.stop()
 
 
-def get_run_start_message_no_streams(topic: str) -> bytes:
+def get_run_start_message_no_streams(topic: str, broker: str) -> RunStartInfo:
     """
     The real implementation finds the last run start
     message in the given topic.
@@ -51,10 +54,11 @@ def get_run_start_message_no_streams(topic: str) -> bytes:
     """
     builder = NexusBuilder()
     builder.add_instrument("DATA_STREAM_TEST")
-    return serialise_pl72("",
-                          "",
-                          datetime.datetime.now(),
-                          nexus_structure=builder.json_string)
+    message = serialise_pl72("",
+                             "",
+                             datetime.datetime.now(),
+                             nexus_structure=builder.json_string)
+    return deserialise_pl72(message)
 
 
 # Short time to use for buffer emit and data_stream interval in tests
@@ -79,7 +83,8 @@ async def test_data_stream_returns_data_from_single_event_message():
             buffer,
             queue,
             consumers,  # type: ignore
-            SHORT_TEST_INTERVAL):
+            SHORT_TEST_INTERVAL,
+            ""):
         assert np.allclose(data.coords['tof'].values, time_of_flight)
 
         # Cause the data_stream generator to stop and exit the "async for"
@@ -106,7 +111,8 @@ async def test_data_stream_returns_data_from_multiple_event_messages():
             buffer,
             queue,
             consumers,  # type: ignore
-            SHORT_TEST_INTERVAL):
+            SHORT_TEST_INTERVAL,
+            ""):
         expected_tofs = np.concatenate((first_tof, second_tof))
         assert np.allclose(data.coords['tof'].values, expected_tofs)
         expected_ids = np.concatenate(
@@ -183,11 +189,15 @@ async def test_data_are_loaded_from_run_start_message():
     buffer = StreamedDataBuffer(queue, TEST_BUFFER_SIZE, SHORT_TEST_INTERVAL)
     consumers = []
     run_info_topic = "fake_topic"
+    reached_assert = False
     async for data in _data_stream(
             buffer,
             queue,
             consumers,  # type: ignore
             SHORT_TEST_INTERVAL,
+            "broker_address",
             run_info_topic,
             get_run_start_message_no_streams):
-        assert data["instrument_name"] == "DATA_STREAM_TEST"
+        assert data["instrument_name"].value == "DATA_STREAM_TEST"
+        reached_assert = True
+    assert reached_assert

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -331,7 +331,7 @@ async def test_topics_from_run_start_message_used_if_topics_arg_not_specified(
                                 "broker",
                                 topics=None,
                                 interval=SHORT_TEST_INTERVAL,
-                                run_info_topic=None,
+                                run_info_topic="run_topic",
                                 query_consumer=query_consumer,
                                 consumer_type=FakeConsumer,
                                 max_iterations=0):

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -262,3 +262,35 @@ async def test_error_raised_if_no_run_start_message_available():
                                     consumer_type=FakeConsumer,
                                     max_iterations=0):
             pass
+
+
+@pytest.mark.asyncio
+async def test_error_if_both_topics_and_run_start_topic_not_specified():
+    queue = asyncio.Queue()
+    buffer = StreamedDataBuffer(queue, TEST_BUFFER_SIZE, SHORT_TEST_INTERVAL)
+    # At least one of "topics" and "run_start_topic" must be specified
+    with pytest.raises(ValueError):
+        async for _ in _data_stream(buffer,
+                                    queue,
+                                    "broker",
+                                    topics=None,
+                                    interval=SHORT_TEST_INTERVAL,
+                                    run_info_topic=None,
+                                    query_consumer=FakeQueryConsumer(),
+                                    consumer_type=FakeConsumer,
+                                    max_iterations=0):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_specified_topics_override_run_start_message_topics():
+    # If "topics" argument is specified then they should be used, even if
+    # a run start topic is provided
+    pass
+
+
+@pytest.mark.asyncio
+async def test_topics_from_run_start_message_used_if_not_specified():
+    # If "topics" argument is not specified then use topics from
+    # run start message
+    pass

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -316,7 +316,24 @@ async def test_specified_topics_override_run_start_message_topics():
 
 
 @pytest.mark.asyncio
-async def test_topics_from_run_start_message_used_if_not_specified():
-    # If "topics" argument is not specified then use topics from
-    # run start message
-    pass
+async def test_topics_from_run_start_message_used_if_topics_arg_not_specified(
+):
+    # If "topics" argument is specified then they should be used, even if
+    # a run start topic is provided
+    queue = asyncio.Queue()
+    buffer = StreamedDataBuffer(queue, TEST_BUFFER_SIZE, SHORT_TEST_INTERVAL)
+    topic_in_run_start_message = "test_topic"
+    test_streams = [Stream("/entry/stream_1", topic_in_run_start_message)]
+    query_consumer = FakeQueryConsumer(streams=test_streams)
+    # At least one of "topics" and "run_start_topic" must be specified
+    async for _ in _data_stream(buffer,
+                                queue,
+                                "broker",
+                                topics=None,
+                                interval=SHORT_TEST_INTERVAL,
+                                run_info_topic=None,
+                                query_consumer=query_consumer,
+                                consumer_type=FakeConsumer,
+                                max_iterations=0):
+        pass
+    assert topic_in_run_start_message in query_consumer.queried_topics

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -31,13 +31,16 @@ def test_no_exception_if_single_nxentry_found_below_root():
         assert scippneutron.load_nexus(nexus_file, root='/entry_1') is None
 
 
-def load_from_nexus(builder: NexusBuilder) -> sc.Variable:
+def load_from_nexus(
+        builder: NexusBuilder) -> Union[sc.Dataset, sc.DataArray, None]:
     with builder.file() as nexus_file:
         return scippneutron.load_nexus(nexus_file)
 
 
-def load_from_json(builder: NexusBuilder) -> sc.Variable:
-    return _load_nexus_json(builder.json_string)
+def load_from_json(
+        builder: NexusBuilder) -> Union[sc.Dataset, sc.DataArray, None]:
+    loaded_data, _, _ = _load_nexus_json(builder.json_string)
+    return loaded_data
 
 
 @pytest.fixture(params=[load_from_nexus, load_from_json])

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -39,7 +39,7 @@ def load_from_nexus(
 
 def load_from_json(
         builder: NexusBuilder) -> Union[sc.Dataset, sc.DataArray, None]:
-    loaded_data, _, _ = _load_nexus_json(builder.json_string)
+    loaded_data, _ = _load_nexus_json(builder.json_string)
     return loaded_data
 
 

--- a/python/tests/test_load_nexus_json.py
+++ b/python/tests/test_load_nexus_json.py
@@ -22,7 +22,7 @@ def test_stream_object_as_transformation_results_in_warning():
     builder.add_dataset_at_path("/entry/source/depends_on", stream_path, {})
 
     with pytest.warns(UserWarning):
-        loaded_data, _, _ = _load_nexus_json(builder.json_string)
+        loaded_data, _ = _load_nexus_json(builder.json_string)
 
     # A 0 distance translation is used in place of the streamed transformation
     default = [0, 0, 0]

--- a/python/tests/test_load_nexus_json.py
+++ b/python/tests/test_load_nexus_json.py
@@ -22,7 +22,7 @@ def test_stream_object_as_transformation_results_in_warning():
     builder.add_dataset_at_path("/entry/source/depends_on", stream_path, {})
 
     with pytest.warns(UserWarning):
-        loaded_data = _load_nexus_json(builder.json_string)
+        loaded_data, _, _ = _load_nexus_json(builder.json_string)
 
     # A 0 distance translation is used in place of the streamed transformation
     default = [0, 0, 0]


### PR DESCRIPTION
Closes #56

#### Changes
If a run info topic is specified then:
- the last available run start message is retrieved by `data_stream`,
- can optionally to join stream at the start of the last run,
- other topics do not need to be specified, they are retrieved from the run start message.