### PR TITLE
Avoid error when loading log in NeXus file with unrecognised units

### DIFF
--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -160,7 +160,7 @@ def _load_detector(group: Group, file_root: h5py.File,
     pixel_positions = None
     pixel_positions_found, _ = nexus.dataset_in_group(group.group,
                                                       "x_pixel_offset")
-    if pixel_positions_found:
+    if pixel_positions_found and detector_ids is not None:
         pixel_positions = _load_pixel_positions(group.group,
                                                 detector_ids.shape[0],
                                                 file_root, nexus)

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -149,11 +149,11 @@ class LoadFromHdf5:
         return group.name.split("/")[-1]
 
     @staticmethod
-    def get_unit(node: Union[h5py.Dataset, h5py.Group]) -> Union[str, sc.Unit]:
+    def get_unit(node: Union[h5py.Dataset, h5py.Group]) -> str:
         try:
             units = node.attrs["units"]
         except (AttributeError, KeyError):
-            return sc.units.dimensionless
+            return "dimensionless"
         return _ensure_str(units)
 
     @staticmethod

--- a/python/src/scippneutron/file_loading/_json_nexus.py
+++ b/python/src/scippneutron/file_loading/_json_nexus.py
@@ -277,11 +277,11 @@ class LoadFromJson:
         return group[_nexus_name]
 
     @staticmethod
-    def get_unit(dataset: Dict) -> Union[str, sc.Unit]:
+    def get_unit(dataset: Dict) -> str:
         try:
             unit = _get_attribute_value(dataset, _nexus_units)
         except MissingAttribute:
-            unit = sc.units.dimensionless
+            unit = "dimensionless"
         return unit
 
     def load_scalar_string(self, group: Dict,

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -70,7 +70,7 @@ def _load_log_data_from_group(group: Group,
         unit = sc.Unit(unit)
     except sc.UnitError:
         warn(f"Unrecognised unit '{unit}' for value dataset "
-             f"in NXlog '{group.path}'")
+             f"in NXlog '{group.path}'; setting unit as 'dimensionless'")
         unit = sc.units.dimensionless
 
     try:

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -69,7 +69,7 @@ def _load_log_data_from_group(group: Group,
     try:
         unit = sc.Unit(unit)
     except sc.UnitError:
-        warn(f"Unrecognised unit '{unit}' for value dataset "
+        warn(f"Unrecognized unit '{unit}' for value dataset "
              f"in NXlog '{group.path}'; setting unit as 'dimensionless'")
         unit = sc.units.dimensionless
 

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -66,6 +66,12 @@ def _load_log_data_from_group(group: Group,
 
     unit = nexus.get_unit(
         nexus.get_dataset_from_group(group.group, value_dataset_name))
+    try:
+        unit = sc.Unit(unit)
+    except sc.UnitError:
+        warn(f"Unrecognised unit '{unit}' for value dataset "
+             f"in NXlog '{group.path}'")
+        unit = sc.units.dimensionless
 
     try:
         dimension_label = "time"

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -1280,11 +1280,12 @@ def test_warning_but_no_error_for_unrecognised_log_unit(
     builder.add_log(
         Log(name, values, times, value_units=unknown_unit, time_units="s"))
 
-    loaded_data = load_function(builder)
+    with pytest.warns(UserWarning):
+        loaded_data = load_function(builder)
 
     # Expect a sc.Dataset with log names as keys
     assert np.allclose(loaded_data[name].data.values.values, values)
     assert np.allclose(loaded_data[name].data.values.coords['time'].values,
                        times)
-    assert loaded_data[name].data.values.unit == sc.units.m
+    assert loaded_data[name].data.values.unit == sc.units.dimensionless
     assert loaded_data[name].data.values.coords['time'].unit == sc.units.s

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -1268,3 +1268,23 @@ def test_linked_datasets_are_found(load_function: Callable):
     expected_detector_ids = np.array([1, 2, 3])
     assert np.array_equal(loaded_data.coords['detector_id'].values,
                           expected_detector_ids)
+
+
+def test_warning_but_no_error_for_unrecognised_log_unit(
+        load_function: Callable):
+    values = np.array([1.1, 2.2, 3.3])
+    times = np.array([4.4, 5.5, 6.6])
+    name = "test_log"
+    builder = NexusBuilder()
+    unknown_unit = "elephants"
+    builder.add_log(
+        Log(name, values, times, value_units=unknown_unit, time_units="s"))
+
+    loaded_data = load_function(builder)
+
+    # Expect a sc.Dataset with log names as keys
+    assert np.allclose(loaded_data[name].data.values.values, values)
+    assert np.allclose(loaded_data[name].data.values.coords['time'].values,
+                       times)
+    assert loaded_data[name].data.values.unit == sc.units.m
+    assert loaded_data[name].data.values.coords['time'].unit == sc.units.s


### PR DESCRIPTION
Warn the user and use `dimensionless` if units in `NXlog` are not recognised.
Problem was discovered when trying to load ISIS files with units such as "is_vetoing", "frames" and "events". I notice that "mBar" is also not recognised, should we do something about that one?