### PR TITLE
Make load_nexus compatible with h5py-lookalikes

### DIFF
--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -60,7 +60,7 @@ class LoadFromHdf5:
         }
 
         def _match_nx_class(_, h5_object):
-            if isinstance(h5_object, h5py.Group):
+            if LoadFromHdf5.is_group(h5_object):
                 try:
                     nx_class = _get_attr_as_str(h5_object, "NX_class")
                     if nx_class in nx_class_names:
@@ -168,7 +168,7 @@ class LoadFromHdf5:
     def get_dataset_from_group(self, group: h5py.Group,
                                dataset_name: str) -> Optional[h5py.Dataset]:
         dataset = self.get_child_from_group(group, dataset_name)
-        if isinstance(dataset, h5py.Dataset):
+        if not self.is_group(dataset):
             return dataset
         return None
 
@@ -191,7 +191,7 @@ class LoadFromHdf5:
     def get_attribute_as_numpy_array(node: Union[h5py.Group, h5py.Dataset],
                                      attribute_name: str) -> np.ndarray:
         try:
-            return node.attrs[attribute_name]
+            return np.array(node.attrs[attribute_name])
         except KeyError:
             raise MissingAttribute
 
@@ -205,4 +205,7 @@ class LoadFromHdf5:
 
     @staticmethod
     def is_group(node: Any):
-        return isinstance(node, h5py.Group)
+        # Note: Not using isinstance(node, h5py.Group) so we can support other
+        # libraries that look like h5py but are not, in particular data
+        # adapted from `tiled`.
+        return hasattr(node, 'visititems')

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -191,7 +191,7 @@ class LoadFromHdf5:
     def get_attribute_as_numpy_array(node: Union[h5py.Group, h5py.Dataset],
                                      attribute_name: str) -> np.ndarray:
         try:
-            return np.array(node.attrs[attribute_name])
+            return np.asarray(node.attrs[attribute_name])
         except KeyError:
             raise MissingAttribute
 


### PR DESCRIPTION
- Avoid checking for instances of `h5py` classes
- Explicitly return attribute as numpy array, since it may return a `list` otherwise.