### PR TITLE
Fix advanced geometry issues

### DIFF
--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -241,7 +241,7 @@ def _to_spherical(pos, output):
     abs_phi = sc.abs(signed_phi)
     output["p-delta"] = (
         np.pi * sc.units.rad) - abs_phi  # angular delta (magnitude) from pole
-    output['p-sign'] = signed_phi / abs_phi  # sign of phi
+    output['p-sign'] = signed_phi  # weighted sign of phi
     return output
 
 
@@ -347,7 +347,7 @@ def get_detector_properties(ws,
                                                    len(spec_info) + 0.5,
                                                    1.0))).mean("detector")
 
-        sign = averaged["p-sign"].data
+        sign = averaged["p-sign"].data / sc.abs(averaged["p-sign"].data)
         averaged["p"] = sign * (
             (np.pi * sc.units.rad) - averaged["p-delta"].data)
         averaged["x"] = averaged["r"].data * sc.sin(

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -283,19 +283,19 @@ def get_detector_properties(ws,
 
     if sample_pos is not None and source_pos is not None:
         total_detectors = spec_info.detectorCount()
-        act_beam = (sample_pos - source_pos).values
-        rot = _rot_from_vectors(act_beam, [0, 0, 1])
-        inv_rot = _rot_from_vectors([0, 0, 1], act_beam)
+        act_beam = (sample_pos - source_pos)
+        rot = _rot_from_vectors(act_beam, sc.vector(value=[0, 0, 1]))
+        inv_rot = _rot_from_vectors(sc.vector(value=[0, 0, 1]), act_beam)
 
         pos_d = sc.Dataset()
         # Create empty to hold position info for all spectra detectors
-        pos_d["x"] = sc.Variable(["detector"],
-                                 shape=[total_detectors],
-                                 unit=sc.units.m)
-        pos_d["y"] = pos_d["x"]
-        pos_d["z"] = pos_d["x"]
-        pos_d.coords[spectrum_dim] = sc.Variable(
-            ["detector"], values=np.empty(total_detectors))
+        pos_d["x"] = sc.zeros(dims=["detector"],
+                              shape=[total_detectors],
+                              unit=sc.units.m)
+        pos_d["y"] = sc.zeros_like(pos_d["x"])
+        pos_d["z"] = sc.zeros_like(pos_d["x"])
+        pos_d.coords[spectrum_dim] = sc.array(dims=["detector"],
+                                              values=np.empty(total_detectors))
 
         spectrum_values = pos_d.coords[spectrum_dim].values
 
@@ -356,8 +356,11 @@ def get_detector_properties(ws,
         pos = sc.geometry.position(averaged["x"].data, averaged["y"].data,
                                    averaged["z"].data)
 
-        return (inv_rot * pos, sc.matrices([spectrum_dim], values=det_rot),
-                sc.vectors([spectrum_dim], values=det_bbox, unit=sc.units.m))
+        return (inv_rot * pos, sc.matrices(dims=[spectrum_dim],
+                                           values=det_rot),
+                sc.vectors(dims=[spectrum_dim],
+                           values=det_bbox,
+                           unit=sc.units.m))
     else:
         pos = np.zeros([nspec, 3])
 
@@ -382,17 +385,17 @@ def get_detector_properties(ws,
                     bboxes.append(s.getBoundingBox().width())
                 pos[i, :] = np.mean(vec3s, axis=0)
                 det_rot[
-                    i, :] = sc.geometry.rotation_matrix_from_quaterion_cooffs(
+                    i, :] = sc.geometry.rotation_matrix_from_quaternion_coeffs(
                         np.mean(quats, axis=0))
                 det_bbox[i, :] = np.sum(bboxes, axis=0)
             else:
                 pos[i, :] = [np.nan, np.nan, np.nan]
                 det_rot[i, :] = [np.nan, np.nan, np.nan, np.nan]
                 det_bbox[i, :] = [np.nan, np.nan, np.nan]
-        return (sc.vectors([spectrum_dim], values=pos, unit=sc.units.m),
-                sc.matrices([spectrum_dim], values=det_rot),
+        return (sc.vectors(dims=[spectrum_dim], values=pos, unit=sc.units.m),
+                sc.matrices(dims=[spectrum_dim], values=det_rot),
                 sc.vectors(
-                    [spectrum_dim],
+                    dims=[spectrum_dim],
                     values=det_bbox,
                     unit=sc.units.m,
                 ))

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -74,6 +74,15 @@ class TestMantidConversion(unittest.TestCase):
         b = a.copy()
         assert sc.identical(a, b)
 
+    def test_advanced_geometry(self):
+        # basic test that positions are approximately equal for detectors for
+        # CNCS given advanced and basic geometry calculation routes
+        x = scn.from_mantid(self.base_event_ws, advanced_geometry=False)
+        y = scn.from_mantid(self.base_event_ws, advanced_geometry=True)
+        assert np.all(
+            np.isclose(x.coords['position'].values,
+                       y.coords['position'].values))
+
     def test_EventWorkspace_no_y_unit(self):
         import mantid.simpleapi as mantid
         tiny_event_ws = mantid.CreateSampleWorkspace(WorkspaceType='Event',
@@ -568,23 +577,23 @@ class TestMantidConversion(unittest.TestCase):
     def test_spherical_conversion(self):
         x = 1.0
         y = 1.0
-        z = 1.0
+        z = 0.0
         spherical = self._exec_to_spherical(x, y, z)
         assert spherical['r'].value == np.sqrt(x**2 + y**2 + z**2)
         assert spherical['t'].value == np.arccos(z /
                                                  np.sqrt(x**2 + y**2 + z**2))
         # Phi now should be between 0 and pi
-        assert spherical['p-delta'].value + spherical['p-sign'].value == np.pi
-        assert spherical['p-sign'].value == np.arctan2(y, x)
+        assert spherical['p-delta'].value == (3.0 / 4) * np.pi
+        assert spherical['p-sign'].value == 1.0
         x = -1.0
         spherical = self._exec_to_spherical(x, y, z)
-        assert spherical['p-delta'].value + spherical['p-sign'].value == np.pi
-        assert spherical['p-sign'].value == np.arctan2(y, x)
+        assert spherical['p-delta'].value == (1.0 / 4) * np.pi
+        assert spherical['p-sign'].value == 1.0
         # Phi now should be between 0 and -pi
         y = -1.0
         spherical = self._exec_to_spherical(x, y, z)
-        assert spherical['p-sign'].value - spherical['p-delta'].value == -np.pi
-        assert spherical['p-sign'].value == np.arctan2(y, x)
+        assert spherical['p-delta'].value == (1.0 / 4) * np.pi
+        assert spherical['p-sign'].value == -1.0
 
     def test_detector_positions(self):
         import mantid.simpleapi as mantid

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -584,16 +584,16 @@ class TestMantidConversion(unittest.TestCase):
                                                  np.sqrt(x**2 + y**2 + z**2))
         # Phi now should be between 0 and pi
         assert spherical['p-delta'].value == (3.0 / 4) * np.pi
-        assert spherical['p-sign'].value == 1.0
+        assert spherical['p-sign'].value > 0.0
         x = -1.0
         spherical = self._exec_to_spherical(x, y, z)
         assert spherical['p-delta'].value == (1.0 / 4) * np.pi
-        assert spherical['p-sign'].value == 1.0
+        assert spherical['p-sign'].value > 0.0
         # Phi now should be between 0 and -pi
         y = -1.0
         spherical = self._exec_to_spherical(x, y, z)
         assert spherical['p-delta'].value == (1.0 / 4) * np.pi
-        assert spherical['p-sign'].value == -1.0
+        assert spherical['p-sign'].value < 0.0
 
     def test_detector_positions(self):
         import mantid.simpleapi as mantid


### PR DESCRIPTION
Problem reported by Celine on slack

Fix two problems.

1. x,y,z buffers set for deep copies, but the behaviour changed as part of 0.7 scipp resulting in shallow copies instead. As a result x = y = z, giving instrument detector positions as colinear points along a line defined by x values
2. Incorrect calculation using signed delta for phi averaging results in y inversion. Originally introduced here https://github.com/scipp/scipp/pull/1339