### PR TITLE
Add source/sample components to the instrument view

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python {{ python }}
     - scipp {{ scipp }}
     - h5py
+    - scipy
 
 test:
   imports:

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -31,6 +31,7 @@ Features
 
 * ``convert`` new returns data arrays with a new coordinate array (for the converted dimension), but data and unrelated meta data is not deep-copied.
   This should improve performance in a number of cases.
+* ``instrument_view`` can show the positions of non-detector components such as choppers, and the sample on the beamline.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -57,7 +57,7 @@ def get_abs_path(path, root):
 
 if __name__ == '__main__':
 
-    args = parser.parse_args()
+    args = parser.parse_known_args()
 
     docs_dir = Path(__file__).parent.absolute()
     work_dir = get_abs_path(path=args.work_dir, root=docs_dir)

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
-# @author Neil Vaytet
+# @author Neil Vaytet and Owen Arnold
 
 import numpy as np
 import pythreejs as p3
@@ -50,9 +50,9 @@ def _find_beam(det_com, pos):
 
 
 def _alignment_matrix(to_align, target):
-    rotaxis = np.cross(to_align, target)
+    rot_axis = np.cross(to_align, target)
     magnitude = np.linalg.norm(to_align) * np.linalg.norm(target)
-    axis_angle = np.arcsin(rotaxis / magnitude)
+    axis_angle = np.arcsin(rot_axis / magnitude)
     return Rot.from_rotvec(axis_angle).as_matrix()
 
 
@@ -151,7 +151,8 @@ def _plot_components(scipp_obj, additional, positions_var, scene):
                       det_center=det_center)
     # Reset camera
     camera = _get_camera(scene)
-    camera.far = furthest_distance * 5.0
+    if camera:
+        camera.far = furthest_distance * 5.0
 
 
 def _get_camera(scene):

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -136,7 +136,7 @@ def _plot_components(scipp_obj, additional, positions_var, scene):
     # Some scaling to set width according to distance from detector center
     scaling_factor = 1 / 10.0
     width = furthest_distance * scaling_factor
-    shapes = {"cube": _box, "cylinder": _cylinder, "disk": _disk_chopper}
+    shapes = {"sample": _box, "source": _cylinder, "chopper": _disk_chopper}
     for item, type in additional.items():
         if type not in shapes:
             supported_shapes = ", ".join(shapes.keys())

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -154,7 +154,8 @@ def instrument_view(scipp_obj=None,
                **kwargs)
 
     # Add additional components from the beamline
-    if plot_non_pixels:
+    # TODO solve hasattr fix
+    if plot_non_pixels and hasattr(plot, 'view'):
         scene = plt.view.figure.scene
         z = _add_beamline(scipp_obj, positions_var, scene)
         # Reset camera

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -136,7 +136,7 @@ def _plot_components(scipp_obj, additional, positions_var, scene):
     # Some scaling to set width according to distance from detector center
     scaling_factor = 1 / 10.0
     width = furthest_distance * scaling_factor
-    shapes = {"sample": _box, "source": _cylinder, "chopper": _disk_chopper}
+    shapes = {"cube": _box, "cylinder": _cylinder, "disk": _disk_chopper}
     for item, type in additional.items():
         if type not in shapes:
             supported_shapes = ", ".join(shapes.keys())

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -205,7 +205,7 @@ def instrument_view(scipp_obj=None,
                **kwargs)
 
     # Add additional components from the beamline
-    if components and not isinstance(plot, PlotDict):
+    if components and not isinstance(plt, PlotDict):
         scene = plt.view.figure.scene
         _plot_components(scipp_obj, components, positions_var, scene)
 

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -129,7 +129,7 @@ def _furthest_component(det_center, scipp_obj, additional):
     return item, max_displacement
 
 
-def _plot_additional(scipp_obj, additional, positions_var, scene):
+def _plot_components(scipp_obj, additional, positions_var, scene):
     det_center = sc.mean(positions_var)
     furthest_key, furthest_distance = _furthest_component(det_center, scipp_obj,
                                                           additional)
@@ -149,12 +149,13 @@ def _plot_additional(scipp_obj, additional, positions_var, scene):
                       display_text=item,
                       bounding_box=([width] * 3),
                       det_center=det_center)
+    # Reset camera
+    camera = _get_camera(scene)
+    camera.far = furthest_distance * 5.0
 
-    return furthest_distance * 5.0
 
-
-def _get_camera(plt):
-    for child in plt.view.figure.scene.children:
+def _get_camera(scene):
+    for child in scene.children:
         if isinstance(child, p3.PerspectiveCamera):
             return child
     return None
