### PR TITLE
Fix spurious warnings for data stream

### DIFF
--- a/python/src/scippneutron/file_loading/_common.py
+++ b/python/src/scippneutron/file_loading/_common.py
@@ -8,6 +8,18 @@ import h5py
 
 
 class BadSource(Exception):
+    """
+    Raise if something is wrong with data source which
+    prevents it being used. Warn the user.
+    """
+    pass
+
+
+class SkipSource(Exception):
+    """
+    Raise to abort using the data source, do not
+    warn the user.
+    """
     pass
 
 
@@ -29,3 +41,4 @@ class Group:
     group: Union[h5py.Group, Dict]
     parent: Union[h5py.Group, Dict]
     path: str
+    contains_stream: bool = False

--- a/python/src/scippneutron/file_loading/_json_nexus.py
+++ b/python/src/scippneutron/file_loading/_json_nexus.py
@@ -70,7 +70,8 @@ def _visit_nodes(root: Dict, nx_class_names: Tuple[str, ...],
                 nx_class = _get_attribute_value(child, _nexus_class)
                 if nx_class in nx_class_names:
                     groups_with_requested_nx_class[nx_class].append(
-                        Group(child, root, "/".join(path)))
+                        Group(child, root, "/".join(path),
+                              contains_stream(child)))
             except MissingAttribute:
                 # It may be a group but not an NX_class,
                 # that's fine, continue to its children

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -33,10 +33,10 @@ def in_memory_hdf5_file_with_two_nxentry() -> Iterator[h5py.File]:
 
 @dataclass
 class EventData:
-    event_id: np.ndarray
+    event_id: Optional[np.ndarray]
     event_time_offset: Optional[np.ndarray]
-    event_time_zero: np.ndarray
-    event_index: np.ndarray
+    event_time_zero: Optional[np.ndarray]
+    event_index: Optional[np.ndarray]
 
 
 @dataclass
@@ -538,17 +538,22 @@ class NexusBuilder:
                                       group_name: str):
         event_group = self._create_nx_class(group_name, "NXevent_data",
                                             parent_group)
-        self._writer.add_dataset(event_group, "event_id", data=data.event_id)
+        if data.event_id is not None:
+            self._writer.add_dataset(event_group,
+                                     "event_id",
+                                     data=data.event_id)
         if data.event_time_offset is not None:
             event_time_offset_ds = self._writer.add_dataset(
                 event_group, "event_time_offset", data=data.event_time_offset)
             self._writer.add_attribute(event_time_offset_ds, "units", "ns")
