### PR TITLE
Use pooch to get tutorial data

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - scipp {{ scipp }}
     - tbb-devel
   run:
+    - pooch
     - python {{ python }}
     - scipp {{ scipp }}
     - h5py
@@ -29,7 +30,6 @@ test:
     - ipykernel = 6.3.1  # see https://github.com/ipython/ipykernel/issues/771
     - ipywidgets
     - matplotlib-base
-    - pooch
     - psutil
     - pytest
     - pytest-asyncio

--- a/docs/tutorials/exploring-data.ipynb
+++ b/docs/tutorials/exploring-data.ipynb
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We  start by loading some data (download [here](https://github.com/ess-dmsc-dram/loki_tube_scripts/raw/master/test/test_data/LARMOR00049338.nxs)), in this case measured with a prototype of the [LoKI](https://europeanspallationsource.se/instruments/loki) detectors at the [LARMOR beamline](https://www.isis.stfc.ac.uk/Pages/Larmor.aspx):"
+    "We  start by loading some data, in this case measured with a prototype of the [LoKI](https://europeanspallationsource.se/instruments/loki) detectors at the [LARMOR beamline](https://www.isis.stfc.ac.uk/Pages/Larmor.aspx):"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = scn.load(filename='LARMOR00049338')"
+    "data = scn.data.tutorial_dense_data()"
    ]
   },
   {

--- a/docs/tutorials/understanding-event-data.ipynb
+++ b/docs/tutorials/understanding-event-data.ipynb
@@ -44,13 +44,7 @@
    "source": [
     "import scipp as sc\n",
     "import scippneutron as scn\n",
-    "import pooch\n",
-    "\n",
-    "path = pooch.retrieve(\n",
-    "    url='https://public.esss.dk/groups/scipp/scippneutron/PG3_4844_event.h5',\n",
-    "    known_hash='md5:983bbc3f04aff0e00388d4be55e788e3'\n",
-    ")\n",
-    "da = sc.io.open_hdf5(path)\n",
+    "da = scn.data.tutorial_event_data()\n",
     "da.plot()"
    ]
   },

--- a/docs/tutorials/working-with-masks.ipynb
+++ b/docs/tutorials/working-with-masks.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We  start by loading some data (download [here](https://github.com/ess-dmsc-dram/loki_tube_scripts/raw/master/test/test_data/LARMOR00049338.nxs)), in this case measured with a prototype of the [LoKI](https://europeanspallationsource.se/instruments/loki) detectors at the [LARMOR beamline](https://www.isis.stfc.ac.uk/Pages/Larmor.aspx):"
+    "We  start by loading some data, in this case measured with a prototype of the [LoKI](https://europeanspallationsource.se/instruments/loki) detectors at the [LARMOR beamline](https://www.isis.stfc.ac.uk/Pages/Larmor.aspx):"
    ]
   },
   {
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = scn.load(filename='LARMOR00049338')\n",
+    "data = scn.data.tutorial_dense_data()\n",
     "counts = data.sum('tof') # used later\n",
     "data"
    ]

--- a/python/src/scippneutron/__init__.py
+++ b/python/src/scippneutron/__init__.py
@@ -27,3 +27,4 @@ from .mantid import from_mantid, to_mantid, load, fit
 from .instrument_view import instrument_view
 from .file_loading.load_nexus import load_nexus, load_nexus_json
 from .data_streaming.data_stream import data_stream
+from . import data

--- a/python/src/scippneutron/data/__init__.py
+++ b/python/src/scippneutron/data/__init__.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 import scipp as sc
-from .._scippneutron import __version__
 
-_version = __version__.split('-')[0]
+_version = '1'
+
+__all__ = ['tutorial_dense_data', 'tutorial_event_data']
 
 
 def _make_pooch():

--- a/python/src/scippneutron/data/__init__.py
+++ b/python/src/scippneutron/data/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+import scipp as sc
+from .._scippneutron import __version__
+
+_version = __version__.split('-')[0]
+
+
+def _make_pooch():
+    import pooch
+    return pooch.create(
+        path=pooch.os_cache('scippneutron'),
+        base_url='https://public.esss.dk/groups/scipp/scippneutron/{version}/',
+        version=_version,
+        registry={
+            'powder-event.h5': 'md5:b8ad26eb3efc2159687134a5396a2671',
+            'loki-at-larmor.hdf5': 'md5:6691ef98406bd4d526e2131ece3c8d69',
+        })
+
+
+_pooch = _make_pooch()
+
+
+def tutorial_dense_data():
+    return sc.io.open_hdf5(_pooch.fetch('loki-at-larmor.hdf5'))
+
+
+def tutorial_event_data():
+    return sc.io.open_hdf5(_pooch.fetch('powder-event.h5'))

--- a/scippneutron-developer-no-mantid.yml
+++ b/scippneutron-developer-no-mantid.yml
@@ -46,6 +46,7 @@ dependencies:
   # Docs
   - ipython
   - pandoc
+  - pooch
   - sphinx
   - sphinx_rtd_theme=0.5.2 # 1.0.0 broken CSS?
   - nbsphinx

--- a/scippneutron-developer-osx.yml
+++ b/scippneutron-developer-osx.yml
@@ -44,6 +44,7 @@ dependencies:
   # Docs
   - ipython
   - pandoc
+  - pooch
   - sphinx
   - sphinx_rtd_theme=0.5.2 # 1.0.0 broken CSS?
   - nbsphinx

--- a/tools/make_tutorial_data.ipynb
+++ b/tools/make_tutorial_data.ipynb
@@ -64,7 +64,7 @@
     "da.bins.data *= sc.where((prompt_start <= tof) & (tof < prompt_stop), 1.0+3.0*sc.exp(-(tof-prompt_start)/sc.scalar(200.0, unit='us')), sc.scalar(1.0))\n",
     "\n",
     "# Reduce data size to 1/3\n",
-    "da['spectrum', 14100:].to_hdf5(filename=filename)"
+    "da['spectrum', 14100:].to_hdf5(filename='powder-event.h5')"
    ]
   }
  ],


### PR DESCRIPTION
Use pooch instead of custom handling of sample data. They key advantage is that it makes notebooks portable, in particular also to our JupyterHub, and to users computers, without requiring manual file downloads.

For later:
- Use same approach for other files used in docs.
- Consider adding generated data, rather than just downloaded. Maybe more relevant for `scipp` itself.
- Are we happy with the naming?

We also need to figure out what to do with versions. The current setup will brake once we make a release. Do we add symlinks for new releases? Or do we version `scippneutron.data` independently from `scippneutron`?