### PR TITLE
Remove root arg from load functions

### DIFF
--- a/python/src/scippneutron/file_loading/_common.py
+++ b/python/src/scippneutron/file_loading/_common.py
@@ -2,8 +2,7 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Matthew Jones
 
-from dataclasses import dataclass
-from typing import Union, Dict, Optional, Any
+from typing import Union, Optional, Any
 import h5py
 import scipp as sc
 import numpy as np
@@ -33,40 +32,15 @@ class MissingAttribute(Exception):
     pass
 
 
-@dataclass
-class JSONGroup:
-    """
-    This class exists because h5py.Group has a "parent" property,
-    but we also need to access the parent when parsing Dict
-    loaded from json
-    """
-    group: Dict
-    parent: Dict
-    name: str
-    file: Dict
+class JSONGroup(dict):
+    def __init__(self, parent: dict, name: str, file: dict, group: dict):
+        super().__init__(**group)
+        self.parent = parent
+        self.name = name
+        self.file = file
 
 
-class H5PYGroup:
-    """
-    Thin wrapper around a h5py group to give it the same interface as JSONGroup above.
-    """
-    def __init__(self, group: h5py.Group):
-        self.group: h5py.Group = group
-
-    @property
-    def parent(self) -> h5py.Group:
-        return self.group.parent
-
-    @property
-    def name(self) -> str:
-        return self.group.name
-
-    @property
-    def file(self) -> h5py.File:
-        return self.group.file
-
-
-Group = Union[H5PYGroup, JSONGroup]
+Group = Union[h5py.Group, JSONGroup]
 
 
 def _add_attr_to_loaded_data(attr_name: str,

--- a/python/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/python/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -8,7 +8,7 @@ from typing import Union, Any, List, Optional, Tuple, Dict
 import h5py
 import numpy as np
 import scipp as sc
-from ._common import Group, H5PYGroup, MissingDataset, MissingAttribute
+from ._common import Group, MissingDataset, MissingAttribute
 
 
 def _cset_to_encoding(cset: int) -> str:
@@ -107,7 +107,7 @@ class LoadFromHdf5:
                 try:
                     nx_class = _get_attr_as_str(h5_object, "NX_class")
                     if nx_class in nx_class_names:
-                        found_groups[nx_class].append(H5PYGroup(h5_object))
+                        found_groups[nx_class].append(h5_object)
                 except KeyError:
                     pass
 

--- a/python/src/scippneutron/file_loading/_json_nexus.py
+++ b/python/src/scippneutron/file_loading/_json_nexus.py
@@ -73,7 +73,7 @@ def _visit_nodes(root: Dict, nx_class_names: Tuple[str, ...],
                         JSONGroup(group=child,
                                   parent=root,
                                   name="/".join(path),
-                                  file={"children": [root]}))
+                                  file={_nexus_children: [root]}))
             except MissingAttribute:
                 # It may be a group but not an NX_class,
                 # that's fine, continue to its children
@@ -118,7 +118,7 @@ def _find_by_type(type_name: str, root: Dict) -> List[Group]:
                         JSONGroup(group=child,
                                   parent=obj,
                                   name="",
-                                  file={"children": [obj]}))
+                                  file={_nexus_children: [obj]}))
                 _visit_nodes_for_type(child, requested_type, objects_found)
         except KeyError:
             # If this object does not have "children" array then go to next
@@ -328,12 +328,10 @@ def get_streams_info(root: Dict) -> List[StreamInfo]:
     streams = []
     for stream in found_streams:
         try:
-            dtype = _filewriter_to_supported_numpy_dtype[stream.group["stream"]
-                                                         ["dtype"]]
+            dtype = _filewriter_to_supported_numpy_dtype[stream["stream"]["dtype"]]
         except KeyError:
             try:
-                dtype = _filewriter_to_supported_numpy_dtype[stream.group["stream"]
-                                                             ["type"]]
+                dtype = _filewriter_to_supported_numpy_dtype[stream["stream"]["type"]]
             except KeyError:
                 dtype = None
 
