### PR TITLE
Update tutorials

### DIFF
--- a/docs/tutorials/exploring-data.ipynb
+++ b/docs/tutorials/exploring-data.ipynb
@@ -91,7 +91,7 @@
     "## Step 2: Plot the data\n",
     "\n",
     "Scipp objects (variables, data arrays, or datasets) can be plotted using the `plot()` method.\n",
-    "Alternatively `sc.plot(obj)` can be used, e.g., when `obj` is a PYthon `dict` of scipp data arrays.\n",
+    "Alternatively `sc.plot(obj)` can be used, e.g., when `obj` is a Python `dict` of scipp data arrays.\n",
     "Since this is neutron-scattering data, we can also use the \"instrument view\", provided by `scn.instrument_view(obj)` (assuming `scippneutron` was imported as `scn`).\n",
     "\n",
     "### Exercise\n",

--- a/docs/tutorials/exploring-data.ipynb
+++ b/docs/tutorials/exploring-data.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# Exploring data\n",
     "\n",
@@ -11,6 +13,8 @@
     "\n",
     "This tutorial contains exercises, but solutions are included directly.\n",
     "We encourage you to download this notebook and run through it step by step before looking at the solutions.\n",
+    "We recommend to use a recent version of *JupyterLab*:\n",
+    "The solutions are included as hidden cells and shown only on demand.\n",
     "\n",
     "First, in addition to importing `scipp`, we import `scippneutron` since this is required for loading Nexus files:"
    ]
@@ -53,9 +57,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 1: Use the HTML representation to see what the loaded data contains\n",
+    "## Step 1: Use the HTML representation to see what the loaded data contains\n",
     "\n",
     "The HTML representation is what Jupyter displays for a scipp object.\n",
+    "\n",
     "- Take some time to explore this view and try to understand all the information (dimensions, dtypes, units, ...).\n",
     "- Note that sections can be expanded, and values can shown by clicking the icons to the right."
    ]
@@ -73,14 +78,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 2: Plot the data\n",
+    "Whenever you get stuck with one of the exercises below we recommend consulting the HTML representations of the objects you are working with."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## Step 2: Plot the data\n",
     "\n",
-    "Scipp objects can be created using the `plot()` method.\n",
-    "Alternatively `sc.plot(obj)` can be used.\n",
+    "Scipp objects (variables, data arrays, or datasets) can be plotted using the `plot()` method.\n",
+    "Alternatively `sc.plot(obj)` can be used, e.g., when `obj` is a PYthon `dict` of scipp data arrays.\n",
     "Since this is neutron-scattering data, we can also use the \"instrument view\", provided by `scn.instrument_view(obj)` (assuming `scippneutron` was imported as `scn`).\n",
     "\n",
+    "### Exercise\n",
+    "\n",
     "- Plot the loaded data and familiarize yourself with the controls.\n",
-    "- Create the instrument view and familiarize yourself with the controls."
+    "- Create the instrument view and familiarize yourself with the controls.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -105,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 3: Exploring meta data\n",
+    "## Step 3: Exploring meta data\n",
     "\n",
     "Above we saw that many attributes are scalar variables with `dtype=DataArray`.\n",
     "The single value in a scalar variable is accessed using the `value` property.\n",
@@ -132,11 +151,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
-    "Exercises:\n",
+    "### Exercise\n",
+    "\n",
     "1. Find some attributes of `data` with `dtype=DataArray` and plot their `value`.\n",
-    "   Also try `sc.table(attr.value)` to show a table representation.\n",
+    "   Also try `sc.table(attr.value)` to show a table representation (where `attr` is an attribute of your choice).\n",
     "2. Find and plot a monitor.\n",
     "3. Try to normalize `data` to monitor 1.\n",
     "   Why does this fail?\n",
