### PR TITLE
Store sample_position as attr and not coord in monitors

### DIFF
--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -525,6 +525,11 @@ def convert_monitors_ws(ws, converter, **ignored):
                             WorkspaceIndexList=[index]) as monitor_ws:
             # Run logs are already loaded in the data workspace
             single_monitor = converter(monitor_ws, load_run_logs=False)
+        # Storing sample_position as a coord of monitors means that monitor
+        # data cannot be combined with scattered data even after conversion
+        # to wavelength, d-spacing, etc. because conversions of monitors do
+        # not use the sample position.
+        # But keep it as an attr in case a user needs it.
         single_monitor.attrs['sample_position'] = single_monitor.coords.pop(
             'sample_position')
         # Remove redundant information that is duplicated from workspace

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -526,6 +526,8 @@ def convert_monitors_ws(ws, converter, **ignored):
                             WorkspaceIndexList=[index]) as monitor_ws:
             # Run logs are already loaded in the data workspace
             single_monitor = converter(monitor_ws, load_run_logs=False)
+        single_monitor.attrs['sample_position'] = single_monitor.coords.pop(
+            'sample_position')
         # Remove redundant information that is duplicated from workspace
         # We get this extra information from the generic converter reuse
         if 'detector_info' in single_monitor.coords:

--- a/python/src/scippneutron/mantid.py
+++ b/python/src/scippneutron/mantid.py
@@ -506,9 +506,8 @@ def _convert_MatrixWorkspace_info(ws, advanced_geometry=False, load_run_logs=Tru
 
 
 def convert_monitors_ws(ws, converter, **ignored):
-    dim, unit = validate_and_get_unit(ws.getAxis(0).getUnit())
     spec_dim, spec_coord = init_spec_axis(ws)
-    spec_info = spec_info = ws.spectrumInfo()
+    spec_info = ws.spectrumInfo()
     comp_info = ws.componentInfo()
     monitors = []
     spec_indices = ((ws.getIndexFromSpectrumNumber(int(i)), i)

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -285,6 +285,19 @@ class TestMantidConversion(unittest.TestCase):
         np.testing.assert_array_equal(ds.masks["spectrum"].values[0:3],
                                       [True, True, True])
 
+    @staticmethod
+    def check_monitor_metadata(monitor):
+        assert 'position' in monitor.coords
+        assert 'source_position' in monitor.coords
+        assert 'sample_position' not in monitor.coords
+        assert 'sample_position' in monitor.attrs
+        # Absence of the following is not crucial, but currently there is
+        # no need for these, and it avoids duplication:
+        assert 'detector_info' not in monitor.coords
+        assert 'sample' not in monitor.coords
+        assert 'SampleTemp' not in monitor.coords, \
+            "Expect run logs not be duplicated in monitor workspaces"
+
     def test_Workspace2D_with_separate_monitors(self):
         from mantid.simpleapi import mtd
         mtd.clear()
@@ -303,9 +316,10 @@ class TestMantidConversion(unittest.TestCase):
         assert expected_monitor_attrs.issubset(attrs)
 
         for monitor_name in expected_monitor_attrs:
-            monitors = ds.attrs[monitor_name].values
-            assert isinstance(monitors, sc.DataArray)
-            assert monitors.shape == [4471]
+            monitor = ds.attrs[monitor_name].value
+            assert isinstance(monitor, sc.DataArray)
+            assert monitor.shape == [4471]
+            self.check_monitor_metadata(monitor)
 
     def test_Workspace2D_with_include_monitors(self):
         from mantid.simpleapi import mtd
@@ -324,9 +338,10 @@ class TestMantidConversion(unittest.TestCase):
         }
         assert expected_monitor_attrs.issubset(attrs)
         for monitor_name in expected_monitor_attrs:
-            monitors = ds.attrs[monitor_name].values
-            assert isinstance(monitors, sc.DataArray)
-            assert monitors.shape == [4471]
+            monitor = ds.attrs[monitor_name].value
+            assert isinstance(monitor, sc.DataArray)
+            assert monitor.shape == [4471]
+            self.check_monitor_metadata(monitor)
 
     def test_EventWorkspace_with_monitors(self):
         from mantid.simpleapi import mtd
@@ -341,16 +356,7 @@ class TestMantidConversion(unittest.TestCase):
             monitor = ds.attrs[monitor_name].value
             assert isinstance(monitor, sc.DataArray)
             assert monitor.shape == [200001]
-            assert 'position' in monitor.coords
-            assert 'source_position' in monitor.coords
-            assert 'sample_position' not in monitor.coords
-            assert 'sample_position' in monitor.attrs
-            # Absence of the following is not crucial, but currently there is
-            # no need for these, and it avoids duplication:
-            assert 'detector_info' not in monitor.coords
-            assert 'sample' not in monitor.coords
-            assert 'SampleTemp' not in monitor.coords,\
-                "Expect run logs not be duplicated in monitor workspaces"
+            self.check_monitor_metadata(monitor)
 
     def test_mdhisto_workspace_q(self):
         from mantid.simpleapi import (CreateMDWorkspace, FakeMDEventData, BinMD)

--- a/python/tests/test_mantid.py
+++ b/python/tests/test_mantid.py
@@ -343,7 +343,8 @@ class TestMantidConversion(unittest.TestCase):
             assert monitor.shape == [200001]
             assert 'position' in monitor.coords
             assert 'source_position' in monitor.coords
-            assert 'sample_position' in monitor.coords
+            assert 'sample_position' not in monitor.coords
+            assert 'sample_position' in monitor.attrs
             # Absence of the following is not crucial, but currently there is
             # no need for these, and it avoids duplication:
             assert 'detector_info' not in monitor.coords


### PR DESCRIPTION
Storing `sample_position` as a coord of monitors means that monitor data cannot be combined with scattered data even after conversion to wavelength, d-spacing, etc. because conversions of monitors do not use the sample position.