### PR TITLE
Better load error messages

### DIFF
--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -862,8 +862,21 @@ def load(filename="",
                            advanced_geometry=advanced_geometry)
 
 
+def _is_mantid_loadable(filename):
+    from mantid.api import FileFinder
+    if FileFinder.getFullPath(filename):
+        return True
+    else:
+        try:
+            # findRuns throws rather than return empty so need try-catch
+            FileFinder.findRuns(filename)
+            return True
+        except Exception:
+            return False
+
+
 def _check_file_path(filename, mantid_alg):
-    from mantid.api import FileFinder, AlgorithmManager, FrameworkManager, FileProperty
+    from mantid.api import AlgorithmManager, FrameworkManager, FileProperty
     FrameworkManager.Instance()
     alg = AlgorithmManager.createUnmanaged(mantid_alg)
     filename_property = [
@@ -875,9 +888,9 @@ def _check_file_path(filename, mantid_alg):
     # is called directly we attempt to find FileProperty. Otherwise paths should be
     # absolute
     if filename_property or mantid_alg == 'Load':
-        if not FileFinder.getFullPath(filename):
+        if not _is_mantid_loadable(filename):
             raise ValueError(
-                f"Mantid cannot find file {filename} and therefore will not load it."
+                f"Mantid cannot find {filename} and therefore will not load it."
             ) from None
     else:
         if not os.path.isfile(filename):

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -839,7 +839,7 @@ def load(filename="",
     if mantid_args is None:
         mantid_args = {}
 
-    _check_file_path(filename, mantid_alg)
+    _check_file_path(str(filename), mantid_alg)
 
     with run_mantid_alg(mantid_alg, filename, **mantid_args) as loaded:
         # Determine what Load has provided us

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -841,7 +841,7 @@ def load(filename="",
 
     _check_file_path(str(filename), mantid_alg)
 
-    with run_mantid_alg(mantid_alg, filename, **mantid_args) as loaded:
+    with run_mantid_alg(mantid_alg, str(filename), **mantid_args) as loaded:
         # Determine what Load has provided us
         from mantid.api import Workspace
         if isinstance(loaded, Workspace):

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -834,12 +834,14 @@ def load(filename="",
              instrument geometry.
     :rtype: Dataset
     """
-    from mantid.api import FileFinder
+    from mantid.api import FileLoaderRegistry
 
     if mantid_args is None:
         mantid_args = {}
 
-    if not FileFinder.getFullPath(filename):
+    try:
+        FileLoaderRegistry.chooseLoader(filename)
+    except ValueError:
         raise ValueError(
             f"Mantid cannot find file {filename} and therefore will not load it.")
 

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -869,10 +869,11 @@ def _check_file_path(filename, mantid_alg):
     filename_property = [
         prop for prop in alg.getProperties() if isinstance(prop, FileProperty)
     ]
-    # if the top level Load algorithm is requested (has no properties of its own)
-    # but we know that child algorithm use FileProperty or the child algorithm
-    # is known called directly and we find FileProperty. Only with File property
-    # can Mantid take fuzzy matches to filenames and run numbers
+    # Only with FileProperty can Mantid take fuzzy matches to filenames and run numbers
+    # If the top level Load algorithm is requested (has no properties of its own)
+    # we know that it's child algorithm uses FileProperty. If the child algorithm
+    # is called directly we attempt to find FileProperty. Otherwise paths should be
+    # absolute
     if filename_property or mantid_alg == 'Load':
         if not FileFinder.getFullPath(filename):
             raise ValueError(

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -834,9 +834,14 @@ def load(filename="",
              instrument geometry.
     :rtype: Dataset
     """
+    from mantid.api import FileFinder
 
     if mantid_args is None:
         mantid_args = {}
+
+    if not FileFinder.getFullPath(filename):
+        raise ValueError(
+            f"Mantid cannot find file {filename} and therefore will not load it.")
 
     with run_mantid_alg(mantid_alg, filename, **mantid_args) as loaded:
         # Determine what Load has provided us
@@ -845,7 +850,7 @@ def load(filename="",
             # A single workspace
             data_ws = loaded
         else:
-            # Seperate data and monitor workspaces
+            # Separate data and monitor workspaces
             data_ws = loaded.OutputWorkspace
 
         if instrument_filename is not None:

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -889,5 +889,20 @@ def test_duplicate_monitor_names():
     assert da.attrs['monitor_14'].value.attrs['spectrum'].value == 14
 
 
+@pytest.mark.skipif(not mantid_is_available(), reason='Mantid framework is unavailable')
+def test_load_error_when_file_not_found_via_fuzzy_match():
+    with pytest.raises(ValueError):
+        scn.load("fictional.nxs")
+
+
+@pytest.mark.skipif(not mantid_is_available(), reason='Mantid framework is unavailable')
+def test_load_error_when_file_not_found_via_exact_match():
+
+    with pytest.raises(ValueError):
+        # CreateWorkspace has no FileProperty and forces
+        # load to evaluate the path given as an absolute path
+        scn.load("fictional.nxs", mantid_alg="CreateWorkspace")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -929,9 +929,6 @@ def test_load_error_when_file_not_found_via_exact_match():
         # load to evaluate the path given as an absolute path
         scn.load("fictional.nxs", mantid_alg="DummyLoader")
 
-    with tempfile.NamedTemporaryFile() as fp:
-        scn.load(fp.name, mantid_alg="DummyLoader")
-
 
 @pytest.mark.skipif(not mantid_is_available(), reason='Mantid framework is unavailable')
 def test_load_via_exact_match():


### PR DESCRIPTION
Fixes #151

It's not as simple as just checking the file path i.e. `os.path.exists` or similar because Mantid will also happily load based on run numbers or incomplete file paths that are taken to be joined with known `Config` data search directories. We therefore have to ask mantid if it can load the file. There are two routes to doing this.

1. `mantid.api.FileFinder`
1. `mantid.api.FindLoaderRegistry`

Preferred option was to use the first as easier to interpret results via return directly. However this function appears to hang on an Instrument Download step in the framework manager initialisation, I am therefore using 2 even though it relies on catching specific exception types and allowing others through.