@@ -144,7 +167,9 @@
     "   Note that `sc.plot()` can be used with a Python `dict` for this purpose: `sc.plot({'a':something, 'b':else})`.\n",
     "5. Convert all the monitors from `'tof'` to `'wavelength'` using, e.g., `mon1_wav = sc.neutron.convert(mon1, 'tof', 'wavelength', scatter=False)`.\n",
     "6. Inspect the HTML view and note how the \"unit conversion\" changed the dimensions and units.\n",
-    "7. Re-plot all the monitors on the same plot, now in `'wavelength'`."
+    "7. Re-plot all the monitors on the same plot, now in `'wavelength'`.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -166,6 +191,13 @@
     "    data / data.attrs['monitor1'].value\n",
     "except sc.CoordError:\n",
     "    print('Data and monitor are in unit TOF, but pixels and monitors are at different position, so data is not comparable')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A monitor can be converted to wavelength as follows:"
    ]
   },
   {
@@ -198,15 +230,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
-    "### Step 4: Fixing metadata\n",
+    "## Step 4: Fixing metadata\n",
     "\n",
-    "Exercises:\n",
-    "1. The `sample_position` coord is wrong, shift the sample by `delta = sc.scalar(value=np.array([0.01,0.01,0.04]), unit=sc.units.m)`.\n",
+    "### Exercise\n",
+    "\n",
+    "Consider the following (hypothetical) problems with the metadata stored in `data`:\n",
+    "\n",
+    "1. The `sample_position` coord (`data.coords['sample_position']`) is wrong, shift the sample by `delta = sc.vector(value=np.array([0.01,0.01,0.04]), unit='m')`.\n",
     "2. Because of a glitch in the timing system the time-of-flight has an offset of $2.3~\\mu s$.\n",
     "   Fix the corresponding coordinate.\n",
-    "3. Use the HTML view of `data` to verify that you applied the corrections/calibrations there, rather than in a copy."
+    "3. Use the HTML view of `data` to verify that you applied the corrections/calibrations there, rather than in a copy.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -215,8 +255,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data.coords['sample_position'] += sc.vector(value=[0.01,0.01,0.04], unit=sc.units.m)\n",
-    "data.coords['tof'] += 2.3 * sc.Unit('us') # note how we forgot to fix the monitor's TOF\n",
+    "data.coords['sample_position'] += sc.vector(value=[0.01,0.01,0.04], unit='m')\n",
+    "data.coords['tof'] += 2.3 * sc.Unit('us')  # note how we forgot to fix the monitor's TOF\n",
     "data"
    ]
   },
@@ -253,7 +293,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 5: A closer look at the data\n",
+    "The offset to the sample could also be done component-wise using the special `fields` property of variables with \"vector\" dtype, e.g.,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.coords['sample_position'].fields.z += 0.001 * sc.Unit('m')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: A closer look at the data\n",
     "\n",
     "The 2-D plot we obtain above by default is often not very enlightening.\n",
     "Define:"
@@ -265,17 +321,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "counts = sc.sum(data, 'tof')"
+    "counts = data.sum('tof')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
-    "Exercises:\n",
+    "### Exercise\n",
+    "\n",
     "1. Create a plot of `counts` and also try the instrument view.\n",
     "2. How many counts are there in total, in all spectra combined?\n",