@@ -205,10 +206,6 @@ def instrument_view(scipp_obj=None,
     # Add additional components from the beamline
     if components and not isinstance(plot, PlotDict):
         scene = plt.view.figure.scene
-        z = _plot_additional(scipp_obj, components, positions_var, scene)
-        # Reset camera
-        if z:
-            camera = _get_camera(plt)
-            camera.far = z * 5.0
+        _plot_components(scipp_obj, components, positions_var, scene)
 
     return plt

--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -3,10 +3,101 @@
 # @author Neil Vaytet
 
 import numpy as np
+import pythreejs as p3
 
 
-def instrument_view(scipp_obj=None, positions="position", pixel_size=None, **kwargs):
+def _cube(position, message, sz, color):
+    geometry = p3.BoxGeometry(width=sz[0],
+                              height=sz[1],
+                              depth=sz[2],
+                              widthSegments=2,
+                              heightSegments=2,
+                              depthSegments=2)
+
+    material = p3.MeshBasicMaterial(color=color)
+    mesh = p3.Mesh(geometry=geometry, material=material)
+    mesh.position = position
+    text_position = (position[0], position[1] + sz[1], position[2])
+    text_mesh = _text_mesh(text_position, message, x_width=sz[0], y_width=sz[1])
+    return mesh, text_mesh
+
+
+def _text_mesh(position, message, x_width, y_width):
+    text_geometry = p3.PlaneGeometry(width=x_width,
+                                     height=y_width,
+                                     widthSegments=2,
+                                     heightSegments=2)
+
+    text = p3.TextTexture(string=message, color='black', size=20)
+    text_material = p3.MeshBasicMaterial(map=text, transparent=True)
+    text_mesh = p3.Mesh(geometry=text_geometry, material=text_material)
+    text_mesh.position = position
+    return text_mesh
+
+
+def _cylinder(position, message, sz, color):
+    geometry = p3.CylinderGeometry(radiusTop=sz[0] / 2,
+                                   radiusBottom=sz[0] / 2,
+                                   height=sz[1],
+                                   radialSegments=12,
+                                   heightSegments=12,
+                                   openEnded=False,
+                                   thetaStart=0,
+                                   thetaLength=2.0 * np.pi)
+
+    material = p3.MeshBasicMaterial(color=color)
+    mesh = p3.Mesh(geometry=geometry, material=material)
+    mesh.position = position
+    # Position label above cylinder
+    text_position = (position[0], position[1] + sz[1], position[2])
+    text_mesh = _text_mesh(text_position, message=message, x_width=sz[0], y_width=sz[1])
+    return mesh, text_mesh
+
+
+def _unpack_to_scene(scene, items):
+    if hasattr(items, "__iter__"):
+        for item in items:
+            scene.add(item)
+    else:
+        scene.add(items)
+
+
+def _add_source(position, scene, sz=(1, 1, 1)):
+    _unpack_to_scene(scene, _cylinder(position,
+                                      message="source",
+                                      sz=sz,
+                                      color="#808080"))
+
+
+def _add_sample(position, scene, sz=(1, 1, 1)):
+    _unpack_to_scene(scene, _cube(position, message="sample", sz=sz, color="#808080"))
+
+
+def _add_beamline(scipp_obj, scene):
+    # TODO calculate sizes
+
+    if "source_position" in scipp_obj.meta:
+        _add_source(tuple(scipp_obj.meta["source_position"].value), scene, sz=(1, 1, 1))
+    if "sample_position" in scipp_obj.meta:
+        _add_sample(tuple(scipp_obj.meta["sample_position"].value),
+                    scene,
+                    sz=(0.5, 0.5, 0.5))
+    # TODO reset camera far field
+
+
+def instrument_view(scipp_obj=None,
+                    positions="position",
+                    pixel_size=None,
+                    plot_non_pixels=True,
+                    **kwargs):
     """
+    :param scipp_obj: scipp object holding geometries
+    :param positions: Key for coord/attr holding positions to use for pixels
+    :param pixel_size: Custom pixel size to use for detector pixels
+    :param plot_non_pixels: If True render other known beamline components.
+    :param kwargs: Additional keyword arguments to pass to scipp.plotting.plot
+    :return: The 3D plot object
+
     Plot a 3D view of the instrument, using the `position` coordinate as the
     detector vector positions.
     Use the `positions` argument to change the vectors used as pixel positions.
@@ -27,8 +118,15 @@ def instrument_view(scipp_obj=None, positions="position", pixel_size=None, **kwa
         if len(pos_array) > 1:
             pixel_size = np.linalg.norm(pos_array[1] - pos_array[0])
 
-    return plot(scipp_obj,
-                projection="3d",
-                positions=positions,
-                pixel_size=pixel_size,
-                **kwargs)
+    plt = plot(scipp_obj,
+               projection="3d",
+               positions=positions,
+               pixel_size=pixel_size,
+               **kwargs)
+
+    # Add additional components from the beamline
+    if plot_non_pixels:
+        scene = plt.view.figure.scene
+        _add_beamline(scipp_obj, scene)
+
+    return plt

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -32,6 +32,7 @@ dependencies:
   - h5py
   - python-confluent-kafka
   - ess-dmsc::ess-streaming-data-types
+  - scipy
 
   # Test
   - psutil


### PR DESCRIPTION
Fixes #23

Basically `instrument_view` will take a dictionary called `components`, which maps the name of something considered "meta" (such that we can establish its position - sc.vector) to one of a bunch of known shapes. shape names are mapped to drawing functions which take care of scaling and orienting the shapes depending upon the beam direction and overall component distribution (distances)

Code in `ess` will allow us to forward these dictionaries on an instrument by instrument basis. One could imaging having a `odin.instrument_view`, which would internally provide the full `components` dictionary.