### PR TITLE
use agg matplotlib backend for tests

### DIFF
--- a/python/tests/test_instrument_view.py
+++ b/python/tests/test_instrument_view.py
@@ -4,8 +4,8 @@ import numpy as np
 from .common import make_dataset_with_beamline
 import pytest
 
-
 import matplotlib
+
 matplotlib.use('Agg')
 
 


### PR DESCRIPTION
Use the `Agg` matplotlib backend in tests for scippneutron to avoid intermittent failures initialising TK on windows.

Believed to be the same issue/fix as in https://github.com/scipp/scipp/pull/2231 