-    "3. Plot a single spectrum of `data` as a 1-D plot using the slicing syntax to access the spectrum."
+    "3. Plot a single spectrum of `data` as a 1-D plot using the slicing syntax `array[dim_name, integer_index]` to access the spectrum.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -303,8 +365,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sc.sum(counts, 'spectrum') # would be another solution\n",
-    "sc.sum(data).value"
+    "# counts.sum('spectrum') # would be another solution\n",
+    "data.sum().value"
    ]
   },
   {
@@ -320,6 +382,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Volumetric detectors\n",
+    "\n",
     "As seen in the instrument view the detectors consist of 4 layers of tubes, each containing 7 straws.\n",
     "Let us try to split up our data, so we can compare layers.\n",
     "There are other (and probably better) ways to do this, but here we try to define an integer variable containing a layer index:"
@@ -332,18 +396,22 @@
    "outputs": [],
    "source": [
     "z = data.coords['position'].fields.z\n",
-    "near = sc.min(z)\n",
-    "far = sc.max(z)\n",
-    "layer = ((z-near)*400).astype(sc.dtype.int32)\n",
+    "near = z.min()\n",
+    "far = z.max()\n",
+    "layer = ((z-near)*400).astype('int32')\n",
     "layer.unit = ''\n",
     "layer.plot()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
-    "Exercises:\n",
+    "### Exercise\n",
+    "\n",
     "- Change the magic parameter `400` in the cell above until pixels fall cleanly into layers, either 4 layers of tubes or 12 layers of straws.\n",
     "- Store `layer` as a new coord in `data`.\n",
     "- Use `sc.groupby(data, group='layer').sum('spectrum')` to group spectra into layers.\n",
@@ -353,7 +421,9 @@
     "  - Use `plot` with `projection='1d'`\n",
     "  - Use `sc.plot` after collapsing dimensions, `sc.collapse(grouped, keep='tof')`\n",
     "- Bonus: When grouping by straw layers, there is a different number of straws in the center layer of each tube (3 instead of 2) due to the flower-pattern arrangement of straws.\n",
-    "  Define a helper data array with data set to 1 for each spectrum, group by layers and sum over spectrum as above, and use this result to normalize the layer-grouped data from above to spectrum count."
+    "  Define a helper data array with data set to 1 for each spectrum (using, e.g., `norm = sc.DataArray(data=sc.ones_like(layer), coords={'layer':layer})`), group by layers and sum over spectrum as above, and use this result to normalize the layer-grouped data from above to spectrum count.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -368,8 +438,16 @@
     "layer = ((z-near)*150).astype(sc.dtype.int32)\n",
     "layer.unit = ''\n",
     "data.coords['layer'] = layer\n",
-    "grouped = sc.groupby(data, group='layer').sum('spectrum')\n",
-    "grouped.plot(projection='1d')\n",
+    "grouped = data.groupby(group='layer').sum('spectrum')\n",
+    "grouped.plot(projection='1d')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sc.plot(sc.collapse(grouped, keep='tof'))"
    ]
   },
@@ -379,8 +457,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "norm = sc.DataArray(data=layer*0+1, coords={'layer':layer})\n",
-    "norm = sc.groupby(norm, group='layer').sum('spectrum')\n",
+    "norm = sc.DataArray(data=sc.ones_like(layer), coords={'layer':layer})\n",
+    "norm = norm.groupby(group='layer').sum('spectrum')\n",
     "sc.plot(sc.collapse(grouped/norm, keep='tof'))"
    ]
   }

--- a/docs/tutorials/working-with-masks.ipynb
+++ b/docs/tutorials/working-with-masks.ipynb
@@ -129,7 +129,6 @@
    "outputs": [],
    "source": [
     "tof = data.coords['tof']\n",
-    "data.masks['prompt-pulse'] = (tof['tof',:-1] > prompt_start) & (tof['tof',1:] < prompt_stop)\n",
     "sc.plot({'before':counts, 'after':data.sum('tof')})"
    ]
   },

--- a/docs/tutorials/working-with-masks.ipynb
+++ b/docs/tutorials/working-with-masks.ipynb
@@ -13,6 +13,9 @@
     "\n",
     "This tutorial contains exercises, but solutions are included directly.\n",
     "We encourage you to download this notebook and run through it step by step before looking at the solutions.\n",
+    "We recommend to use a recent version of *JupyterLab*:\n",
+    "The solutions are included as hidden cells and shown only on demand.\n",
+    "\n",
     "As a side effect, the exercises will help in getting more familiar with the basic concepts of operations.\n",
     "\n",
     "First, in addition to importing `scipp`, we import `scippneutron` since this is required for loading Nexus files:"
