### PR TITLE
No deployment for next

### DIFF
--- a/.azure-pipelines/next.yml
+++ b/.azure-pipelines/next.yml
@@ -47,6 +47,6 @@ extends:
       windows:
         py_versions: ['3.7']
         conda_env: 'scippneutron-developer-no-mantid-next.yml'
-    deploy: true
+    deploy: false
     conda_label: 'next'
     publish_docs: false


### PR DESCRIPTION
* Further in the release cycle, we will want to create next packages.
* Testing upstream changes in scipp against scippneturon is still useful, and we want to do this so we know where breaking changes are introduced (see scipp readme.md for badge status). 

Problem
* We currently have a `next` branch which is == `main` at the point of release to support the above.
* Pushes to scipp/label/dev trigger the `next` pipeline of `scippeneutron` (as they should)
* New packages are made with exact same build number as the release *_0.
* When these are pushed to anaconda, anaconda thinks you are overwriting the existing package (previously labelled `main`) with `scipp/label/next`. This effectively removes the release from the `scipp` channel. so for example `conda install scippneutron=0.2 -c scipp` no longer works!
