### PR TITLE
Load nexus time offsets

### DIFF
--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -197,7 +197,7 @@ class LoadFromHdf5:
 
     @staticmethod
     def get_attribute(node: Union[h5py.Group, h5py.Dataset],
-                             attribute_name: str) -> Any:
+                      attribute_name: str) -> Any:
         try:
             return node.attrs[attribute_name]
         except KeyError:

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -196,6 +196,14 @@ class LoadFromHdf5:
             raise MissingAttribute
 
     @staticmethod
+    def get_attribute(node: Union[h5py.Group, h5py.Dataset],
+                             attribute_name: str) -> Any:
+        try:
+            return node.attrs[attribute_name]
+        except KeyError:
+            raise MissingAttribute
+
+    @staticmethod
     def get_string_attribute(node: Union[h5py.Group, h5py.Dataset],
                              attribute_name: str) -> str:
         try:

--- a/python/src/scippneutron/file_loading/_json_nexus.py
+++ b/python/src/scippneutron/file_loading/_json_nexus.py
@@ -305,6 +305,11 @@ class LoadFromJson:
         return np.array(attribute_value)
 
     @staticmethod
+    def get_attribute(node: Dict, attribute_name: str) -> Any:
+        attribute_value = _get_attribute_value(node, attribute_name)
+        return attribute_value
+
+    @staticmethod
     def get_string_attribute(node: Dict, attribute_name: str) -> str:
         attribute_value = _get_attribute_value(node, attribute_name)
         return attribute_value

--- a/python/src/scippneutron/file_loading/_json_nexus.py
+++ b/python/src/scippneutron/file_loading/_json_nexus.py
@@ -306,13 +306,11 @@ class LoadFromJson:
 
     @staticmethod
     def get_attribute(node: Dict, attribute_name: str) -> Any:
-        attribute_value = _get_attribute_value(node, attribute_name)
-        return attribute_value
+        return _get_attribute_value(node, attribute_name)
 
     @staticmethod
     def get_string_attribute(node: Dict, attribute_name: str) -> str:
-        attribute_value = _get_attribute_value(node, attribute_name)
-        return attribute_value
+        return _get_attribute_value(node, attribute_name)
 
     @staticmethod
     def is_group(node: Any):

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -146,13 +146,13 @@ def _load_log_data_from_group(group: Group, nexus: LoadFromNexus,
         time_dataset = group.group.get(time_dataset_name)
         try:
             log_start_time = nexus.get_string_attribute(time_dataset, "start")
-        except MissingAttribute:
+        except (MissingAttribute, TypeError):
             log_start_time = None
 
         try:
             scaling_factor = nexus.get_attribute(time_dataset,
                                                  "scaling_factor")
-        except MissingAttribute:
+        except (MissingAttribute, TypeError):
             scaling_factor = None
 
         times = _correct_nxlog_times(raw_times=raw_times,

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -5,17 +5,19 @@
 import numpy as np
 from typing import Tuple, List, Union
 import scipp as sc
-from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group)
+from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute,
+                      Group)
 from ._nexus import LoadFromNexus, ScippData
 from warnings import warn
 from dateutil.parser import parse as parse_date
 
 
 def load_logs(loaded_data: ScippData, log_groups: List[Group],
-              nexus: LoadFromNexus):
+              nexus: LoadFromNexus, run_start_time: str):
     for group in log_groups:
         try:
-            log_data_name, log_data = _load_log_data_from_group(group, nexus)
+            log_data_name, log_data = _load_log_data_from_group(
+                group, nexus, run_start_time)
             _add_log_to_data(log_data_name, log_data, group.path, loaded_data)
         except BadSource as e:
             warn(f"Skipped loading {group.path} due to:\n{e}")
