### PR TITLE
Fix iter compilation error against Scipp main

### DIFF
--- a/neutron/convert.cpp
+++ b/neutron/convert.cpp
@@ -26,6 +26,14 @@ using namespace scipp::dataset;
 namespace scipp::neutron {
 
 namespace {
+
+template <class T> static decltype(auto) iter(T &d) {
+  if constexpr (std::is_same_v<T, Dataset>)
+    return d;
+  else
+    return d.iterable_view();
+}
+
 // Iterable facade around a single object
 template <class T> class IterableFacade {
 public:


### PR DESCRIPTION
The `iter` helper class was removed from Scipp, we copy it back in `convert.cpp` that uses it.

This is temporary since `convert.cpp` will change to using `transform_coords`, but it allows to compile scippneutron until these changes have been finalised.