### PR TITLE
Allow loading individual nx classes

### DIFF
--- a/python/src/scippneutron/__init__.py
+++ b/python/src/scippneutron/__init__.py
@@ -25,6 +25,8 @@ from ._scippneutron import convert
 from ._scippneutron import position, source_position, sample_position, incident_beam, scattered_beam, Ltotal, L1, L2, two_theta
 from .mantid import from_mantid, to_mantid, load, fit
 from .instrument_view import instrument_view
-from .file_loading.load_nexus import load_nexus, load_nexus_json
+from .file_loading.load_nexus import load_nexus, load_nexus_json, load_nexus_monitors, \
+    load_nexus_instrument_name, load_nexus_disk_chopper, load_nexus_sample, \
+    load_nexus_source, load_nexus_start_and_end_time, load_nexus_title
 from .data_streaming.data_stream import data_stream
 from . import data

--- a/python/src/scippneutron/__init__.py
+++ b/python/src/scippneutron/__init__.py
@@ -27,6 +27,6 @@ from .mantid import from_mantid, to_mantid, load, fit
 from .instrument_view import instrument_view
 from .file_loading.load_nexus import load_nexus, load_nexus_json, load_nexus_monitors, \
     load_nexus_instrument_name, load_nexus_disk_chopper, load_nexus_sample, \
-    load_nexus_source, load_nexus_start_and_end_time, load_nexus_title
+    load_nexus_source, load_nexus_start_and_end_time, load_nexus_title, load_nexus_logs
 from .data_streaming.data_stream import data_stream
 from . import data

--- a/python/src/scippneutron/file_loading/_common.py
+++ b/python/src/scippneutron/file_loading/_common.py
@@ -3,9 +3,8 @@
 # @author Matthew Jones
 
 from dataclasses import dataclass
-from typing import Union, Dict, Optional
+from typing import Union, Dict
 import h5py
-from ._nexus import LoadFromNexus
 
 
 class BadSource(Exception):
@@ -43,13 +42,3 @@ class Group:
     parent: Union[h5py.Group, Dict]
     path: str
     contains_stream: bool = False
-
-
-@dataclass
-class NexusMeta:
-    """
-    Data class to encapsulate access to an open nexus file.
-    """
-    nexus_file: Union[h5py.File, Dict]
-    nexus: LoadFromNexus
-    root: Optional[str] = "/"

--- a/python/src/scippneutron/file_loading/_common.py
+++ b/python/src/scippneutron/file_loading/_common.py
@@ -3,10 +3,9 @@
 # @author Matthew Jones
 
 from dataclasses import dataclass
-from typing import Union, Dict, Optional, Any
+from typing import Union, Dict, Optional
 import h5py
-import scipp as sc
-import numpy as np
+from ._nexus import LoadFromNexus
 
 
 class BadSource(Exception):
@@ -46,25 +45,11 @@ class Group:
     contains_stream: bool = False
 
 
-def _add_attr_to_loaded_data(attr_name: str,
-                             data: sc.Variable,
-                             value: np.ndarray,
-                             unit: sc.Unit,
-                             dtype: Optional[Any] = None):
-    try:
-        data = data.attrs
-    except AttributeError:
-        pass
-
-    try:
-        if dtype is not None:
-            if dtype == sc.dtype.vector_3_float64:
-                data[attr_name] = sc.vector(value=value, unit=unit)
-            elif dtype == sc.dtype.matrix_3_float64:
-                data[attr_name] = sc.matrix(value=value, unit=unit)
-            else:
-                data[attr_name] = sc.Variable(value=value, dtype=dtype, unit=unit)
-        else:
-            data[attr_name] = sc.Variable(value=value, unit=unit)
-    except KeyError:
-        pass
+@dataclass
+class NexusMeta:
+    """
+    Data class to encapsulate access to an open nexus file.
+    """
+    nexus_file: Union[h5py.File, Dict]
+    nexus: LoadFromNexus
+    root: Optional[str] = "/"