@@ -23,41 +25,50 @@ def load_logs(loaded_data: ScippData, log_groups: List[Group],
             pass  # skip without warning user
 
 
-def _correct_nxlog_times(raw_times: sc.Variable,
-                         run_start: str = None,
-                         log_start: str = None,
-                         scaling_factor: Union[float, np.float_] = None) -> sc.Variable:
+def _correct_nxlog_times(
+        raw_times: sc.Variable,
+        run_start: str = None,
+        log_start: str = None,
+        scaling_factor: Union[float, np.float_] = None) -> sc.Variable:
     """
-    The nexus standard allows an arbitrary scaling factor to be inserted between the
-    numbers in the `time` series and the unit of time reported in the nexus attribute.
+    The nexus standard allows an arbitrary scaling factor to be inserted
+    between the numbers in the `time` series and the unit of time reported
+    in the nexus attribute.
 
-    The times are also relative to a given start time, which might be different for all
-    logs.
+    The times are also relative to a given log start time, which might be
+    different for each log.
 
-    This method implements these corrections and returns a variable with time data
-    relative to the provided run start time.
+    This method implements these corrections and returns a variable with
+    time data relative to the provided run start time.
 
     See https://manual.nexusformat.org/classes/base_classes/NXlog.html
 
     Args:
         raw_times: The raw time data from a nexus file.
-        run_start: Optional, the start time of the run in an ISO8601 string. If not
-            provided defaults to the beginning of the unix epoch (1970-01-01T00:00:00Z).
-        log_start: Optional, the start time of the log in an ISO8601 string. If not
-            provided defaults to the beginning of the unix epoch (1970-01-01T00:00:00Z).
-        scaling_factor: Optional, the start time of the log in an ISO8601 string. If
-            not provided, defaults to 1 (a no-op scaling factor).
+        run_start: Optional, the start time of the run in an ISO8601
+            string. If not provided, defaults to the beginning of the
+            unix epoch (1970-01-01T00:00:00Z).
+        log_start: Optional, the start time of the log in an ISO8601
+            string. If not provided, defaults to the beginning of the
+            unix epoch (1970-01-01T00:00:00Z).
+        scaling_factor: Optional, the start time of the log in an
+            ISO8601 string. If not provided, defaults to 1
+            (a no-op scaling factor).
     """
-    _log_start_ts = sc.scalar(
-        value=parse_date(log_start).timestamp() if log_start is not None else 0.,
-        unit=sc.units.s, dtype=sc.dtype.float64)
+    _log_start_ts = sc.scalar(value=parse_date(log_start).timestamp()
+                              if log_start is not None else 0.,
+                              unit=sc.units.s,
+                              dtype=sc.dtype.float64)
 
-    _run_start_ts = sc.scalar(
-        value=parse_date(run_start).timestamp() if run_start is not None else 0.,
-        unit=sc.units.s, dtype=sc.dtype.float64)
+    _run_start_ts = sc.scalar(value=parse_date(run_start).timestamp()
+                              if run_start is not None else 0.,
+                              unit=sc.units.s,
+                              dtype=sc.dtype.float64)
 
-    _scale = sc.scalar(value=scaling_factor if scaling_factor is not None else 1.,
-                       unit=sc.units.dimensionless, dtype=sc.dtype.float64)
+    _scale = sc.scalar(
+        value=scaling_factor if scaling_factor is not None else 1.,
+        unit=sc.units.dimensionless,
+        dtype=sc.dtype.float64)
 
     return (raw_times * _scale) + (_log_start_ts - _run_start_ts)
 
@@ -92,15 +103,11 @@ def _add_log_to_data(log_data_name: str, log_data: sc.Variable,
              f"{log_data_name} used as attribute name.")
 
 
-def _load_log_data_from_group(group: Group,
-                              nexus: LoadFromNexus) -> Tuple[str, sc.Variable]:
+def _load_log_data_from_group(group: Group, nexus: LoadFromNexus,
+                              run_start_time: str) -> Tuple[str, sc.Variable]:
     property_name = nexus.get_name(group.group)
     value_dataset_name = "value"
     time_dataset_name = "time"
-
-    run_start_time = nexus.load_scalar_string(group.group.parent.parent, "start_time")
-    run_start_time = nexus.load()
-    print(f"run start time: {run_start_time}")
 
     try:
         values = nexus.load_dataset_from_group_as_numpy_array(
@@ -127,20 +134,22 @@ def _load_log_data_from_group(group: Group,
         dimension_label = "time"
         is_time_series = True
         raw_times = nexus.load_dataset(group.group, time_dataset_name,
-                                   [dimension_label])
+                                       [dimension_label])
 
         time_dataset = group.group.get(time_dataset_name)
         try:
-            start = nexus.get_string_attribute(time_dataset, "start")
+            log_start_time = nexus.get_string_attribute(time_dataset, "start")
         except MissingAttribute:
-            start = None
+            log_start_time = None
 
         try:
-            scaling_factor = nexus.get_attribute(time_dataset, "scaling_factor")
+            scaling_factor = nexus.get_attribute(time_dataset,
+                                                 "scaling_factor")
         except MissingAttribute:
             scaling_factor = None
 
-        times = _correct_nxlog_times(raw_times=raw_times, log_start=start,
+        times = _correct_nxlog_times(raw_times=raw_times,
+                                     log_start=log_start_time,
                                      scaling_factor=scaling_factor,
                                      run_start=run_start_time)
 

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -55,6 +55,13 @@ def _correct_nxlog_times(
             ISO8601 string. If not provided, defaults to 1
             (a no-op scaling factor).
     """
+    try:
+        sc.to_unit(raw_times, sc.units.s)
+    except sc.UnitError:
+        raise BadSource(
+            "The units of time in an NXlog entry must be convertible to "
+            f"seconds, not '{raw_times.unit}'.")
+
     _log_start_ts = sc.scalar(value=parse_date(log_start).timestamp()
                               if log_start is not None else 0.,
                               unit=sc.units.s,

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -143,7 +143,8 @@ def _load_log_data_from_group(group: Group, nexus: LoadFromNexus,
         raw_times = nexus.load_dataset(group.group, time_dataset_name,
                                        [dimension_label])
 
-        time_dataset = group.group.get(time_dataset_name)
+        time_dataset = nexus.get_dataset_from_group(group.group,
+                                                    time_dataset_name)
         try:
             log_start_time = nexus.get_string_attribute(time_dataset, "start")
         except (MissingAttribute, TypeError):

--- a/python/src/scippneutron/file_loading/load_nexus.py
+++ b/python/src/scippneutron/file_loading/load_nexus.py
@@ -161,7 +161,7 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
         try:
             run_start_time = nexus.load_scalar_string(
                 groups[nx_entry][0].group, "start_time")
-        except (AttributeError, MissingDataset):
+        except (AttributeError, TypeError, MissingDataset):
             run_start_time = None
     else:
         run_start_time = None

--- a/python/src/scippneutron/file_loading/load_nexus.py
+++ b/python/src/scippneutron/file_loading/load_nexus.py
@@ -87,6 +87,14 @@ def _load_title(entry_group: Group, data: ScippData, nexus: LoadFromNexus):
                                     "experiment_title", data, nexus)
 
 
+def _load_start_and_end_time(entry_group: Group, data: ScippData,
+                             nexus: LoadFromNexus):
+    _add_string_attr_to_loaded_data(entry_group.group, "start_time",
+                                    "start_time", data, nexus)
+    _add_string_attr_to_loaded_data(entry_group.group, "end_time", "end_time",
+                                    data, nexus)
+
+
 def load_nexus(data_file: Union[str, h5py.File],
                root: str = "/",
                quiet=True) -> Optional[ScippData]:
@@ -145,15 +153,30 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
         loaded_data = sc.Dataset({})
     else:
         no_event_data = False
-    load_logs(loaded_data, groups[nx_log], nexus)
+
+    if groups[nx_entry]:
+        _load_title(groups[nx_entry][0], loaded_data, nexus)
+        _load_start_and_end_time(groups[nx_entry][0], loaded_data, nexus)
+
+        try:
+            run_start_time = nexus.load_scalar_string(
+                groups[nx_entry][0].group, "start_time")
+        except (AttributeError, MissingDataset):
+            run_start_time = None
+    else:
+        run_start_time = None
+
+    load_logs(loaded_data,
+              groups[nx_log],
+              nexus,
+              run_start_time=run_start_time)
+
     if groups[nx_sample]:
         _load_sample(groups[nx_sample], loaded_data, nexus_file, nexus)
     if groups[nx_source]:
         _load_source(groups[nx_source], loaded_data, nexus_file, nexus)
     if groups[nx_instrument]:
         _load_instrument_name(groups[nx_instrument], loaded_data, nexus)
-    if groups[nx_entry]:
-        _load_title(groups[nx_entry][0], loaded_data, nexus)
     # Return None if we have an empty dataset at this point
     if no_event_data and not loaded_data.keys():
         loaded_data = None

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -45,7 +45,12 @@ class Log:
     value: Optional[np.ndarray]
     time: Optional[np.ndarray] = None
     value_units: Optional[str] = None
-    time_units: Optional[str] = None
+
+    # From
+    # https://manual.nexusformat.org/classes/base_classes/NXlog.html?highlight=nxlog
+    # time units are non-optional if time series data is present, and the unit
+    # must be a unit of time (i.e. convertible to seconds).
+    time_units: Optional[str] = "s"
 
 
 class TransformationType(Enum):

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -368,10 +368,10 @@ class NexusBuilder:
     def add_title(self, title: str):
         self._title = title
 
-    def add_start_time(self, start_time: str):
+    def add_run_start_time(self, start_time: str):
         self._start_time = start_time
 
-    def add_end_time(self, end_time: str):
+    def add_run_end_time(self, end_time: str):
         self._end_time = end_time
 
     def add_sample(self, sample: Sample):

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -262,6 +262,10 @@ class JsonWriter:
     def add_attribute(parent: Dict, name: str, value: Union[str, np.ndarray]):
         if isinstance(value, str):
             attr_info = {"string_size": len(value), "type": "string"}
+        elif isinstance(value, float):
+            attr_info = {"size": 1, "type": "float64"}
+        elif isinstance(value, int):
+            attr_info = {"size": 1, "type": "int64"}
         else:
             attr_info = {
                 "size": value.shape,

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -52,6 +52,9 @@ class Log:
     # must be a unit of time (i.e. convertible to seconds).
     time_units: Optional[str] = "s"
 
+    start_time: Optional[str] = None
+    scaling_factor: Optional[float] = None
+
 
 class TransformationType(Enum):
     TRANSLATION = "translation"
@@ -324,6 +327,8 @@ class NexusBuilder:
         self._logs: List[Log] = []
         self._instrument_name: Optional[str] = None
         self._title: Optional[str] = None
+        self._start_time: Optional[str] = None
+        self._end_time: Optional[str] = None
         self._sample: List[Sample] = []
         self._source: List[Source] = []
         self._hard_links: List[Link] = []
@@ -358,6 +363,12 @@ class NexusBuilder:
 
     def add_title(self, title: str):
         self._title = title
+
+    def add_start_time(self, start_time: str):
+        self._start_time = start_time
+
+    def add_end_time(self, end_time: str):
+        self._end_time = end_time
 
     def add_sample(self, sample: Sample):
         self._sample.append(sample)
@@ -425,6 +436,14 @@ class NexusBuilder:
         entry_group = self._create_nx_class("entry", "NXentry", nexus_file)
         if self._title is not None:
             self._writer.add_dataset(entry_group, "title", data=self._title)
+        if self._start_time is not None:
+            self._writer.add_dataset(entry_group,
+                                     "start_time",
+                                     data=self._start_time)
+        if self._end_time is not None:
+            self._writer.add_dataset(entry_group,
+                                     "end_time",
+                                     data=self._end_time)
         self._write_event_data(entry_group)
         self._write_logs(entry_group)
         self._write_sample(entry_group)
@@ -617,6 +636,11 @@ class NexusBuilder:
                                                data=log.time)
             if log.time_units is not None:
                 self._writer.add_attribute(time_ds, "units", log.time_units)
+            if log.start_time is not None:
+                self._writer.add_attribute(time_ds, "start", log.start_time)
+            if log.scaling_factor is not None:
+                self._writer.add_attribute(time_ds, "scaling_factor",
+                                           log.scaling_factor)
         return log_group
 
     def _add_transformation_as_log(self, transform: Transformation,


### PR DESCRIPTION
Add corrections of `NXLog` timestamps:
- Convert all times to be relative to start of run
  * In the case where start of run = start of log timestamp this is a no-op, but this is not necessarily the case
- Implement corrections for logged times with a scaling factor, which needs to be applied to times before arriving at the units of time specified in `NXLog @units`
- Add test cases for `units != s` in the NXLog entry - they will get converted to s as part of loading.

Closes https://github.com/scipp/scippneutron/issues/20