### PR TITLE
Switch to ModuleNotFoundError for mantid related tests

### DIFF
--- a/python/tests/mantid_data_helper.py
+++ b/python/tests/mantid_data_helper.py
@@ -11,7 +11,7 @@ def mantid_is_available():
     try:
         import mantid  # noqa: F401
         return True
-    except ImportError:
+    except ModuleNotFoundError:
         return False
 
 

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -10,14 +10,7 @@ import os
 import scipp as sc
 import scippneutron as scn
 from .mantid_data_helper import MantidDataHelper
-
-
-def mantid_is_available():
-    try:
-        import mantid  # noqa: F401
-        return True
-    except ImportError:
-        return False
+from .mantid_data_helper import mantid_is_available
 
 
 def memory_is_at_least_gb(required):

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -9,8 +9,7 @@ import os
 
 import scipp as sc
 import scippneutron as scn
-from .mantid_data_helper import MantidDataHelper
-from .mantid_data_helper import mantid_is_available
+from .mantid_data_helper import MantidDataHelper, mantid_is_available
 
 
 def memory_is_at_least_gb(required):


### PR DESCRIPTION
We want CI to fail if there are mantid-framework problems resulting from environment/package clashes rather than silently skipping tests. A recent example would be the installation/upgrade of runtime boost 1.76 compatible with scipp/scipp-neutron, which caused an ImportError for mantid. Now we would see such errors directly as we only identify that the module is missing.