@@ -344,7 +342,6 @@ def get_streams_info(root: Dict) -> List[StreamInfo]:
             pass
 
         streams.append(
-            StreamInfo(stream.group["stream"]["topic"],
-                       stream.group["stream"]["writer_module"],
-                       stream.group["stream"]["source"], dtype, units))
+            StreamInfo(stream["stream"]["topic"], stream["stream"]["writer_module"],
+                       stream["stream"]["source"], dtype, units))
     return streams

--- a/python/src/scippneutron/file_loading/_monitor_data.py
+++ b/python/src/scippneutron/file_loading/_monitor_data.py
@@ -7,14 +7,11 @@ from ._detector_data import load_detector_data
 
 
 def _load_data_from_histogram_mode_monitor(group: Group, nexus: LoadFromNexus):
-    dims = nexus.get_string_attribute(nexus.get_child_from_group(group.group, "data"),
+    dims = nexus.get_string_attribute(nexus.get_child_from_group(group, "data"),
                                       "axes").split(",")
 
-    data = nexus.load_dataset(group.group, "data", dimensions=dims)
-    coords = {
-        dim: nexus.load_dataset(group.group, dim, dimensions=[dim])
-        for dim in dims
-    }
+    data = nexus.load_dataset(group, "data", dimensions=dims)
+    coords = {dim: nexus.load_dataset(group, dim, dimensions=[dim]) for dim in dims}
     return sc.DataArray(data=data, coords=coords)
 
 
@@ -25,7 +22,7 @@ def load_monitor_data(monitor_groups: List[Group], nexus: LoadFromNexus) -> Dict
 
         # Look for event mode data structures in NXMonitor. Event-mode data takes
         # precedence over histogram-mode-data if available.
-        if nexus.dataset_in_group(group.group, "event_id")[0]:
+        if nexus.dataset_in_group(group, "event_id")[0]:
             events = load_detector_data([group], [], nexus, True, True)
             monitor_data[monitor_name] = sc.scalar(value=events)
             warnings.warn(f"Event data present in NXMonitor group {group.name}. "

--- a/python/src/scippneutron/file_loading/_positions.py
+++ b/python/src/scippneutron/file_loading/_positions.py
@@ -52,7 +52,7 @@ def load_positions_of_components(groups: List[Group],
                                       unit=units,
                                       dtype=sc.dtype.vector_3_float64)
         else:
-            _add_coord_to_loaded_data(f"{nexus.get_name(group.group)}_position",
+            _add_coord_to_loaded_data(f"{nexus.get_name(group)}_position",
                                       data,
                                       position,
                                       unit=units,
@@ -65,8 +65,8 @@ def _get_position_of_component(
         nx_class: str,
         nexus: LoadFromNexus,
         default_position: Optional[np.ndarray] = None) -> Tuple[np.ndarray, sc.Unit]:
-    depends_on_found, _ = nexus.dataset_in_group(group.group, "depends_on")
-    distance_found, _ = nexus.dataset_in_group(group.group, "distance")
+    depends_on_found, _ = nexus.dataset_in_group(group, "depends_on")
+    distance_found, _ = nexus.dataset_in_group(group, "distance")
     if depends_on_found:
         try:
             position = get_position_from_transformations(group, nexus)
@@ -76,11 +76,10 @@ def _get_position_of_component(
         units = sc.units.m
     elif distance_found:
 
-        position = np.array([
-            0, 0,
-            nexus.load_dataset_from_group_as_numpy_array(group.group, "distance")
-        ])
-        units = nexus.get_unit(nexus.get_dataset_from_group(group.group, "distance"))
+        position = np.array(
+            [0, 0,
+             nexus.load_dataset_from_group_as_numpy_array(group, "distance")])
+        units = nexus.get_unit(nexus.get_dataset_from_group(group, "distance"))
         if units == sc.units.dimensionless:
             warn(f"'distance' dataset in {nx_class} is missing "
                  f"units attribute, skipping loading {name} position")

--- a/python/src/scippneutron/file_loading/_sample.py
+++ b/python/src/scippneutron/file_loading/_sample.py
@@ -33,7 +33,7 @@ def load_ub_matrices_of_components(groups: List[Group], data: Union[sc.DataArray
     properties = {"ub_matrix": _get_ub_of_component, "u_matrix": _get_u_of_component}
     for sc_property, extractor in properties.items():
         for group in groups:
-            matrix, units = extractor(group.group, nx_class, nexus)
+            matrix, units = extractor(group, nx_class, nexus)
             if matrix is None:
                 continue
             if len(groups) == 1:
@@ -43,7 +43,7 @@ def load_ub_matrices_of_components(groups: List[Group], data: Union[sc.DataArray
                                          unit=units,
                                          dtype=sc.dtype.matrix_3_float64)
             else:
-                _add_attr_to_loaded_data(f"{nexus.get_name(group.group)}_{sc_property}",
+                _add_attr_to_loaded_data(f"{nexus.get_name(group)}_{sc_property}",
                                          data,
                                          matrix,
                                          unit=units,

--- a/python/src/scippneutron/file_loading/_transformations.py
+++ b/python/src/scippneutron/file_loading/_transformations.py
@@ -62,11 +62,11 @@ def get_full_transformation_matrix(group: Group, nexus: LoadFromNexus) -> np.nda
     """
     transformations = []
     try:
-        depends_on = nexus.load_scalar_string(group.group, "depends_on")
+        depends_on = nexus.load_scalar_string(group, "depends_on")
     except MissingDataset:
         depends_on = '.'
-    _get_transformations(depends_on, transformations, group,
-                         nexus.get_name(group.group), nexus)
+    _get_transformations(depends_on, transformations, group, nexus.get_name(group),
+                         nexus)
     total_transform_matrix = np.identity(4)
     for transformation in transformations:
         total_transform_matrix = np.matmul(transformation, total_transform_matrix)

--- a/python/src/scippneutron/file_loading/load_nexus.py
+++ b/python/src/scippneutron/file_loading/load_nexus.py
@@ -52,11 +52,10 @@ def _load_instrument_name(instrument_groups: List[Group], nexus: LoadFromNexus) 
     try:
         if len(instrument_groups) > 1:
             warn(f"More than one {nx_instrument} found in file, "
-                 f"loading name from {instrument_groups[0].group.name} only")
+                 f"loading name from {instrument_groups[0].name} only")
         return {
             "instrument_name":
-            sc.scalar(
-                value=nexus.load_scalar_string(instrument_groups[0].group, "name"))
+            sc.scalar(value=nexus.load_scalar_string(instrument_groups[0], "name"))
         }
     except MissingDataset:
         return {}
@@ -66,10 +65,9 @@ def _load_chopper(chopper_groups: List[Group], nexus: LoadFromNexus) -> Dict:
     choppers = {}
     for chopper_group in chopper_groups:
         chopper_name = chopper_group.name.split("/")[-1]
-        rotation_speed = nexus.load_dataset(group=chopper_group.group,
+        rotation_speed = nexus.load_dataset(group=chopper_group,
                                             dataset_name="rotation_speed")
-        distance = nexus.load_dataset(group=chopper_group.group,
-                                      dataset_name="distance")
+        distance = nexus.load_dataset(group=chopper_group, dataset_name="distance")
         choppers[chopper_name] = sc.DataArray(data=sc.scalar(value=chopper_name),
                                               attrs={
                                                   "rotation_speed": rotation_speed,
@@ -97,7 +95,7 @@ def _load_title(entry_group: Group, nexus: LoadFromNexus) -> Dict:
     try:
         return {
             "experiment_title":
-            sc.scalar(value=nexus.load_scalar_string(entry_group.group, "title"))
+            sc.scalar(value=nexus.load_scalar_string(entry_group, "title"))
         }
     except MissingDataset:
         return {}
@@ -107,8 +105,7 @@ def _load_start_and_end_time(entry_group: Group, nexus: LoadFromNexus) -> Dict:
     times = {}
     for time in ["start_time", "end_time"]:
         try:
-            times[time] = sc.scalar(
-                value=nexus.load_scalar_string(entry_group.group, time))
+            times[time] = sc.scalar(value=nexus.load_scalar_string(entry_group, time))
         except MissingDataset:
             pass
     return times


### PR DESCRIPTION
Remove explicit `root` arguments from load functions, instead using properties of `H5PYGroup` or `JSONGroup`.

Relates to https://github.com/scipp/scippneutron/issues/141#issuecomment-949480799