### PR TITLE
Return floats in `convert`

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -6,6 +6,11 @@ Release Notes
 Since v0.4.1
 ------------
 
+Bugfixes
+~~~~~~~~
+
+* Change output dtype of ``convert`` to always be floating point, fixes incorrect truncation of the result to integer if, e.g. ``tof`` is an integer `#230 <https://github.com/scipp/scippneutron/pull/230>`_.
+
 v0.4.1 (November 2021)
 ----------------------
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -9,7 +9,7 @@ Since v0.4.1
 Bugfixes
 ~~~~~~~~
 
-* Change output dtype of ``convert`` to always be floating point, fixes incorrect truncation of the result to integer if, e.g. ``tof`` is an integer `#230 <https://github.com/scipp/scippneutron/pull/230>`_.
+* Change output dtype of graphs for coordinate transformations to always be floating point, fixes incorrect truncation of the result to integer if, e.g. ``tof`` is an integer (this also affects ``convert``) `#230 <https://github.com/scipp/scippneutron/pull/230>`_.
 
 v0.4.1 (November 2021)
 ----------------------


### PR DESCRIPTION
Currently, the building blocks of `convert` return the dtype of the input. It is reasonable to store `tof` as integers, but this would mean that, e.g., `wavelength` is returned as integers, too, which makes no sense and truncates the results.
This PR changes that behaviour to always returns floats while preserving the precision of the input. (Except that `int32` inputs yield `float64` outputs.)