### PR TITLE
Fixes and refactor for `load_nexus`

### DIFF
--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -226,21 +226,15 @@ def _load_event_group(group: Group, file_root: h5py.File, nexus: LoadFromNexus,
                       dtype=np.float32,
                       with_variances=True)
 
-    data_dict = {
-        "data": weights,
-        "coords": {
-            _time_of_flight: event_time_offset,
-            _detector_dimension: event_id,
-        },
-    }
-
-    events = sc.DataArray(**data_dict)
+    events = sc.DataArray(data=weights,
+                          coords={
+                              _time_of_flight: event_time_offset,
+                              _detector_dimension: event_id,
+                          })
 
     _check_event_ids_and_det_number_types_valid(
         event_id.dtype if detector_data.detector_ids is None else
         detector_data.detector_ids.dtype, event_id.dtype)
-
-    detector_group = group.parent
 
     event_index = sc.array(dims=[_pulse_dimension],
                            values=event_index,

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -371,7 +371,8 @@ def load_detector_data(event_data_groups: List[Group], detector_groups: List[Gro
         else:
             if _max_tof.value != np.finfo(type(_max_tof.value)).max:
                 _max_tof.value = np.nextafter(_max_tof.value, float("inf"))
-        events.coords[_time_of_flight] = sc.concatenate(_min_tof, _max_tof, _time_of_flight)
+        events.coords[_time_of_flight] = sc.concatenate(_min_tof, _max_tof,
+                                                        _time_of_flight)
 
     return events
 

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -354,7 +354,7 @@ def load_detector_data(event_data_groups: List[Group], detector_groups: List[Gro
             _min_tof, _max_tof = _max_tof, _min_tof
         if np.issubdtype(type(_max_tof.value), np.integer):
             if _max_tof.value != np.iinfo(type(_max_tof.value)).max:
-                _max_tof.value += 1
+                _max_tof += sc.ones_like(_max_tof)
         else:
             if _max_tof.value != np.finfo(type(_max_tof.value)).max:
                 _max_tof.value = np.nextafter(_max_tof.value, float("inf"))

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -248,7 +248,7 @@ def _load_event_group(group: Group, file_root: h5py.File, nexus: LoadFromNexus,
     pulse_times = _load_pulse_times(group, nexus)
 
     begins = event_index
-    # There is some variation in the last recorded event_index in files # from different
+    # There is some variation in the last recorded event_index in files from different
     # institutions. We try to make sure here that it is what would be the first index of
     # the next pulse. In other words, ensure that event_index includes the bin edge for
     # the last pulse.
@@ -340,6 +340,8 @@ def load_detector_data(event_data_groups: List[Group], detector_groups: List[Gro
                 sizes=data.event_data.events.sizes, dtype='datetime64', unit='ns')
             data.event_data.bins.coords['pulse_time'][
                 ...] = data.event_data.coords['pulse_time']
+            # TODO Looking into using `erase=[_pulse_dimension]` instead of binning
+            # underlying buffer. Must prove that performance can be unaffected.
             da = sc.bin(data.event_data.bins.constituents['data'],
                         groups=[data.detector_ids])
             # Add a single time-of-flight bin

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -334,7 +334,7 @@ def load_detector_data(event_data_groups: List[Group], detector_groups: List[Gro
                 sizes=data.event_data.events.sizes, dtype='datetime64', unit='ns')
             data.event_data.bins.coords['pulse_time'][
                 ...] = data.event_data.coords['pulse_time']
-            # TODO Looking into using `erase=[_pulse_dimension]` instead of binning
+            # TODO Look into using `erase=[_pulse_dimension]` instead of binning
             # underlying buffer. Must prove that performance can be unaffected.
             da = sc.bin(data.event_data.bins.constituents['data'],
                         groups=[data.detector_ids])

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -155,15 +155,15 @@ def _create_empty_events_data_array(tof_dtype: Any = np.int64,
 def _load_pulse_times(group: Group, nexus: LoadFromNexus) -> sc.Variable:
     time_zero_group = "event_time_zero"
 
-    _raw_pulse_times = nexus.load_dataset(group.group,
+    event_time_zero = nexus.load_dataset(group.group,
                                           time_zero_group,
                                           dimensions=[_pulse_dimension])
 
     try:
-        pulse_times = sc.to_unit(_raw_pulse_times, sc.units.ns, copy=False)
+        pulse_times = sc.to_unit(event_time_zero, sc.units.ns, copy=False)
     except sc.UnitError:
         raise BadSource(f"Could not load pulse times: units attribute "
-                        f"'{_raw_pulse_times.unit}' in NXEvent at "
+                        f"'{event_time_zero.unit}' in NXEvent at "
                         f"{group.path}/{time_zero_group} is not convertible"
                         f" to nanoseconds.")
 

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -357,20 +357,21 @@ def load_detector_data(event_data_groups: List[Group], detector_groups: List[Gro
         _dim = _detector_dimension if bin_by_pixel else _bank_dimension
         events = sc.concatenate(events, _bin_events(detectors.pop(0)), dim=_dim)
 
-    event_tofs = events.events.coords[_time_of_flight]
-    _min_tof = event_tofs.min()
-    _max_tof = event_tofs.max()
-    # This can happen if there were no events in the file at all as sc.min will
-    # return double_max and sc.max will return double_min
-    if _min_tof.value >= _max_tof.value:
-        _min_tof, _max_tof = _max_tof, _min_tof
-    if np.issubdtype(type(_max_tof.value), np.integer):
-        if _max_tof.value != np.iinfo(type(_max_tof.value)).max:
-            _max_tof += sc.ones_like(_max_tof)
-    else:
-        if _max_tof.value != np.finfo(type(_max_tof.value)).max:
-            _max_tof.value = np.nextafter(_max_tof.value, float("inf"))
-    events.coords[_time_of_flight] = sc.concatenate(_min_tof, _max_tof, _time_of_flight)
+    if bin_by_pixel:
+        event_tofs = events.events.coords[_time_of_flight]
+        _min_tof = event_tofs.min()
+        _max_tof = event_tofs.max()
+        # This can happen if there were no events in the file at all as sc.min will
+        # return double_max and sc.max will return double_min
+        if _min_tof.value >= _max_tof.value:
+            _min_tof, _max_tof = _max_tof, _min_tof
+        if np.issubdtype(type(_max_tof.value), np.integer):
+            if _max_tof.value != np.iinfo(type(_max_tof.value)).max:
+                _max_tof += sc.ones_like(_max_tof)
+        else:
+            if _max_tof.value != np.finfo(type(_max_tof.value)).max:
+                _max_tof.value = np.nextafter(_max_tof.value, float("inf"))
+        events.coords[_time_of_flight] = sc.concatenate(_min_tof, _max_tof, _time_of_flight)
 
     return events
 

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -82,10 +82,7 @@ _map_to_supported_type = {
 
 
 def _ensure_supported_int_type(dataset_type: Any):
-    try:
-        return _map_to_supported_type[dataset_type]
-    except KeyError:
-        return dataset_type
+    return _map_to_supported_type.get(dataset_type, dataset_type)
 
 
 class LoadFromHdf5:

--- a/python/tests/test_load_nexus.py
+++ b/python/tests/test_load_nexus.py
@@ -1789,8 +1789,8 @@ def test_load_monitors_with_event_mode_data(load_function: Callable):
 def test_load_raw_detector_data_from_nexus_file(load_function: Callable):
     event_time_offsets = np.array([456, 743, 347, 345, 632])
     event_ids = np.array([1, 2, 3, 1, 3])
-    time_zeros = np.array([1, 2, 3, 4])
-    event_index = np.array([0, 3, 3, 5])
+    time_zeros = np.array([1, 2, 3])
+    event_index = np.array([0, 3, 3])
     event_data = EventData(
         event_id=event_ids,
         event_time_offset=event_time_offsets,


### PR DESCRIPTION
- Fix error from `event_id` with values exceeding int64_max.
- Simplify control flow.
- Use scipp rather than `numpy.diff` to map pulse times to events.
- Avoid duplicate loading of pixel positions, unclear why this was needed.
- Fix and simplify handling of tof min/max finding.