### PR TITLE
Pin scipp version

### DIFF
--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -3,3 +3,6 @@ python:
 
 boost:
   - 1.75
+
+scipp:
+  - 0.6

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,11 +13,11 @@ requirements:
     - git
     - ninja
     - python {{ python }}
-    - scipp
+    - scipp {{ scipp }}
     - tbb-devel
   run:
     - python {{ python }}
-    - scipp
+    - scipp {{ scipp }}
     - h5py
 
 test:


### PR DESCRIPTION
The plan is to make a patch-release with this, to avoid installing new releases of the scipp package before scippneutron packages have been updated.