### PR TITLE
Remove boost-cpp pin

### DIFF
--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -37,3 +37,9 @@ extends:
       linux:
         py_versions: ['3.7']
         conda_env: 'scippneutron-developer.yml'
+      osx:
+        py_versions: ['3.7']
+        conda_env: 'scippneutron-developer.yml'
+      windows:
+        py_versions: ['3.7']
+        conda_env: 'scippneutron-developer-no-mantid.yml'

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -37,9 +37,3 @@ extends:
       linux:
         py_versions: ['3.7']
         conda_env: 'scippneutron-developer.yml'
-      osx:
-        py_versions: ['3.7']
-        conda_env: 'scippneutron-developer.yml'
-      windows:
-        py_versions: ['3.7']
-        conda_env: 'scippneutron-developer-no-mantid.yml'

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -14,7 +14,7 @@ resources:
     name: scipp/pipelines
     type: github
     endpoint: scipp
-    ref: main
+    ref: document-without-build-deps # TODO update to main
 
 trigger:
   branches:

--- a/.azure-pipelines/pull_request.yml
+++ b/.azure-pipelines/pull_request.yml
@@ -14,7 +14,7 @@ resources:
     name: scipp/pipelines
     type: github
     endpoint: scipp
-    ref: document-without-build-deps # TODO update to main
+    ref: main
 
 trigger:
   branches:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -7,7 +7,7 @@ source:
 
 requirements:
   build:
-    - boost-cpp {{ boost }}
+    - boost-cpp
     - cmake
     - gxx_linux-64 9.3.* [linux64]
     - git

--- a/scippneutron-developer-next.yml
+++ b/scippneutron-developer-next.yml
@@ -10,7 +10,7 @@ channels:
 
 dependencies:
   # Build
-  - boost-cpp=1.75 # see https://github.com/scipp/scipp/issues/1888
+  - boost-cpp
   - ninja
   - tbb-devel
   - scipp/label/dev::scipp

--- a/scippneutron-developer-next.yml
+++ b/scippneutron-developer-next.yml
@@ -23,7 +23,6 @@ dependencies:
   - mantid-framework
   - matplotlib-base
   - numpy >=1.15.3
-  - python
   - python-configuration
   - pythreejs
   - pyyaml
@@ -35,7 +34,6 @@ dependencies:
   - pytest-asyncio
   - python-confluent-kafka
   - ess-dmsc::ess-streaming-data-types
-  - scipp/label/dev::scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer-next.yml
+++ b/scippneutron-developer-next.yml
@@ -14,12 +14,13 @@ dependencies:
   - ninja
   - tbb-devel
   - scipp/label/dev::scipp
+  - python
 
   # Run
   - appdirs
   - ipympl
   - ipywidgets
-  - mantid-framework
+  - mantid-framework>=6.0.20210412.0948
   - matplotlib-base
   - numpy >=1.15.3
   - python
@@ -29,13 +30,12 @@ dependencies:
   - tbb
   - traitlets
   - h5py
-  - python-confluent-kafka
-  - ess-dmsc::ess-streaming-data-types
-
-  # Test
   - psutil
   - pytest
   - pytest-asyncio
+  - python-confluent-kafka
+  - ess-dmsc::ess-streaming-data-types
+  - scipp/label/dev::scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer-next.yml
+++ b/scippneutron-developer-next.yml
@@ -20,7 +20,7 @@ dependencies:
   - appdirs
   - ipympl
   - ipywidgets
-  - mantid-framework>=6.0.20210412.0948
+  - mantid-framework
   - matplotlib-base
   - numpy >=1.15.3
   - python

--- a/scippneutron-developer-no-mantid-next.yml
+++ b/scippneutron-developer-no-mantid-next.yml
@@ -13,7 +13,7 @@ channels:
 
 dependencies:
   # Build
-  - boost-cpp=1.75 # see https://github.com/scipp/scipp/issues/1888
+  - boost-cpp=1.75
   - ninja
   - tbb-devel
   - scipp/label/dev::scipp

--- a/scippneutron-developer-no-mantid-next.yml
+++ b/scippneutron-developer-no-mantid-next.yml
@@ -13,10 +13,11 @@ channels:
 
 dependencies:
   # Build
-  - boost-cpp=1.75
+  - boost-cpp
   - ninja
   - tbb-devel
   - scipp/label/dev::scipp
+  - python
 
   # Run
   - appdirs
