### PR TITLE
Turn off mantid logging to prevent it from appearing in the docs

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -69,7 +69,8 @@ if __name__ == '__main__':
     extensions = [".nxs", ".h5", ".hdf5", ".raw"]
     download_multiple(remote_url, data_dir, extensions)
 
-    # Create Mantid properties file so that it can find the data files
+    # Create Mantid properties file so that it can find the data files.
+    # Also turn off the logging so that it doesn't appear in the docs.
     home = str(Path.home())
     config_dir = os.path.join(home, ".mantid")
     make_dir(config_dir)
@@ -77,6 +78,7 @@ if __name__ == '__main__':
     with open(properties_file, "a") as f:
         f.write(
             "\nusagereports.enabled=0\ndatasearch.directories={}\n".format(data_dir))
+        f.write("\nlogging.loggers.root.level=error\n")
 
     # Build the docs with sphinx-build
     status = subprocess.check_call(


### PR DESCRIPTION
Output is gone from docs.

Before:
![Screenshot at 2021-08-20 18-59-24](https://user-images.githubusercontent.com/39047984/130268323-645ad33a-60b9-4b74-ad65-8b89df4b7ab9.png)

After:
![Screenshot at 2021-08-20 18-59-30](https://user-images.githubusercontent.com/39047984/130268334-707072db-0db0-4843-980f-999b2e9a8227.png)