--- a/python/src/scippneutron/file_loading/_detector_data.py
+++ b/python/src/scippneutron/file_loading/_detector_data.py
@@ -8,7 +8,8 @@ from typing import Optional, List, Any, Dict, Union
 import numpy as np
 import scipp
 
-from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group)
+from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group,
+                      NexusMeta)
 import scipp as sc
 from warnings import warn
 from ._transformations import get_full_transformation_matrix
@@ -290,11 +291,13 @@ def _check_event_ids_and_det_number_types_valid(detector_id_type: Any,
 
 
 def load_detector_data(event_data_groups: List[Group], detector_groups: List[Group],
-                       file_root: h5py.File, nexus: LoadFromNexus, quiet: bool,
+                       nexus_meta: NexusMeta, quiet: bool,
                        bin_by_pixel: bool) -> Optional[sc.DataArray]:
-    detectors = _load_data_from_each_nx_detector(detector_groups, file_root, nexus)
+    detectors = _load_data_from_each_nx_detector(detector_groups, nexus_meta.nexus_file,
+                                                 nexus_meta.nexus)
     detectors = _load_data_from_each_nx_event_data(detectors, event_data_groups,
-                                                   file_root, nexus, quiet)
+                                                   nexus_meta.nexus_file,
+                                                   nexus_meta.nexus, quiet)
 
     if not detectors:
         # If there were no data to load we are done

--- a/python/src/scippneutron/file_loading/_log_data.py
+++ b/python/src/scippneutron/file_loading/_log_data.py
@@ -5,9 +5,8 @@
 import numpy as np
 from typing import Tuple, List, Union, Dict
 import scipp as sc
-from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group,
-                      NexusMeta)
-from ._nexus import LoadFromNexus
+from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group)
+from ._nexus import LoadFromNexus, NexusMeta
 from warnings import warn
 from dateutil.parser import parse as parse_date, ParserError
 

--- a/python/src/scippneutron/file_loading/_monitor_data.py
+++ b/python/src/scippneutron/file_loading/_monitor_data.py
@@ -1,4 +1,3 @@
-import h5py
 from typing import List, Dict
 import warnings
 from ._common import Group
@@ -19,22 +18,21 @@ def _load_data_from_histogram_mode_monitor(group: Group, nexus: LoadFromNexus):
     return sc.DataArray(data=data, coords=coords)
 
 
-def load_monitor_data(monitor_groups: List[Group], file_root: h5py.File,
-                      nexus: LoadFromNexus) -> Dict:
+def load_monitor_data(monitor_groups: List[Group], nexus_meta) -> Dict:
     monitor_data = {}
     for group in monitor_groups:
         monitor_name = group.path.split("/")[-1]
 
         # Look for event mode data structures in NXMonitor. Event-mode data takes
         # precedence over histogram-mode-data if available.
-        if nexus.dataset_in_group(group.group, "event_id")[0]:
-            events = load_detector_data([group], [], file_root, nexus, True, True)
+        if nexus_meta.nexus.dataset_in_group(group.group, "event_id")[0]:
+            events = load_detector_data([group], [], nexus_meta, True, True)
             monitor_data[monitor_name] = sc.scalar(value=events)
             warnings.warn(f"Event data present in NXMonitor group {group.path}. "
                           f"Histogram-mode monitor data from this group will be "
                           f"ignored.")
         else:
-            data = _load_data_from_histogram_mode_monitor(group, nexus)
+            data = _load_data_from_histogram_mode_monitor(group, nexus_meta.nexus)
             monitor_data[monitor_name] = sc.scalar(value=data)
 
     return monitor_data

--- a/python/src/scippneutron/file_loading/_monitor_data.py
+++ b/python/src/scippneutron/file_loading/_monitor_data.py
@@ -2,7 +2,7 @@ from typing import List, Dict
 import warnings
 from ._common import Group
 import scipp as sc
-from ._nexus import LoadFromNexus
+from ._nexus import LoadFromNexus, NexusMeta
 from ._detector_data import load_detector_data
 
 