@@ -31,11 +32,10 @@ dependencies:
   - tbb
   - traitlets
   - h5py
-
-  # Test
   - psutil
   - pytest
   - pytest-asyncio
+  - scipp/label/dev::scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer-no-mantid-next.yml
+++ b/scippneutron-developer-no-mantid-next.yml
@@ -25,7 +25,6 @@ dependencies:
   - ipywidgets
   - matplotlib-base
   - numpy >=1.15.3
-  - python
   - python-configuration
   - pythreejs
   - pyyaml
@@ -35,7 +34,6 @@ dependencies:
   - psutil
   - pytest
   - pytest-asyncio
-  - scipp/label/dev::scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -13,7 +13,7 @@ channels:
 
 dependencies:
   # Build
-  - boost-cpp=1.75 # see https://github.com/scipp/scipp/issues/1888
+  - boost-cpp
   - ninja
   - tbb-devel
   - scipp

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -17,6 +17,7 @@ dependencies:
   - ninja
   - tbb-devel
   - scipp
+  - python
 
   # Run
   - appdirs
@@ -31,11 +32,10 @@ dependencies:
   - tbb
   - traitlets
   - h5py
-
-  # Test
   - psutil
   - pytest
   - pytest-asyncio
+  - scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -25,7 +25,6 @@ dependencies:
   - ipywidgets
   - matplotlib-base
   - numpy >=1.15.3
-  - python
   - python-configuration
   - pythreejs
   - pyyaml
@@ -35,7 +34,6 @@ dependencies:
   - psutil
   - pytest
   - pytest-asyncio
-  - scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -23,7 +23,6 @@ dependencies:
   - mantid-framework
   - matplotlib-base
   - numpy >=1.15.3
-  - python
   - python-configuration
   - pythreejs
   - pyyaml
@@ -35,7 +34,6 @@ dependencies:
   - pytest-asyncio
   - python-confluent-kafka
   - ess-dmsc::ess-streaming-data-types
-  - scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -7,7 +7,6 @@ name: scippneutron-developer
 channels:
   - conda-forge
   - scipp
-  - nodefaults
 
 dependencies:
   # Build
@@ -21,7 +20,7 @@ dependencies:
   - appdirs
   - ipympl
   - ipywidgets
-  - mantid-framework=6.0.20210412.0948
+  - mantid-framework>=6.0.20210412.0948
   - matplotlib-base
   - numpy >=1.15.3
   - python

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -32,11 +32,7 @@ dependencies:
   - h5py
   - python-confluent-kafka
   - ess-dmsc::ess-streaming-data-types
-
-  # Test
-  - psutil
-  - pytest
-  - pytest-asyncio
+  - scipp
 
   # Formatting & static analysis
   - pre-commit

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -20,7 +20,7 @@ dependencies:
   - appdirs
   - ipympl
   - ipywidgets
-  - mantid-framework
+  - mantid-framework=6.0.20210412.0948
   - matplotlib-base
   - numpy >=1.15.3
   - python

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -30,6 +30,9 @@ dependencies:
   - tbb
   - traitlets
   - h5py
+  - psutil
+  - pytest
+  - pytest-asyncio
   - python-confluent-kafka
   - ess-dmsc::ess-streaming-data-types
   - scipp

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -7,10 +7,11 @@ name: scippneutron-developer
 channels:
   - conda-forge
   - scipp
+  - nodefaults
 
 dependencies:
   # Build
-  - boost-cpp=1.75 # see https://github.com/scipp/scipp/issues/1888
+  - boost-cpp
   - ninja
   - tbb-devel
   - scipp

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -15,6 +15,7 @@ dependencies:
   - ninja
   - tbb-devel
   - scipp
+  - python
 
   # Run
   - appdirs

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -20,7 +20,7 @@ dependencies:
   - appdirs
   - ipympl
   - ipywidgets
-  - mantid-framework>=6.0.20210412.0948
+  - mantid-framework
   - matplotlib-base
   - numpy >=1.15.3
   - python


### PR DESCRIPTION
Explore work around applied here #84 technically we should not need to pin our build-time only dependencies. If we do, need to establish what exactly is brining in a conflicting runtime boost version. Partial fix to https://github.com/scipp/scipp/issues/1888

Consider alongside https://github.com/scipp/pipelines/pull/6

Will need to do similar things for scipp itself where pinning can also be removed.