### PR TITLE
Disable data streaming tests on OSX

### DIFF
--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -17,7 +17,6 @@ dependencies:
   - tbb-devel
   - scipp::scipp
   - cmake
-  - pip
 
   # Run
   - appdirs
@@ -25,14 +24,14 @@ dependencies:
   - ipympl
   - ipywidgets
   - matplotlib-base
-  - numpy >=1.15.3
+  - numpy>=1.20.0
   - python
   - python-configuration
   - pythreejs
   - pyyaml
   - tbb
-  - traitlets
   - h5py
+  - scipy>=1.7.0
 
   # Test
   - psutil
@@ -48,7 +47,7 @@ dependencies:
   - ipython
   - pandoc
   - sphinx
-  - sphinx_rtd_theme
+  - sphinx_rtd_theme=0.5.2 # 1.0.0 broken CSS?
   - nbsphinx
   - python-graphviz
   - docutils=0.16 # see https://github.com/spatialaudio/nbsphinx/issues/549

--- a/scippneutron-developer-osx.yml
+++ b/scippneutron-developer-osx.yml
@@ -22,17 +22,14 @@ dependencies:
   - ipywidgets
   - scipp::mantid-framework
   - matplotlib-base
-  - numpy >=1.15.3
+  - numpy>=1.20.0
   - python
   - python-configuration
   - pythreejs
   - pyyaml
   - tbb
-  - traitlets
   - h5py
-  - python-confluent-kafka
-  - ess-dmsc::ess-streaming-data-types
-  - scipy
+  - scipy>=1.7.0
 
   # Test
   - psutil
@@ -48,7 +45,7 @@ dependencies:
   - ipython
   - pandoc
   - sphinx
-  - sphinx_rtd_theme
+  - sphinx_rtd_theme=0.5.2 # 1.0.0 broken CSS?
   - nbsphinx
   - python-graphviz
   - docutils=0.16 # see https://github.com/spatialaudio/nbsphinx/issues/549

--- a/scippneutron-developer.yml
+++ b/scippneutron-developer.yml
@@ -23,17 +23,16 @@ dependencies:
   - ipywidgets
   - scipp::mantid-framework
   - matplotlib-base
-  - numpy >=1.15.3
+  - numpy>=1.20.0
   - python
   - python-configuration
   - pythreejs
   - pyyaml
   - tbb
-  - traitlets
   - h5py
   - python-confluent-kafka
   - ess-dmsc::ess-streaming-data-types
-  - scipy
+  - scipy>=1.7.0
 
   # Test
   - psutil


### PR DESCRIPTION
Because of intermittently failing data streaming tests on osx, we disable them and require future investigation (#172)

- Remove kafka related deps in osx
- Cleanup env files.
- Require minimum versions on `numpy>=1.20.0` and `scipy>=1.7.0`