@@ -43,7 +46,7 @@
    "outputs": [],
    "source": [
     "data = scn.load(filename='LARMOR00049338')\n",
-    "counts = sc.sum(data, 'tof') # used later\n",
+    "counts = data.sum('tof') # used later\n",
     "data"
    ]
   },
@@ -73,21 +76,28 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Exercise 1: Masking a prompt pulse\n",
     "\n",
     "1. Create a prompt-pulse mask for the region between $17500~\\mathrm{\\mu s}$ and $19000~\\mathrm{\\mu s}$.\n",
     "   Notes:\n",
+    "   - Define, e.g., `prompt_start = 17500 * sc.Unit('us')` and the same for the upper bound of the prompt pulse.\n",
     "   - Use comparison operators such as `==`, `<=` or `>`.\n",
     "   - Combine multiple conditions into one using `&` (\"and\"), `|` (\"or\"), or `^` (\"exclusive or\").\n",
     "   - Masks are stored in a data array by storing them in the `masks` dictionary, e.g., `data.masks['prompt-pulse'] = ...`.\n",
     "   - If something goes wrong, masks can be removed with Python's `del`, e.g., `del data.masks['wrong']`.\n",
     "   - If you run into an error regarding a length mismatch when inserting the coordinate, remember that `'tof'` is a bin-edge coordinate, i.e., it is by 1 longer than the number of bins.\n",
     "     Use, e.g., only the left bin edges, i.e., all but the last, to create the masks.\n",
+    "     This can be achieved using slicing, e.g., `array[dim_name, integer_index]`.\n",
     "2. Use the HTML view and plot the data after masking to explore the effect.\n",
-    "3. Pass a `dict` containing `counts` (computed above as `counts = sc.sum(data, 'tof')`) and the equivalent counts computed *after* masking to `sc.plot`.\n",
-    "   Use this to verify that the prompt-pulse mask results in removal of counts."
+    "3. Pass a `dict` containing `counts` (computed above as `counts = data.sum('tof')`) and the equivalent counts computed *after* masking to `sc.plot`.\n",
+    "   Use this to verify that the prompt-pulse mask results in removal of counts.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -96,8 +106,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "prompt_start = 17500 * sc.Unit('us')\n",
+    "prompt_stop = 19000 * sc.Unit('us')\n",
     "tof = data.coords['tof']\n",
-    "data.masks['prompt-pulse'] = (tof['tof',:-1] > 17500.0 * sc.units.us) & (tof['tof',:-1] < 19000.0 * sc.units.us)\n",
+    "data.masks['prompt-pulse'] = (tof['tof',:-1] > prompt_start) & (tof['tof',:-1] < prompt_stop)\n",
     "data"
    ]
   },
@@ -117,20 +129,26 @@
    "outputs": [],
    "source": [
     "tof = data.coords['tof']\n",
-    "data.masks['prompt-pulse'] = (tof['tof',:-1] > 17500.0 * sc.units.us) & (tof['tof',1:] < 19000.0 * sc.units.us)\n",
-    "sc.plot({'before':counts, 'after':sc.sum(data, 'tof')})"
+    "data.masks['prompt-pulse'] = (tof['tof',:-1] > prompt_start) & (tof['tof',1:] < prompt_stop)\n",
+    "sc.plot({'before':counts, 'after':data.sum('tof')})"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Exercise 2: Masking spatially\n",
     "\n",
     "By masking an `x` range, mask the end of the tubes.\n",
+    "\n",
     "- Define `x = data.coords['position'].fields.x` to extract only the x-component of the position coordinate.\n",
     "- Create the masks.\n",
-    "- Use the instrument view (`sc.neutron.instrument_view(data)`) to inspect the result."
+    "- Use the instrument view (`scn.instrument_view(data)`) to inspect the result.\n",
+    "\n",
+    "### Solution"
    ]
   },
   {
@@ -140,7 +158,7 @@
    "outputs": [],
    "source": [
     "x = data.coords['position'].fields.x\n",
-    "data.masks['tube-ends'] = x < -0.2 * sc.units.m\n",
+    "data.masks['tube-ends'] = sc.abs(x) > 0.5 * sc.Unit('m')\n",
     "scn.instrument_view(sc.sum(data, 'tof'), norm='log') # sum and norm are optional"
    ]
   },
