### PR TITLE
Plotting dependencies are optional

### DIFF
--- a/python/src/scippneutron/instrument_view.py
+++ b/python/src/scippneutron/instrument_view.py
@@ -3,9 +3,13 @@
 # @author Neil Vaytet and Owen Arnold
 
 import numpy as np
-import pythreejs as p3
 import scipp as sc
 from scipy.spatial.transform import Rotation as Rot
+try:
+    import pythreejs as p3
+except ImportError as ex:
+    p3 = None
+    _pythreejs_import_error = ex
 
 
 def _create_text_sprite(position, bounding_box, display_text):
@@ -235,6 +239,8 @@ def instrument_view(scipp_obj=None,
     the returned geometrical shape is a wireframe instead of a shape with
     opaque faces
     """
+    if not p3:
+        raise _pythreejs_import_error
 
     from scipp.plotting import plot
     from scipp.plotting.objects import PlotDict


### PR DESCRIPTION
scippneutron/__init__.py imports instrument_view with plotting dependencies considered optional

```
ImportError while importing test module '/write_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../miniconda3/envs/ess-developer-latest/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/reflectometry/write_test.py:15: in <module>
    from ess.reflectometry import write, data, orso
src/ess/reflectometry/data.py:13: in <module>
    import scippneutron as scn
../../miniconda3/envs/ess-developer-latest/lib/python3.7/scippneutron/__init__.py:27: in <module>
    from .instrument_view import instrument_view
../../miniconda3/envs/ess-developer-latest/lib/python3.7/scippneutron/instrument_view.py:6: in <module>
    import pythreejs as p3
E   ModuleNotFoundError: No module named 'pythreejs'
```