-        event_time_zero_ds = self._writer.add_dataset(
-            event_group, "event_time_zero", data=data.event_time_zero)
-        self._writer.add_attribute(event_time_zero_ds, "units", "ns")
-        self._writer.add_dataset(event_group,
-                                 "event_index",
-                                 data=data.event_index)
+        if data.event_time_zero is not None:
+            event_time_zero_ds = self._writer.add_dataset(
+                event_group, "event_time_zero", data=data.event_time_zero)
+            self._writer.add_attribute(event_time_zero_ds, "units", "ns")
+        if data.event_index is not None:
+            self._writer.add_dataset(event_group,
+                                     "event_index",
+                                     data=data.event_index)
 
     def _add_transformations_to_file(self, transform: Transformation,
                                      parent_group: h5py.Group,

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -4,7 +4,7 @@ import scipp as sc
 import asyncio
 from typing import List, Tuple, Callable, Dict, Optional
 import numpy as np
-from .nexus_helpers import NexusBuilder, Stream, Log
+from .nexus_helpers import NexusBuilder, Stream, Log, EventData
 
 try:
     import streaming_data_types  # noqa: F401
@@ -962,10 +962,10 @@ async def test_no_warning_for_missing_datasets_if_group_contains_stream(
     test_instrument_name = "DATA_STREAM_TEST"
     builder.add_instrument(test_instrument_name)
     builder.add_log(Log("log", None))
+    builder.add_event_data(EventData(None, None, None, None))
     builder.add_stream(Stream("/entry/log"))
+    builder.add_stream(Stream("/entry/events_0"))
     nexus_structure = builder.json_string
-
-    print(nexus_structure)
 
     queue, buffer = queue_and_buffer
     run_info_topic = "fake_topic"
@@ -987,5 +987,6 @@ async def test_no_warning_for_missing_datasets_if_group_contains_stream(
     assert reached_assert
     assert len(
         record_warnings
-    ) == 0, "Expect no 'missing datasets' warning from the NXlog because it " \
-            "contains a stream which will provide the missing data"
+    ) == 0, "Expect no 'missing datasets' warning from the NXlog or " \
+            "NXevent_data because they each contain a stream which " \
+            "will provide the missing data"

--- a/python/tests/test_data_stream.py
+++ b/python/tests/test_data_stream.py
@@ -4,7 +4,7 @@ import scipp as sc
 import asyncio
 from typing import List, Tuple, Callable, Dict, Optional
 import numpy as np
-from .nexus_helpers import NexusBuilder, Stream
+from .nexus_helpers import NexusBuilder, Stream, Log
 
 try:
     import streaming_data_types  # noqa: F401
@@ -320,7 +320,7 @@ async def test_specified_topics_override_run_start_message_topics(
     queue, buffer = queue_and_buffer
     test_topics = ["whiting", "snail", "porpoise"]
     topic_in_run_start_message = "test_topic"
-    test_streams = [Stream("/entry/stream_1", topic_in_run_start_message)]
+    test_streams = [Stream("/entry", topic_in_run_start_message)]
     query_consumer = FakeQueryConsumer(streams=test_streams)
     async for _ in _data_stream(buffer,
                                 queue,
@@ -342,7 +342,7 @@ async def test_topics_from_run_start_message_used_if_topics_arg_not_specified(
         queue_and_buffer):
     queue, buffer = queue_and_buffer
     topic_in_run_start_message = "test_topic"
-    test_streams = [Stream("/entry/stream_1", topic_in_run_start_message)]
+    test_streams = [Stream("/entry", topic_in_run_start_message)]
     query_consumer = FakeQueryConsumer(streams=test_streams)
     async for _ in _data_stream(buffer,
                                 queue,
@@ -362,7 +362,7 @@ async def test_start_time_from_run_start_msg_not_used_if_start_now_specified(
         queue_and_buffer):
     queue, buffer = queue_and_buffer
     topic_in_run_start_message = "test_topic"
-    test_streams = [Stream("/entry/stream_1", topic_in_run_start_message)]
+    test_streams = [Stream("/entry", topic_in_run_start_message)]
     test_start_time = 123456
     query_consumer = FakeQueryConsumer(streams=test_streams,
                                        start_time=test_start_time)
@@ -386,7 +386,7 @@ async def test_start_time_from_run_start_msg_used_if_requested(
         queue_and_buffer):
     queue, buffer = queue_and_buffer
     topic_in_run_start_message = "test_topic"
-    test_streams = [Stream("/entry/stream_1", topic_in_run_start_message)]
+    test_streams = [Stream("/entry", topic_in_run_start_message)]
     test_start_time = 123456
     query_consumer = FakeQueryConsumer(streams=test_streams,
                                        start_time=test_start_time)
@@ -950,3 +950,42 @@ async def test_data_stream_emits_if_multiple_chopper_msgs_exceed_buffer():
         assert not queue.empty(), "Expect data to have been emitted to " \
                                   "queue as buffer size was exceeded"
         break
+
+
+@pytest.mark.asyncio
+async def test_no_warning_for_missing_datasets_if_group_contains_stream(
+        queue_and_buffer):
+    # Create NeXus description for run start message which contains
+    # an NXlog which contains no datasets but does have a Stream
+    # source for the data
+    builder = NexusBuilder()
+    test_instrument_name = "DATA_STREAM_TEST"
+    builder.add_instrument(test_instrument_name)
+    builder.add_log(Log("log", None))
+    builder.add_stream(Stream("/entry/log"))
+    nexus_structure = builder.json_string
+
+    print(nexus_structure)
+
+    queue, buffer = queue_and_buffer
+    run_info_topic = "fake_topic"
+    reached_assert = False
+
+    with pytest.warns(None) as record_warnings:
+        async for _ in _data_stream(buffer,
+                                    queue,
+                                    "broker", [""],
+                                    SHORT_TEST_INTERVAL,
+                                    run_info_topic=run_info_topic,
+                                    query_consumer=FakeQueryConsumer(
+                                        test_instrument_name,
+                                        nexus_structure=nexus_structure),
+                                    consumer_type=FakeConsumer,
+                                    max_iterations=0):
+            reached_assert = True
+            break
+    assert reached_assert
+    assert len(
+        record_warnings
+    ) == 0, "Expect no 'missing datasets' warning from the NXlog because it " \
+            "contains a stream which will provide the missing data"


### PR DESCRIPTION
Closes #85

**Do not review or merge until #86 is merged.** (branches from feature branch)

Avoids warning the user of missing datasets if the group instead contains a stream object to provide the missing data.