@@ -18,7 +18,7 @@ def _load_data_from_histogram_mode_monitor(group: Group, nexus: LoadFromNexus):
     return sc.DataArray(data=data, coords=coords)
 
 
-def load_monitor_data(monitor_groups: List[Group], nexus_meta) -> Dict:
+def load_monitor_data(monitor_groups: List[Group], nexus_meta: NexusMeta) -> Dict:
     monitor_data = {}
     for group in monitor_groups:
         monitor_name = group.path.split("/")[-1]

--- a/python/src/scippneutron/file_loading/_nexus.py
+++ b/python/src/scippneutron/file_loading/_nexus.py
@@ -1,9 +1,20 @@
 from ._json_nexus import LoadFromJson
 from ._hdf5_nexus import LoadFromHdf5
-from typing import Union, Dict
+from typing import Union, Dict, Optional
+from dataclasses import dataclass
 import h5py
 import scipp as sc
 
 LoadFromNexus = Union[LoadFromJson, LoadFromHdf5]
 GroupObject = Union[h5py.Group, Dict]
 ScippData = Union[sc.Dataset, sc.DataArray, None]
+
+
+@dataclass
+class NexusMeta:
+    """
+    Data class to encapsulate access to an open nexus file.
+    """
+    nexus_file: Union[h5py.File, Dict]
+    nexus: LoadFromNexus
+    root: Optional[str] = "/"

--- a/python/src/scippneutron/file_loading/_sample.py
+++ b/python/src/scippneutron/file_loading/_sample.py
@@ -1,12 +1,11 @@
-from typing import List, Tuple, Union
-import h5py
+from typing import List, Tuple
 import numpy as np
 import scipp as sc
-from ._common import Group, _add_attr_to_loaded_data
+from ._common import Group
 from ._nexus import LoadFromNexus, GroupObject
 
 
