### PR TITLE
Fix units encoding error

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -39,6 +39,7 @@ Bugfixes
   Duplicate named detectors (including monitors) will have unique names created by concatenating the name with the spectrum number for that detector.
   This fixes a bug with monitors where previously, duplicate entries encoutered after the first were rejected from the output metadata.
   In the case of instruments such as POLARIS, all monitors will now be translated.
+* ``load_nexus`` will no longer fail to load nexus files containing strings with non-ascii characters, for example a log with units of '°'.
 
 Contributors
 ~~~~~~~~~~~~

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -1,28 +1,54 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Jones
+import warnings
 
 from typing import Union, Any, List, Optional, Tuple, Dict
 
 import h5py
+import h5py.h5a
+import h5py.h5t
 import numpy as np
 import scipp as sc
 from ._common import Group, MissingDataset, MissingAttribute
 
 
 def _get_attr_as_str(h5_object, attribute_name: str):
-    try:
-        return h5_object.attrs[attribute_name].decode("utf8")
-    except AttributeError:
-        return h5_object.attrs[attribute_name]
+    return _ensure_str(h5_object.attrs[attribute_name],
+                       LoadFromHdf5.get_string_encoding(h5_object, attribute_name))
 
 
-def _ensure_str(str_or_bytes: Union[str, bytes]) -> str:
-    try:
-        str_or_bytes = str(str_or_bytes, encoding="utf8")  # type: ignore
-    except TypeError:
-        pass
-    return str_or_bytes
+def _ensure_str(str_or_bytes: Union[str, bytes], encoding: str) -> str:
+    """
+    See https://docs.h5py.org/en/stable/strings.html for justification about some of
+    the operations performed in this method. In particular, variable-length strings
+    are returned as `str` from h5py, but need to be encoded using the surrogateescape
+    error handler and then decoded using the encoding specified in the nexus file in
+    order to get a correctly encoded string in all cases.
+
+    Note also that the nexus standard leaves unspecified the behaviour of H5T_CSET_ASCII
+    for characters >=128. Common extensions are the latin-1 ("extended ascii") character
+    set which appear to be used in nexus files from some facilities. Attempt to load
+    these strings with the latin-1 extended character set, but warn as this is
+    technically unspecified behaviour.
+    """
+    if isinstance(str_or_bytes, str):
+        str_or_bytes = str_or_bytes.encode('utf-8', 'surrogateescape')
+
+    if encoding == "ascii":
+        try:
+            return str(str_or_bytes, encoding="ascii")
+        except UnicodeDecodeError as e:
+            decoded = str(str_or_bytes, encoding="latin-1")
+            warnings.warn(f"Encoding for bytes '{str_or_bytes}' declared as ascii, "
+                          f"but contains characters in extended ascii range. Assuming "
+                          f"extended ASCII (latin-1), but this behaviour is not "
+                          f"specified by the HDF5 or nexus standards and may therefore "
+                          f"be incorrect. Decoded string using latin-1 is '{decoded}'. "
+                          f"Error was '{str(e)}'.")
+            return decoded
+    else:
+        return str(str_or_bytes, encoding)
 
 
 _map_to_supported_type = {
@@ -152,7 +178,7 @@ class LoadFromHdf5:
             units = node.attrs["units"]
         except (AttributeError, KeyError):
             return "dimensionless"
-        return _ensure_str(units)
+        return _ensure_str(units, LoadFromHdf5.get_string_encoding(node, "units"))
 
     @staticmethod
     def get_child_from_group(group: Dict,
@@ -172,9 +198,25 @@ class LoadFromHdf5:
     @staticmethod
     def load_scalar_string(group: h5py.Group, dataset_name: str) -> str:
         try:
-            return _ensure_str(group[dataset_name][...].item())
+            return _ensure_str(group[dataset_name][...].item(),
+                               LoadFromHdf5.get_string_encoding(group, dataset_name))
         except KeyError:
             raise MissingDataset
+
+    @staticmethod
+    def get_string_encoding(group: h5py.Group, dataset_name: str):
+        cset = h5py.h5a.get_info(group.id, dataset_name.encode("ascii")).cset
+
+        if cset == h5py.h5t.CSET_ASCII:
+            return "ascii"
+        elif cset == h5py.h5t.CSET_UTF8:
+            return "utf-8"
+        else:
+            warnings.warn(f"Unknown character set in HDF5 data file. Expected data "
+                          f"types are {h5py.h5t.CSET_ASCII} (H5T_CSET_ASCII) or "
+                          f"{h5py.h5t.CSET_UTF8} (H5T_CSET_UTF8) but got '{cset}'. "
+                          f"Assuming data is UTF-8 encoded but this may be incorrect.")
+            return "utf-8"
 
     @staticmethod
     def get_object_by_path(group: Union[h5py.Group, h5py.File],
@@ -204,7 +246,8 @@ class LoadFromHdf5:
     def get_string_attribute(node: Union[h5py.Group, h5py.Dataset],
                              attribute_name: str) -> str:
         try:
-            return _ensure_str(node.attrs[attribute_name])
+            return _ensure_str(node.attrs[attribute_name],
+                               LoadFromHdf5.get_string_encoding(node, attribute_name))
         except KeyError:
             raise MissingAttribute
 

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -11,7 +11,18 @@ import scipp as sc
 from ._common import Group, MissingDataset, MissingAttribute
 
 
-def cset_to_encoding(cset: int):
+def _cset_to_encoding(cset: int) -> str:
+    """
+    Converts a HDF5 cset into a python encoding. Allowed values for cset are
+    h5py.h5t.CSET_ASCII and h5py.h5t.CSET_UTF8.
+
+    Args:
+        cset: The HDF character set to convert
+
+    Returns:
+        A string describing the encoding suitable for calls to str(encoding=...)
+        Either "ascii" or "utf-8".
+    """
     if cset == h5py.h5t.CSET_ASCII:
         return "ascii"
     elif cset == h5py.h5t.CSET_UTF8:
@@ -24,7 +35,7 @@ def cset_to_encoding(cset: int):
         return "utf-8"
 
 
-def _get_attr_as_str(h5_object, attribute_name: str):
+def _get_attr_as_str(h5_object, attribute_name: str) -> str:
     return _ensure_str(h5_object.attrs[attribute_name],
                        LoadFromHdf5.get_attr_encoding(h5_object, attribute_name))
 
@@ -37,11 +48,11 @@ def _ensure_str(str_or_bytes: Union[str, bytes], encoding: str) -> str:
     error handler and then decoded using the encoding specified in the nexus file in
     order to get a correctly encoded string in all cases.
 
-    Note that the nexus standard leaves unspecified the behaviour of H5T_CSET_ASCII
+    Note that the nexus standard leaves unspecified the behavior of H5T_CSET_ASCII
     for characters >=128. Common extensions are the latin-1 ("extended ascii") character
     set which appear to be used in nexus files from some facilities. Attempt to load
     these strings with the latin-1 extended character set, but warn as this is
-    technically unspecified behaviour.
+    technically unspecified behavior.
     """
     if isinstance(str_or_bytes, str):
         str_or_bytes = str_or_bytes.encode("utf-8", errors="surrogateescape")
@@ -53,7 +64,7 @@ def _ensure_str(str_or_bytes: Union[str, bytes], encoding: str) -> str:
             decoded = str(str_or_bytes, encoding="latin-1")
             warnings.warn(f"Encoding for bytes '{str_or_bytes}' declared as ascii, "
                           f"but contains characters in extended ascii range. Assuming "
-                          f"extended ASCII (latin-1), but this behaviour is not "
+                          f"extended ASCII (latin-1), but this behavior is not "
                           f"specified by the HDF5 or nexus standards and may therefore "
                           f"be incorrect. Decoded string using latin-1 is '{decoded}'. "
                           f"Error was '{str(e)}'.")
@@ -215,13 +226,13 @@ class LoadFromHdf5:
 
         cset = h5py.h5d.open(group.id,
                              dataset_name.encode("utf-8")).get_type().get_cset()
-        return _ensure_str(val, cset_to_encoding(cset))
+        return _ensure_str(val, _cset_to_encoding(cset))
 
     @staticmethod
-    def get_attr_encoding(group: h5py.Group, dataset_name: str):
+    def get_attr_encoding(group: h5py.Group, dataset_name: str) -> str:
         cset = h5py.h5a.open(group.id,
                              dataset_name.encode("utf-8")).get_type().get_cset()
-        return cset_to_encoding(cset)
+        return _cset_to_encoding(cset)
 
     @staticmethod
     def get_object_by_path(group: Union[h5py.Group, h5py.File],

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -28,11 +28,9 @@ def _cset_to_encoding(cset: int) -> str:
     elif cset == h5py.h5t.CSET_UTF8:
         return "utf-8"
     else:
-        warnings.warn(f"Unknown character set in HDF5 data file. Expected data "
-                      f"types are {h5py.h5t.CSET_ASCII} (H5T_CSET_ASCII) or "
-                      f"{h5py.h5t.CSET_UTF8} (H5T_CSET_UTF8) but got '{cset}'. "
-                      f"Assuming data is UTF-8 encoded but this may be incorrect.")
-        return "utf-8"
+        raise ValueError(f"Unknown character set in HDF5 data file. Expected data "
+                         f"types are {h5py.h5t.CSET_ASCII} (H5T_CSET_ASCII) or "
+                         f"{h5py.h5t.CSET_UTF8} (H5T_CSET_UTF8) but got '{cset}'. ")
 
 
 def _get_attr_as_str(h5_object, attribute_name: str) -> str:

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -36,9 +36,9 @@ class EventData:
     event_time_offset: Optional[np.ndarray]
     event_time_zero: Optional[np.ndarray]
     event_index: Optional[np.ndarray]
-    event_time_zero_unit: Optional[str] = "ns"
-    event_time_zero_offset: Optional[str] = "1970-01-01T00:00:00Z"
-    event_time_offset_unit: Optional[str] = "ns"
+    event_time_zero_unit: Optional[Union[str, bytes]] = "ns"
+    event_time_zero_offset: Optional[Union[str, bytes]] = "1970-01-01T00:00:00Z"
+    event_time_offset_unit: Optional[Union[str, bytes]] = "ns"
 
 
 @dataclass
@@ -46,15 +46,15 @@ class Log:
     name: str
     value: Optional[np.ndarray]
     time: Optional[np.ndarray] = None
-    value_units: Optional[str] = None
+    value_units: Optional[Union[str, bytes]] = None
 
     # From
     # https://manual.nexusformat.org/classes/base_classes/NXlog.html?highlight=nxlog
     # time units are non-optional if time series data is present, and the unit
     # must be a unit of time (i.e. convertible to seconds).
-    time_units: Optional[str] = "s"
+    time_units: Optional[Union[str, bytes]] = "s"
 
-    start_time: Optional[str] = None
+    start_time: Optional[Union[str, bytes]] = None
     scaling_factor: Optional[float] = None
 
 
@@ -71,8 +71,8 @@ class Transformation:
     time: Optional[np.ndarray] = None
     depends_on: Union["Transformation", str, None] = None
     offset: Optional[np.ndarray] = None
-    value_units: Optional[str] = None
-    time_units: Optional[str] = None
+    value_units: Optional[Union[str, bytes]] = None
+    time_units: Optional[Union[str, bytes]] = None
 
 
 @dataclass
@@ -83,7 +83,7 @@ class Detector:
     x_offsets: Optional[np.ndarray] = None
     y_offsets: Optional[np.ndarray] = None
     z_offsets: Optional[np.ndarray] = None
-    offsets_unit: Optional[str] = None
+    offsets_unit: Optional[Union[str, bytes]] = None
     depends_on: Optional[Transformation] = None
 
 
@@ -92,7 +92,7 @@ class Sample:
     name: str
     depends_on: Optional[Transformation] = None
     distance: Optional[float] = None
-    distance_units: Optional[str] = None
+    distance_units: Optional[Union[str, bytes]] = None
 
 
 @dataclass
@@ -100,7 +100,7 @@ class Source:
     name: str
     depends_on: Union[Transformation, None, str] = None
     distance: Optional[float] = None
-    distance_units: Optional[str] = None
+    distance_units: Optional[Union[str, bytes]] = None
 
 
 @dataclass
@@ -161,12 +161,12 @@ class InMemoryNeXusWriter:
 
     @staticmethod
     def add_dataset(parent: h5py.Group, name: str,
-                    data: Union[str, np.ndarray]) -> h5py.Dataset:
+                    data: Union[str, bytes, np.ndarray]) -> h5py.Dataset:
         return parent.create_dataset(name, data=data)
 
     @staticmethod
     def add_attribute(parent: Union[h5py.Group, h5py.Dataset], name: str,
-                      value: Union[str, np.ndarray]):
+                      value: Union[str, bytes, np.ndarray]):
         parent.attrs[name] = value
 
     @staticmethod
@@ -237,8 +237,9 @@ class JsonWriter:
             self.add_attribute(dataset, name, value)
 
     @staticmethod
-    def add_dataset(parent: Dict, name: str, data: Union[str, np.ndarray]) -> Dict:
-        if isinstance(data, str):
+    def add_dataset(parent: Dict, name: str, data: Union[str, bytes,
+                                                         np.ndarray]) -> Dict:
+        if isinstance(data, (str, bytes)):
             dataset_info = {"string_size": len(data), "type": "string"}
         elif isinstance(data, float):
             dataset_info = {"size": 1, "type": "float32"}
@@ -259,8 +260,8 @@ class JsonWriter:
         return new_dataset
 
     @staticmethod
-    def add_attribute(parent: Dict, name: str, value: Union[str, np.ndarray]):
-        if isinstance(value, str):
+    def add_attribute(parent: Dict, name: str, value: Union[str, bytes, np.ndarray]):
+        if isinstance(value, (str, bytes)):
             attr_info = {"string_size": len(value), "type": "string"}
         elif isinstance(value, float):
             attr_info = {"size": 1, "type": "float64"}
@@ -359,7 +360,7 @@ class NexusBuilder:
     def add_instrument(self, name: str):
         self._instrument_name = name
 
-    def add_title(self, title: str):
+    def add_title(self, title: str, encoding="utf-8"):
         self._title = title
 
     def add_run_start_time(self, start_time: str):

--- a/python/tests/nexus_helpers.py
+++ b/python/tests/nexus_helpers.py
@@ -360,7 +360,7 @@ class NexusBuilder:
     def add_instrument(self, name: str):
         self._instrument_name = name
 
-    def add_title(self, title: str, encoding="utf-8"):
+    def add_title(self, title: str):
         self._title = title
 
     def add_run_start_time(self, start_time: str):

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -18,6 +18,14 @@ from typing import List, Type, Union, Callable
 from scippneutron.file_loading.load_nexus import _load_nexus_json
 from dateutil.parser import parse as parse_date
 
+# representative sample of UTF-8 test strings from
+# https://www.w3.org/2001/06/utf-8-test/UTF-8-demo.html
+UTF8_TEST_STRINGS = (
+    "∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i), ∀x∈ℝ: ⌈x⌉ = −⌊−x⌋, α ∧ ¬β = ¬(¬α ∨ β)",
+    "2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 mm",
+    "Σὲ γνωρίζω ἀπὸ τὴν κόψη",
+)
+
 
 def _timestamp(date: str):
     return parse_date(date).timestamp()
@@ -1542,5 +1550,58 @@ def test_nexus_file_with_invalid_run_start_date_warns_and_skips_logs(
 
     with pytest.warns(UserWarning, match="The run start time "):
         loaded_data = load_function(builder)
-
         assert "test_log_1" not in loaded_data
+
+
+def test_extended_ascii_in_ascii_encoded_dataset(load_function: Callable):
+    if load_function == load_from_json:
+        pytest.skip("JSON serialiser can only serialize strings, not bytes.")
+
+    builder = NexusBuilder()
+    # When writing, if we use bytes h5py will write as ascii encoding
+    # 0xb0 = degrees symbol in latin-1 encoding.
+    builder.add_title(b"run at rot=90" + bytes([0xb0]))
+
+    with pytest.warns(UserWarning, match="contains characters in extended ascii range"):
+        loaded_data = load_function(builder)
+
+        assert sc.identical(loaded_data["experiment_title"],
+                            sc.DataArray(data=sc.scalar("run at rot=90°")))
+
+
+@pytest.mark.parametrize("test_string", UTF8_TEST_STRINGS)
+def test_utf8_encoded_dataset(load_function: Callable, test_string):
+    builder = NexusBuilder()
+    # When writing, if we use str h5py will write as utf8 encoding
+    builder.add_title(test_string)
+
+    loaded_data = load_function(builder)
+
+    assert sc.identical(loaded_data["experiment_title"],
+                        sc.DataArray(data=sc.scalar(test_string)))
+
+
+def test_extended_ascii_in_ascii_encoded_attribute(load_function: Callable):
+    if load_function == load_from_json:
+        pytest.skip("JSON serialiser can only serialize strings, not bytes.")
+
+    builder = NexusBuilder()
+    # When writing, if we use bytes h5py will write as ascii encoding
+    # 0xb0 = degrees symbol in latin-1 encoding.
+    builder.add_log(Log(name="testlog", value_units=bytes([0xb0]), value=np.array([0])))
+
+    with pytest.warns(UserWarning, match="contains characters in extended ascii range"):
+        loaded_data = load_function(builder)
+
+        assert loaded_data["testlog"].data.values.unit == sc.units.deg
+
+
+# Can't use UTF-8 test strings as above for this test as the units need to be valid.
+# Just do a single test with degrees.
+def test_utf8_encoded_attribute(load_function: Callable):
+    builder = NexusBuilder()
+    # When writing, if we use str h5py will write as utf8 encoding
+    builder.add_log(Log(name="testlog", value_units="°", value=np.array([0])))
+
+    loaded_data = load_function(builder)
+    assert loaded_data["testlog"].data.values.unit == sc.units.deg

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -1598,8 +1598,7 @@ def test_utf8_encoded_attribute(load_function: Callable):
     loaded_data = load_function(builder)
     assert loaded_data["testlog"].data.values.unit == sc.units.deg
 
-    
-    
+
 def test_load_nexus_adds_single_tof_bin(load_function: Callable):
     event_time_offsets = np.array([456, 743, 347, 345, 632], dtype="float64")
     event_data = EventData(


### PR DESCRIPTION
Closes https://github.com/scipp/scippneutron/issues/140

This PR ensures that we always load string datasets and attributes with the encodings specified in the nexus file.

For ASCII-encoded data in the nexus file, it allows the common extended ascii (latin-1) format, but warns as this is technically unspecified behaviour. Data files from ISIS do sometimes use these extended ASCII code points (see example LET data file linked to ticket). Data marked as UTF-8 will still be loaded correctly using that encoding.

See also https://docs.h5py.org/en/stable/strings.html 