### PR TITLE
Temporarily disable windows builds and clone main branch from googlebenchmark instead of master

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -44,8 +44,8 @@ extends:
       osx:
         py_versions: ['3.7']
         conda_env: 'scippneutron-developer.yml'
-      windows:
-        py_versions: ['3.7']
-        conda_env: 'scippneutron-developer-no-mantid.yml'
+      # windows:
+      #   py_versions: ['3.7']
+      #   conda_env: 'scippneutron-developer-no-mantid.yml'
     deploy: true
     conda_label: 'dev'

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -40,6 +40,6 @@ extends:
       osx:
         py_versions: ['3.7']
         conda_env: 'scippneutron-developer.yml'
-      windows:
-        py_versions: ['3.7']
-        conda_env: 'scippneutron-developer-no-mantid.yml'
+      # windows:
+      #   py_versions: ['3.7']
+      #   conda_env: 'scippneutron-developer-no-mantid.yml'

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -36,9 +36,9 @@ extends:
       osx:
         py_versions: ['3.7']
         conda_env: 'scippneutron-developer.yml'
-      windows:
-        py_versions: ['3.7']
-        conda_env: 'scippneutron-developer-no-mantid.yml'
+      # windows:
+      #   py_versions: ['3.7']
+      #   conda_env: 'scippneutron-developer-no-mantid.yml'
     deploy: true
     conda_label: 'main'
     release: true

--- a/cmake/GoogleBenchmark.in
+++ b/cmake/GoogleBenchmark.in
@@ -7,7 +7,7 @@ find_package(Git)
 include(ExternalProject)
 ExternalProject_Add(googlebenchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googlebenchmark-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googlebenchmark-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
- Temporarily disable windows builds because of compilation failure after compiler update on azure from MSVC-19.28.29915.0 to MSVC-19.29.30037.0
- Googlebenchmark has changed their primary branch name from `master` to `main`