### PR TITLE
Fix broken import

### DIFF
--- a/python/src/scippneutron/data_streaming/_data_buffer.py
+++ b/python/src/scippneutron/data_streaming/_data_buffer.py
@@ -12,7 +12,7 @@ from streaming_data_types.timestamps_tdct import deserialise_tdct, Timestamps
 from streaming_data_types.exceptions import WrongSchemaException
 from typing import Optional, Dict, List, Any, Union, Callable
 from warnings import warn
-from python.src.scippneutron.file_loading._json_nexus import StreamInfo
+from ..file_loading._json_nexus import StreamInfo
 from datetime import datetime
 """
 The ESS data streaming system uses Google FlatBuffers to serialise


### PR DESCRIPTION
Broken import was causing data_stream tests not to be run on CI.

Check tests in `test_data_stream.py` are being run in the log on Azure before merging:
https://dev.azure.com/scipp/scippneutron/_build/results?buildId=5810&view=logs&j=a111e0f8-30a5-5221-2818-2887bca8cba8&t=13f10413-a65c-523c-8e6c-97a432137d5a