### PR TITLE
Deal with absent shape object

### DIFF
--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -317,7 +317,6 @@ def get_detector_properties(ws,
                     det_idx = definition[j][0]
                     p = det_info.position(det_idx)
                     r = det_info.rotation(det_idx)
-                    s = comp_info.shape(det_idx)
                     spectrum_values[idx] = i
                     x_values[idx] = p.X()
                     y_values[idx] = p.Y()
@@ -328,7 +327,11 @@ def get_detector_properties(ws,
                                   r.imagJ(),
                                   r.imagK(),
                                   r.real()]))
-                    bboxes.append(s.getBoundingBox().width())
+                    if comp_info.hasValidShape(det_idx):
+                        s = comp_info.shape(det_idx)
+                        bboxes.append(s.getBoundingBox().width())
+                    else:
+                        bboxes.append(-1)  # not physical
                 det_rot[
                     i, :] = sc.geometry.rotation_matrix_from_quaternion_coeffs(
                         np.mean(quats, axis=0))

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -330,8 +330,6 @@ def get_detector_properties(ws,
                     if comp_info.hasValidShape(det_idx):
                         s = comp_info.shape(det_idx)
                         bboxes.append(s.getBoundingBox().width())
-                    else:
-                        bboxes.append(-1)  # not physical
                 det_rot[
                     i, :] = sc.geometry.rotation_matrix_from_quaternion_coeffs(
                         np.mean(quats, axis=0))
@@ -381,14 +379,15 @@ def get_detector_properties(ws,
                     det_idx = definition[j][0]
                     p = det_info.position(det_idx)
                     r = det_info.rotation(det_idx)
-                    s = comp_info.shape(det_idx)
                     vec3s.append([p.X(), p.Y(), p.Z()])
                     quats.append(
                         np.array([r.imagI(),
                                   r.imagJ(),
                                   r.imagK(),
                                   r.real()]))
-                    bboxes.append(s.getBoundingBox().width())
+                    if comp_info.hasValidShape(det_idx):
+                        s = comp_info.shape(det_idx)
+                        bboxes.append(s.getBoundingBox().width())
                 pos[i, :] = np.mean(vec3s, axis=0)
                 det_rot[
                     i, :] = sc.geometry.rotation_matrix_from_quaternion_coeffs(


### PR DESCRIPTION
Loading via converters can segfault with `advanced_geometry=True` if the mantid instruments detectors has no shape. Probably as a result of dereferencing a null shape ptr.

This should be a patch release candidate.

Need this to fix https://github.com/scipp/ess/pull/31