### PR TITLE
Remove find_package calls for dependencies of scipp

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,13 +64,10 @@ conan_cmake_install(
   BUILD outdated
 )
 
-find_package(Boost 1.67 REQUIRED)
-find_package(Eigen3 REQUIRED)
 find_package(GTest CONFIG REQUIRED)
 find_package(Python 3.7 REQUIRED COMPONENTS Interpreter Development)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(scipp 0.9 REQUIRED)
-find_package(LLNL-Units REQUIRED)
 
 # MP : Parallel compile, add before any targets so all use it
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:-MP>)


### PR DESCRIPTION
I believe these are redundant, since `find_package(scipp)` should pull these in.