@@ -151,6 +169,7 @@
     "## Exercise 3: Combining conditions\n",
     "\n",
     "Mask the broken pixels with zero counts near the beam stop (center).\n",
+    "\n",
     "- Note that there are pixels at larger scattering angles (larger x) which have real zeros.\n",
     "  These should not be masked.\n",
     "- Combine the condition for zero counts with a spatial mask, e.g., based on `x`, to ensure the mask takes only effect close to the direct beam / beam stop."
@@ -163,7 +182,17 @@
    "outputs": [],
    "source": [
     "# This would mask too much, what needs to be added?\n",
-    "counts.data == 0.0 * sc.units.counts"
+    "counts.data == 0.0 * sc.Unit('counts')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "### Solution"
    ]
   },
   {
@@ -172,14 +201,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "broken = (counts.data == 0.0 * sc.units.counts) & (sc.abs(x) < 0.1 * sc.units.m)\n",
+    "broken = (counts.data == 0.0 * sc.Unit('counts')) & (sc.abs(x) < 0.1 * sc.Unit('m'))\n",
     "data.masks['bad-pixels'] = broken\n",
-    "scn.instrument_view(sc.sum(data, 'tof'), norm='log') # sum and norm are optional"
+    "scn.instrument_view(sc.sum(data, 'tof')) # sum is optional"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "## Exercise 4: More spatial masking\n",
     "\n",
@@ -190,7 +222,9 @@
     "- Mask a scattering-angle ($\\theta$) range.\n",
     "  Hint: The scattering angle can be computed as `theta = 0.5 * scn.two_theta(data)`\n",
     "- Mask a wedge.\n",
-    "  Hint: `phi = sc.atan2(y=y,x=x)`"
+    "  Hint: `phi = sc.atan2(y=y,x=x)`\n",
+    "  \n",
+    "### Solution"
    ]
   },
   {
@@ -228,7 +262,7 @@
     "- Adapt the code for masking a wedge to return an integer sector index (e.g, 0...5).\n",
     "- Store the result as a coordinate.\n",
     "- Use `groupby` to group by sector.\n",
-    "  Note that `sc.groupby(...).copy(group)` can be used to extract a given group by index, instead of applying reductions."
+    "  Note that `groupby(...).copy(group)` can be used to extract a given group by index, instead of applying reductions."
    ]
   },
   {
@@ -239,6 +273,7 @@
     "\n",
     "Finally, let us group according to scattering angle and sum spectra.\n",
     "Questions:\n",
+    "\n",
     "- Can you see the effect of the circle/ring/theta-range that you masked above?\n",
     "- Why is the prompt-pulse mask preserved, but not the other masks?"
    ]
@@ -251,16 +286,33 @@
    "source": [
     "theta_edges = sc.array(dims=['theta'], unit='rad', values=np.linspace(0, 0.1, num=100))\n",
     "data.coords['theta'] = 0.5 * scn.two_theta(data)\n",
-    "# - prompt-pulse mask is preserved since we did not sum over time-of-flight.\n",
-    "# - Masked pixels (spectra) cannot be preserved since we sum over spectra,\n",
-    "#   and the sum simply skips the masked spectra.\n",
     "sc.groupby(data, group='theta', bins=theta_edges).sum('spectrum').plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "### Solution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    " - The prompt-pulse mask is preserved since we did not sum over time-of-flight.\n",
+    " - Masked pixels (spectra) cannot be preserved since we sum over spectra, and the sum simply skips the masked spectra."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -274,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update and improve the two introduction tutorials that we also use for our courses. The goal of this is to be able to use identical notebooks in the course since maintaining separate variants is not sustainable in the long run.

See also https://github.com/ess-dmsc-dram/python-course-ikon/tree/master/notebooks/7_scipp.