-def _get_matrix_of_component(group: GroupObject, nx_class: str, nexus: LoadFromNexus,
+def _get_matrix_of_component(group: GroupObject, nexus: LoadFromNexus,
                              name: str) -> Tuple[np.ndarray, sc.Unit]:
     matrix_found, _ = nexus.dataset_in_group(group, name)
     if matrix_found:
@@ -16,37 +15,30 @@ def _get_matrix_of_component(group: GroupObject, nx_class: str, nexus: LoadFromN
         return None
 
 
-def _get_ub_of_component(group: GroupObject, nx_class: str,
+def _get_ub_of_component(group: GroupObject,
                          nexus: LoadFromNexus) -> Tuple[np.ndarray, sc.Unit]:
-    return _get_matrix_of_component(group, nx_class, nexus,
-                                    "ub_matrix"), sc.units.angstrom**-1
+    return _get_matrix_of_component(group, nexus, "ub_matrix"), sc.units.angstrom**-1
 
 
-def _get_u_of_component(group: GroupObject, nx_class: str,
+def _get_u_of_component(group: GroupObject,
                         nexus: LoadFromNexus) -> Tuple[np.ndarray, sc.Unit]:
-    return _get_matrix_of_component(group, nx_class, nexus,
-                                    "orientation_matrix"), sc.units.one
+    return _get_matrix_of_component(group, nexus, "orientation_matrix"), sc.units.one
 
 
-def load_ub_matrices_of_components(groups: List[Group], data: Union[sc.DataArray,
-                                                                    sc.Dataset],
-                                   name: str, nx_class: str, file_root: h5py.File,
+def load_ub_matrices_of_components(groups: List[Group], name: str,
                                    nexus: LoadFromNexus):
+    ub_matrices = {}
     properties = {"ub_matrix": _get_ub_of_component, "u_matrix": _get_u_of_component}
     for sc_property, extractor in properties.items():
         for group in groups:
-            matrix, units = extractor(group.group, nx_class, nexus)
+            matrix, units = extractor(group.group, nexus)
             if matrix is None:
                 continue
+
             if len(groups) == 1:
-                _add_attr_to_loaded_data(f"{name}_{sc_property}",
-                                         data,
-                                         matrix,
-                                         unit=units,
-                                         dtype=sc.dtype.matrix_3_float64)
+                name = f"{name}_{sc_property}"
             else:
-                _add_attr_to_loaded_data(f"{nexus.get_name(group.group)}_{sc_property}",
-                                         data,
-                                         matrix,
-                                         unit=units,
-                                         dtype=sc.dtype.matrix_3_float64)
+                name = f"{nexus.get_name(group.group)}_{sc_property}"
+
+            ub_matrices[name] = sc.matrix(value=matrix, unit=units)
+    return ub_matrices

--- a/python/src/scippneutron/file_loading/load_nexus.py
+++ b/python/src/scippneutron/file_loading/load_nexus.py
@@ -92,7 +92,7 @@ def _load_sample(sample_groups: List[Group], nexus_meta: NexusMeta):
     ub_matrices = load_ub_matrices_of_components(sample_groups, "sample",
                                                  nexus_meta.nexus)
 
-    return positions | ub_matrices
+    return {**positions, **ub_matrices}
 
 
 def _load_source(source_groups: List[Group], nexus_meta: NexusMeta):

--- a/python/tests/test_load_nexus_metadata.py
+++ b/python/tests/test_load_nexus_metadata.py
@@ -75,7 +75,7 @@ def test_load_nexus_sample_metadata():
 
 def test_load_nexus_disk_chopper_metadata():
     builder = NexusBuilder()
-    builder.add_chopper(Chopper(name="chopper_1", distance=8.0, rotation_speed=300))
+    builder.add_chopper(Chopper(name="chopper_1", distance=8.0, rotation_speed=300.0))
 
     with builder.file() as file:
         loaded = load_nexus_disk_chopper(file)
@@ -86,7 +86,7 @@ def test_load_nexus_disk_chopper_metadata():
                      coords={},
                      attrs={
                          "distance": sc.scalar(8.0),
-                         "rotation_speed": sc.scalar(300, dtype=sc.dtype.int32),
+                         "rotation_speed": sc.scalar(300.0),
                      }))
 
 

--- a/python/tests/test_load_nexus_metadata.py
+++ b/python/tests/test_load_nexus_metadata.py
@@ -1,0 +1,135 @@
+from .nexus_helpers import (
+    NexusBuilder,
+    Log,
+    Sample,
+    Source,
+    Monitor,
+    Chopper,
+)
+import numpy as np
+import scipp as sc
+from scippneutron import load_nexus_monitors, \
+    load_nexus_instrument_name, load_nexus_disk_chopper, load_nexus_sample, \
+    load_nexus_source, load_nexus_start_and_end_time, load_nexus_title, load_nexus_logs
+
+
+def test_load_log_metadata():
+    builder = NexusBuilder()
+    log_1 = Log("test_log", np.array([1.1, 2.2, 3.3]), np.array([4.4, 5.5, 6.6]))
+    log_2 = Log("test_log_2", np.array([123, 253, 756]), np.array([246, 1235, 2369]))
+    builder.add_log(log_1)
+    builder.add_log(log_2)
+
+    with builder.file() as file:
+        loaded = load_nexus_logs(file)
+
+    assert np.allclose(loaded[log_1.name].values.data.values, log_1.value)
+    assert np.allclose(loaded[log_1.name].values.coords['time'].values, log_1.time)
+    assert np.array_equal(loaded[log_2.name].values.data.values, log_2.value)
+    assert np.array_equal(loaded[log_2.name].values.coords['time'].values, log_2.time)
+
+
+def test_load_title_metadata():
+    builder = NexusBuilder()
+    builder.add_title("my_experiment_title")
+
+    with builder.file() as file:
+        loaded = load_nexus_title(file)
+
+    assert sc.identical(loaded["experiment_title"], sc.scalar("my_experiment_title"))
+
+
+def test_load_start_and_end_time_metadata():
+    builder = NexusBuilder()
+    builder.add_run_start_time("1980-01-01T06:00:00Z")
+    builder.add_run_end_time("1990-01-01T06:00:00Z")
+
+    with builder.file() as file:
+        loaded = load_nexus_start_and_end_time(file)
+
+    assert sc.identical(loaded["start_time"], sc.scalar("1980-01-01T06:00:00Z"))
+    assert sc.identical(loaded["end_time"], sc.scalar("1990-01-01T06:00:00Z"))
+
+
+def test_load_nexus_source_metadata():
+    builder = NexusBuilder()
+    builder.add_source(Source(name="source_1", distance=5.0, distance_units="m"))
+
+    with builder.file() as file:
+        loaded = load_nexus_source(file)
+
+    assert sc.identical(loaded["source_position"],
+                        sc.vector(value=[0, 0, 5], unit=sc.units.m))
+
+
+def test_load_nexus_sample_metadata():
+    builder = NexusBuilder()
+    builder.add_sample(Sample(name="sample_1", distance=3.0, distance_units="m"))
+
+    with builder.file() as file:
+        loaded = load_nexus_sample(file)
+
+    assert sc.identical(loaded["sample_position"],
+                        sc.vector(value=[0, 0, 3], unit=sc.units.m))
+
+
+def test_load_nexus_disk_chopper_metadata():
+    builder = NexusBuilder()
+    builder.add_chopper(Chopper(name="chopper_1", distance=8.0, rotation_speed=300))
+
+    with builder.file() as file:
+        loaded = load_nexus_disk_chopper(file)
+
+    assert sc.identical(
+        loaded["chopper_1"],
+        sc.DataArray(data=sc.scalar("chopper_1"),
+                     coords={},
+                     attrs={
+                         "distance": sc.scalar(8.0),
+                         "rotation_speed": sc.scalar(300, dtype=sc.dtype.int32),
+                     }))
+
+
+def test_load_nexus_inst_name_metadata():
+    builder = NexusBuilder()
+    builder.add_instrument("my_instrument_name")
+
+    with builder.file() as file:
+        loaded = load_nexus_instrument_name(file)
+
+    assert sc.identical(loaded["instrument_name"], sc.scalar("my_instrument_name"))
+
+
+def test_load_monitor_metadata():
+    builder = NexusBuilder()
+    builder.add_monitor(
+        Monitor(
+            name="monitor1",
+            data=np.ones(shape=(2, 4, 6), dtype="float64"),
+            axes=[
+                ("event_index", np.arange(3, 5, dtype="float64")),
+                ("period_index", np.arange(3, 7, dtype="float64")),
+                ("time_of_flight", np.arange(3, 9, dtype="float64")),
+            ],
+        ))
+
+    with builder.file() as file:
+        loaded = load_nexus_monitors(file)
+
+    assert sc.identical(
+        loaded["monitor1"].values,
+        sc.DataArray(data=sc.ones(
+            dims=["event_index", "period_index", "time_of_flight"],
+            shape=(2, 4, 6),
+            dtype=sc.dtype.float64),
+                     coords={
+                         "event_index":
+                         sc.Variable(dims=["event_index"],
+                                     values=np.arange(3, 5, dtype="float64")),
+                         "period_index":
+                         sc.Variable(dims=["period_index"],
+                                     values=np.arange(3, 7, dtype="float64")),
+                         "time_of_flight":
+                         sc.Variable(dims=["time_of_flight"],
+                                     values=np.arange(3, 9, dtype="float64")),
+                     }))


### PR DESCRIPTION
Fixes https://github.com/scipp/scippneutron/issues/141

- Refactor all metadata loading functions to use a common interface
- Add user-facing functions that can be used to load individual metadata items (title, logs, source, sample, ...) from a file without loading that entire file.

Draft at this stage - still need to support loading non-metadata classes (e.g. NXevent_data) and add separate unit tests for the new metadata-loading functions.