### PR TITLE
Add recommended scipy to user env files

### DIFF
--- a/docs/environments/scippneutron-latest.yml
+++ b/docs/environments/scippneutron-latest.yml
@@ -19,3 +19,4 @@ dependencies:
   - scipp/label/dev::mantid-framework
   - scipp/label/dev::scippneutron
   - scipp::scipp
+  - scipy

--- a/docs/environments/scippneutron.yml
+++ b/docs/environments/scippneutron.yml
@@ -2,9 +2,9 @@ name: scippneutron
 
 channels:
   - conda-forge
-  - scipp
 
 dependencies:
+  - ess-dmsc::ess-streaming-data-types
   - h5py
   - ipympl
   - ipython
@@ -12,10 +12,10 @@ dependencies:
   - jupyterlab
   - jupyterlab_widgets
   - jupyter_nbextensions_configurator
-  - mantid-framework
   - matplotlib-base
   - nodejs
-  - pythreejs
-  - scippneutron
   - python-confluent-kafka
-  - ess-dmsc::ess-streaming-data-types
+  - pythreejs
+  - scipp::mantid-framework
+  - scipp::scippneutron
+  - scipy


### PR DESCRIPTION
Add `scipy` so `scipp.constants` and `scipp.spatial` will work.