### PR TITLE
Fix invisible plots in docs

### DIFF
--- a/docs/_templates/topbar/launchbuttons.html
+++ b/docs/_templates/topbar/launchbuttons.html
@@ -3,7 +3,7 @@
      This allows us to add the version selection menu in some unused white space
      that is always visible. -->
 <div class="dropdown-buttons-trigger">
-    <button id="dropdown-buttons-trigger" class="btn btn-secondary topbarbtn" style="font-size: 1em;padding-top:0.33rem;">Scippneutron version
+    <button id="dropdown-buttons-trigger" class="btn btn-secondary topbarbtn" style="font-size: 1em;padding-top:0.33rem;">Version
       <i class="fa fa-caret-down"></i>
     </button>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,7 +188,7 @@ texinfo_documents = [
 # -- Options for Matplotlib in notebooks ----------------------------------
 
 nbsphinx_execute_arguments = [
-    "--Session.metadata='scipp_docs_build=True'",
+    "--Session.metadata=scipp_docs_build=True",
 ]
 
 # -- Options for doctest --------------------------------------------------


### PR DESCRIPTION
There was a bad syntax for the `Session.metadata` in the `nbsphinx_execute_arguments` inside the `docs/conf.py` file.

I also changed `Scippneutron version` to `Version`, as I felt it was a bit too long.