### PR TITLE
Avoid long lines in docs and modernize syntax

### DIFF
--- a/docs/tutorials/1_exploring-data.ipynb
+++ b/docs/tutorials/1_exploring-data.ipynb
@@ -206,7 +206,10 @@
     "try:\n",
     "    data / data.attrs['monitor1'].value\n",
     "except sc.CoordError:\n",
-    "    print('Data and monitor are in unit TOF, but pixels and monitors are at different position, so data is not comparable')"
+    "    print(\n",
+    "        \"\"\"Data and monitor are in unit TOF, but pixels and monitors\n",
+    "are at different position, so data is not comparable.\"\"\"\n",
+    "    )"
    ]
   },
   {
@@ -244,7 +247,8 @@
    },
    "outputs": [],
    "source": [
-    "sc.plot({f'monitor{i}':data.attrs[f'monitor{i}'].value for i in [1,2,3,4,5]}, norm='log')"
+    "monitors = {f'monitor{i}': data.attrs[f'monitor{i}'].value for i in [1, 2, 3, 4, 5]}\n",
+    "sc.plot(monitors, norm='log')"
    ]
   },
   {
@@ -257,7 +261,13 @@
    },
    "outputs": [],
    "source": [
-    "sc.plot({f'monitor{i}':scn.convert(data.attrs[f'monitor{i}'].value, 'tof', 'wavelength', scatter=False) for i in [1,2,3,4,5]}, norm='log')"
+    "converted_monitors = {\n",
+    "    f'monitor{i}': scn.convert(\n",
+    "        data.attrs[f'monitor{i}'].value, 'tof', 'wavelength', scatter=False\n",
+    "    )\n",
+    "    for i in [1, 2, 3, 4, 5]\n",
+    "}\n",
+    "sc.plot(converted_monitors, norm='log')"
    ]
   },
   {
@@ -290,7 +300,7 @@
    },
    "outputs": [],
    "source": [
-    "data.coords['sample_position'] += sc.vector(value=[0.01,0.01,0.04], unit='m')\n",
+    "data.coords['sample_position'] += sc.vector(value=[0.01, 0.01, 0.04], unit='m')\n",
     "data.coords['tof'] += 2.3 * sc.Unit('us')  # note how we forgot to fix the monitor's TOF\n",
     "data"
    ]
@@ -445,7 +455,7 @@
    },
    "outputs": [],
    "source": [
-    "data['spectrum',10000].plot()"
+    "data['spectrum', 10000].plot()"
    ]
   },
   {
@@ -468,7 +478,7 @@
     "z = data.coords['position'].fields.z\n",
     "near = z.min()\n",
     "far = z.max()\n",
-    "layer = ((z-near)*400).astype('int32')\n",
+    "layer = ((z - near) * 400).astype('int32')\n",
     "layer.unit = ''\n",
     "layer.plot()"
    ]
@@ -508,7 +518,7 @@
     "# NOTE:\n",
     "# - set magic factor to, e.g., 150 to group by straw layer\n",
     "# - set magic factor to, e.g., 40 to group by tube layer\n",
-    "layer = ((z-near)*150).astype(sc.dtype.int32)\n",
+    "layer = ((z - near) * 150).astype(sc.dtype.int32)\n",
     "layer.unit = ''\n",
     "data.coords['layer'] = layer\n",
     "grouped = data.groupby(group='layer').sum('spectrum')\n",
@@ -538,9 +548,9 @@
    },
    "outputs": [],
    "source": [
-    "norm = sc.DataArray(data=sc.ones_like(layer), coords={'layer':layer})\n",
+    "norm = sc.DataArray(data=sc.ones_like(layer), coords={'layer': layer})\n",
     "norm = norm.groupby(group='layer').sum('spectrum')\n",
-    "sc.plot(sc.collapse(grouped/norm, keep='tof'))"
+    "sc.plot(sc.collapse(grouped / norm, keep='tof'))"
    ]
   }
  ],
@@ -560,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/2_working-with-masks.ipynb
+++ b/docs/tutorials/2_working-with-masks.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "data = scn.data.tutorial_dense_data()\n",
-    "counts = data.sum('tof') # used later\n",
+    "counts = data.sum('tof')  # used later\n",
     "data"
    ]
   },
@@ -112,7 +112,8 @@
     "prompt_start = 17500 * sc.Unit('us')\n",
     "prompt_stop = 19000 * sc.Unit('us')\n",
     "tof = data.coords['tof']\n",
-    "data.masks['prompt-pulse'] = (tof['tof',:-1] > prompt_start) & (tof['tof',:-1] < prompt_stop)\n",
+    "mask = (tof['tof', :-1] > prompt_start) & (tof['tof', :-1] < prompt_stop)\n",
+    "data.masks['prompt-pulse'] = mask\n",
     "data"
    ]
   },
@@ -140,7 +141,7 @@
    "outputs": [],
    "source": [
     "tof = data.coords['tof']\n",
-    "sc.plot({'before':counts, 'after':data.sum('tof')})"
+    "sc.plot({'before': counts, 'after': data.sum('tof')})"
    ]
   },
   {
@@ -172,7 +173,7 @@
    "source": [
     "x = data.coords['position'].fields.x\n",
     "data.masks['tube-ends'] = sc.abs(x) > 0.5 * sc.Unit('m')\n",
-    "scn.instrument_view(sc.sum(data, 'tof'), norm='log') # sum and norm are optional"
+    "scn.instrument_view(sc.sum(data, 'tof'), norm='log')  # sum and norm are optional"
    ]
   },
   {
@@ -219,7 +220,7 @@
    "source": [
     "broken = (counts.data == 0.0 * sc.Unit('counts')) & (sc.abs(x) < 0.1 * sc.Unit('m'))\n",
     "data.masks['bad-pixels'] = broken\n",
-    "scn.instrument_view(sc.sum(data, 'tof')) # sum is optional"
+    "scn.instrument_view(sc.sum(data, 'tof'))  # sum is optional"
    ]
   },
   {
@@ -258,7 +259,7 @@
     "z = pos.fields.z\n",
     "\n",
     "# could use offsets x0 and y0 to mask away from z axis\n",
-    "r = sc.sqrt(x*x + y*y)\n",
+    "r = sc.sqrt(x * x + y * y)\n",
     "data.masks['circle'] = r < 0.09 * sc.units.m\n",
     "\n",
     "data.masks['ring'] = (0.14 * sc.units.m < r) & (r < 0.19 * sc.units.m)\n",
@@ -266,8 +267,8 @@
     "theta = 0.5 * scn.two_theta(data)\n",
     "data.masks['theta'] = (0.03 * sc.units.rad < theta) & (theta < 0.04 * sc.units.rad)\n",
     "\n",
-    "# sc.to_unit is optional, but useful if we prefer thinking in degrees rather than radians\n",
-    "phi = sc.to_unit(sc.atan2(y=y,x=x), unit='deg')\n",
+    "# sc.to_unit is optional, but useful if we prefer degrees rather than radians\n",
+    "phi = sc.to_unit(sc.atan2(y=y, x=x), unit='deg')\n",
     "data.masks['wedge'] = (10.0 * sc.units.deg < phi) & (phi < 20.0 * sc.units.deg)\n",
     "\n",
     "scn.instrument_view(sc.sum(data, 'tof'), norm='log')"
@@ -347,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/3_understanding-event-data.ipynb
+++ b/docs/tutorials/3_understanding-event-data.ipynb
@@ -44,6 +44,7 @@
    "source": [
     "import scipp as sc\n",
     "import scippneutron as scn\n",
+    "\n",
     "da = scn.data.tutorial_event_data()\n",
     "da.plot()"
    ]
@@ -270,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.table(spec.values[0]['event',:5])"
+    "sc.table(spec.values[0]['event', :5])"
    ]
   },
   {
@@ -355,12 +356,16 @@
     "# Start and stop are fictitious and this prompt pulse is not actually present in the raw data from SNS\n",
     "prompt_start = 4000.0 * sc.Unit('us')\n",
     "prompt_stop = 5000.0 * sc.Unit('us')\n",
-    "prompt_tof_edges = sc.sort(sc.concat([spec.coords['tof'], prompt_start, prompt_stop], 'tof'), 'tof')\n",
-    "prompt = sc.DataArray(data=sc.Variable(dims=['tof'], values=[0,11000,0], unit='counts'),\n",
-    "            coords={'tof':prompt_tof_edges})\n",
+    "prompt_tof_edges = sc.sort(\n",
+    "    sc.concat([spec.coords['tof'], prompt_start, prompt_stop], 'tof'), 'tof'\n",
+    ")\n",
+    "prompt = sc.DataArray(\n",
+    "    data=sc.array(dims=['tof'], values=[0, 11000, 0], unit='counts'),\n",
+    "    coords={'tof': prompt_tof_edges},\n",
+    ")\n",
     "tof_edges = sc.linspace(dim='tof', start=0.0, stop=17000, num=1701, unit='us')\n",
     "spec_hist = sc.histogram(da.bins.concat('spectrum'), bins=tof_edges)\n",
-    "sc.plot({'spec':spec_hist, 'prompt':prompt})"
+    "sc.plot({'spec': spec_hist, 'prompt': prompt})"
    ]
   },
   {
@@ -386,7 +391,9 @@
    "source": [
     "spec1 = da['spectrum', 8050].copy()  # copy since we do some modifications below\n",
     "event_tof = spec.bins.coords['tof']\n",
-    "spec1.bins.masks['prompt_pulse'] = (prompt_start <= event_tof) & (event_tof < prompt_stop)\n",
+    "spec1.bins.masks['prompt_pulse'] = (prompt_start <= event_tof) & (\n",
+    "    event_tof < prompt_stop\n",
+    ")\n",
     "sc.plot({'original': da['spectrum', 8050], 'prompt_mask': spec1})"
    ]
   },
@@ -419,7 +426,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.table(spec1.values[0]['event',:5])\n",
+    "sc.table(spec1.values[0]['event', :5])\n",
     "sc.show(spec1)"
    ]
   },
@@ -527,7 +534,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot({'event-mask':spec1, 'bin-mask (1.1x)':spec2*sc.scalar(1.1)})"
+    "sc.plot({'event-mask': spec1, 'bin-mask (1.1x)': spec2 * sc.scalar(1.1)})"
    ]
   },
   {
@@ -599,7 +606,12 @@
    "source": [
     "tmin = proton_charge.coords['time'].min()\n",
     "tmax = proton_charge.coords['time'].max()\n",
-    "pulse_time = sc.arange(dim='pulse_time', start=tmin.value, stop=tmax.value, step=(tmax.value - tmin.value) / 10)\n",
+    "pulse_time = sc.arange(\n",
+    "    dim='pulse_time',\n",
+    "    start=tmin.value,\n",
+    "    stop=tmax.value,\n",
+    "    step=(tmax.value - tmin.value) / 10,\n",
+    ")\n",
     "pulse_time"
    ]
   },
@@ -659,7 +671,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "binned_spec.plot(resolution={'x':100, 'y':20})"
+    "binned_spec.plot(resolution={'x': 100, 'y': 20})"
    ]
   },
   {
@@ -739,8 +751,8 @@
    "outputs": [],
    "source": [
     "pulse_time_edges = tmin + sc.to_unit(\n",
-    "    sc.array(dims=['pulse_time'],\n",
-    "             values=[0, 43, 55, 92], unit='min'), 'ns')\n",
+    "    sc.array(dims=['pulse_time'], values=[0, 43, 55, 92], unit='min'), 'ns'\n",
+    ")\n",
     "# Alternative solution to creating edges:\n",
     "# t1 = tmin + sc.to_unit(43 * sc.Unit('min'), 'ns')\n",
     "# t2 = tmin + sc.to_unit(55 * sc.Unit('min'), 'ns')\n",
@@ -750,7 +762,7 @@
     "binned_spec = sc.bin(spec, edges=[prompt_tof_edges, pulse_time_edges])\n",
     "binned_spec.masks['prompt_pulse'] = prompt_mask\n",
     "binned_spec.masks['bad_beam'] = pulse_time_mask\n",
-    "binned_spec.plot(resolution={'x':100, 'y':20})"
+    "binned_spec.plot(resolution={'x': 100, 'y': 20})"
    ]
   },
   {
@@ -832,6 +844,7 @@
    "outputs": [],
    "source": [
     "import scippneutron as scn\n",
+    "\n",
     "da_dspacing = scn.convert(binned_da, 'tof', 'dspacing', scatter=True)\n",
     "# `dspacing` is now a multi-dimensional coordinate, which makes plotting inconvenient, so we adapt the binning\n",
     "dspacing = sc.linspace(dim='dspacing', unit='Angstrom', start=0.0, stop=3.0, num=4)\n",
@@ -894,7 +907,7 @@
     "tmp = da_dspacing_total\n",
     "lines = {}\n",
     "lines['total'] = tmp.bins.concat('pulse_time')\n",
-    "for i in 0,2:\n",
+    "for i in 0, 2:\n",
     "    lines[f'interval{i}'] = tmp['pulse_time', i]\n",
     "sc.plot(lines, resolution=1000, norm='log')"
    ]
@@ -916,7 +929,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pulse_time = sc.arange(dim='pulse_time', start=tmin.value, stop=tmax.value, step=(tmax.value - tmin.value) / 10)\n",
+    "pulse_time = sc.arange(\n",
+    "    dim='pulse_time',\n",
+    "    start=tmin.value,\n",
+    "    stop=tmax.value,\n",
+    "    step=(tmax.value - tmin.value) / 10,\n",
+    ")\n",
     "split = sc.bin(da_dspacing_total, edges=[pulse_time])\n",
     "sc.plot(sc.collapse(split, keep='dspacing'), resolution=5000)"
    ]
@@ -961,9 +979,13 @@
     "two_theta_cut = sc.linspace(dim='two_theta', unit='rad', start=0.4, stop=1.0, num=2)\n",
     "# Do not use many bins, fewer is better for performance\n",
     "dspacing_cut = sc.linspace(dim='dspacing', unit='Angstrom', start=0.0, stop=2.0, num=2)\n",
-    "pulse_time_cut = tmin + sc.to_unit(sc.array(dims=['pulse_time'], unit='s', values=[0,10*60]), 'ns')\n",
+    "pulse_time_cut = tmin + sc.to_unit(\n",
+    "    sc.array(dims=['pulse_time'], unit='s', values=[0, 10 * 60]), 'ns'\n",
+    ")\n",
     "\n",
-    "cut = sc.bin(da_dspacing, edges=[two_theta_cut, dspacing_cut, pulse_time_cut], erase=['spectrum'])\n",
+    "cut = sc.bin(\n",
+    "    da_dspacing, edges=[two_theta_cut, dspacing_cut, pulse_time_cut], erase=['spectrum']\n",
+    ")\n",
     "cut"
    ]
   },
@@ -984,7 +1006,9 @@
    "source": [
     "cut = cut['pulse_time', 0]  # squeeze pulse time (dim of length 1)\n",
     "cut = cut['two_theta', 0]  # squeeze two_theta (dim of length 1)\n",
-    "dspacing_edges = sc.linspace(dim='dspacing', unit='Angstrom', start=0.0, stop=2.0, num=5000)\n",
+    "dspacing_edges = sc.linspace(\n",
+    "    dim='dspacing', unit='Angstrom', start=0.0, stop=2.0, num=5000\n",
+    ")\n",
     "cut = sc.histogram(cut, bins=dspacing_edges)\n",
     "cut.plot()"
    ]
@@ -1028,10 +1052,16 @@
    "source": [
     "two_theta_cut = sc.linspace(dim='two_theta', unit='rad', start=0.4, stop=1.0, num=101)\n",
     "dspacing_cut = sc.linspace(dim='dspacing', unit='Angstrom', start=0.0, stop=2.0, num=2)\n",
-    "pulse_time_cut = tmin + sc.to_unit(sc.array(dims=['pulse_time'], unit='s', values=[0,10*60]), 'ns')\n",
-    "cut = sc.bin(da_dspacing, edges=[two_theta_cut, dspacing_cut, pulse_time_cut], erase=['spectrum'])\n",
+    "pulse_time_cut = tmin + sc.to_unit(\n",
+    "    sc.array(dims=['pulse_time'], unit='s', values=[0, 10 * 60]), 'ns'\n",
+    ")\n",
+    "cut = sc.bin(\n",
+    "    da_dspacing, edges=[two_theta_cut, dspacing_cut, pulse_time_cut], erase=['spectrum']\n",
+    ")\n",
     "cut = cut['pulse_time', 0]  # squeeze pulse time (dim of length 1)\n",
-    "dspacing_edges = sc.linspace(dim='dspacing', unit='Angstrom', start=0.0, stop=2.0, num=5000)\n",
+    "dspacing_edges = sc.linspace(\n",
+    "    dim='dspacing', unit='Angstrom', start=0.0, stop=2.0, num=5000\n",
+    ")\n",
     "cut = sc.histogram(cut, bins=dspacing_edges)\n",
     "cut.plot()"
    ]
@@ -1053,7 +1083,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/3_understanding-event-data.ipynb
+++ b/docs/tutorials/3_understanding-event-data.ipynb
@@ -391,9 +391,8 @@
    "source": [
     "spec1 = da['spectrum', 8050].copy()  # copy since we do some modifications below\n",
     "event_tof = spec.bins.coords['tof']\n",
-    "spec1.bins.masks['prompt_pulse'] = (prompt_start <= event_tof) & (\n",
-    "    event_tof < prompt_stop\n",
-    ")\n",
+    "mask = (prompt_start <= event_tof) & (event_tof < prompt_stop)\n",
+    "spec1.bins.masks['prompt_pulse'] = mask\n",
     "sc.plot({'original': da['spectrum', 8050], 'prompt_mask': spec1})"
    ]
   },

--- a/docs/tutorials/powder-diffraction.ipynb
+++ b/docs/tutorials/powder-diffraction.ipynb
@@ -458,16 +458,13 @@
    "outputs": [],
    "source": [
     "# compute centers of theta bins\n",
-    "angles = normalized.coords['two_theta'].values\n",
-    "angles = 0.5 * (angles[1:] + angles[:-1])\n",
-    "sc.plot(\n",
-    "    {\n",
-    "        f'{round(angles[group], 3)} rad': normalized['dspacing', 300:500][\n",
-    "            'two_theta', group\n",
-    "        ]\n",
-    "        for group in range(2, 6)\n",
-    "    }\n",
-    ")"
+    "angle = normalized.coords['two_theta'].values\n",
+    "angle = 0.5 * (angle[1:] + angle[:-1])\n",
+    "results = {\n",
+    "    f'{round(angle[group], 3)} rad': normalized['dspacing', 300:500]['two_theta', group]\n",
+    "    for group in range(2, 6)\n",
+    "}\n",
+    "sc.plot(results)"
    ]
   }
  ],

--- a/docs/tutorials/powder-diffraction.ipynb
+++ b/docs/tutorials/powder-diffraction.ipynb
@@ -45,11 +45,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample = scn.load(scn.data.get_path('PG3_4844_event.nxs'),\n",
-    "                  load_pulse_times=False,\n",
-    "                  mantid_args={'LoadMonitors': True})\n",
-    "vanadium = scn.load(scn.data.get_path('PG3_4866_event.nxs'),\n",
-    "                    load_pulse_times=False)"
+    "sample = scn.load(\n",
+    "    scn.data.get_path('PG3_4844_event.nxs'),\n",
+    "    load_pulse_times=False,\n",
+    "    mantid_args={'LoadMonitors': True},\n",
+    ")\n",
+    "vanadium = scn.load(scn.data.get_path('PG3_4866_event.nxs'), load_pulse_times=False)"
    ]
   },
   {
@@ -131,9 +132,7 @@
    "source": [
     "sample.coords['two_theta'] = scn.two_theta(sample)\n",
     "vanadium.coords['two_theta'] = scn.two_theta(vanadium)\n",
-    "two_theta_bins = sc.Variable(dims=['two_theta'],\n",
-    "                             unit=sc.units.rad,\n",
-    "                             values=np.linspace(0.0, np.pi, num=2000))"
+    "two_theta = sc.linspace(dim='two_theta', unit='rad', start=0.0, stop=np.pi, num=2000)"
    ]
   },
   {
@@ -149,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta_sample = sc.groupby(sample, 'two_theta', bins=two_theta_bins).bins.concatenate('spectrum')"
+    "theta_sample = sc.groupby(sample, 'two_theta', bins=two_theta).bins.concat('spectrum')"
    ]
   },
   {
@@ -261,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edges = sc.Variable(dims=['wavelength'], unit=sc.units.angstrom, values=np.linspace(0, 1, num=1000))\n",
+    "edges = sc.linspace(dim='wavelength', unit='Angstrom', start=0.0, stop=1.0, num=1000)\n",
     "mon = sc.rebin(mon, 'wavelength', edges)\n",
     "mon"
    ]
@@ -348,9 +347,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dspacing_bins = sc.arange(dim='dspacing', start=0.3, stop=2.0, step=0.001, unit=sc.units.angstrom)\n",
-    "hist = sc.Dataset(data={'sample':sc.histogram(dspacing_sample, bins=dspacing_bins),\n",
-    "                        'vanadium':sc.histogram(dspacing_vanadium, bins=dspacing_bins)})\n",
+    "dspacing = sc.arange(dim='dspacing', start=0.3, stop=2.0, step=0.001, unit='Angstrom')\n",
+    "hist = sc.Dataset(\n",
+    "    data={\n",
+    "        'sample': sc.histogram(dspacing_sample, bins=dspacing),\n",
+    "        'vanadium': sc.histogram(dspacing_vanadium, bins=dspacing),\n",
+    "    }\n",
+    ")\n",
     "sc.show(hist['spectrum', 0:3]['dspacing', 0:7])"
    ]
   },
@@ -414,11 +417,15 @@
    "source": [
     "two_theta = sc.linspace(dim='two_theta', unit='rad', start=0.0, stop=np.pi, num=16)\n",
     "\n",
-    "focussed_sample = sc.groupby(dspacing_sample, 'two_theta', bins=two_theta).bins.concatenate('spectrum')\n",
-    "focussed_vanadium = sc.groupby(dspacing_vanadium, 'two_theta', bins=two_theta).bins.concatenate('spectrum')\n",
-    "norm = sc.histogram(focussed_vanadium, bins=dspacing_bins)\n",
+    "focussed_sample = sc.groupby(dspacing_sample, 'two_theta', bins=two_theta).bins.concat(\n",
+    "    'spectrum'\n",
+    ")\n",
+    "focussed_vanadium = sc.groupby(\n",
+    "    dspacing_vanadium, 'two_theta', bins=two_theta\n",
+    ").bins.concat('spectrum')\n",
+    "norm = sc.histogram(focussed_vanadium, bins=dspacing)\n",
     "focussed_sample.bins /= sc.lookup(func=norm, dim='dspacing')\n",
-    "normalized = sc.histogram(focussed_sample, bins=dspacing_bins)"
+    "normalized = sc.histogram(focussed_sample, bins=dspacing)"
    ]
   },
   {
@@ -434,7 +441,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(normalized, vmin=sc.scalar(0), vmax=sc.scalar(0.4))"
+    "normalized.plot(vmin=sc.scalar(0), vmax=sc.scalar(0.4))"
    ]
   },
   {
@@ -452,10 +459,15 @@
    "source": [
     "# compute centers of theta bins\n",
     "angles = normalized.coords['two_theta'].values\n",
-    "angles = 0.5*(angles[1:] + angles[:-1])\n",
-    "sc.plot({f'{round(angles[group], 3)} rad':\n",
-    "         normalized['dspacing', 300:500]['two_theta', group]\n",
-    "         for group in range(2,6)})"
+    "angles = 0.5 * (angles[1:] + angles[:-1])\n",
+    "sc.plot(\n",
+    "    {\n",
+    "        f'{round(angles[group], 3)} rad': normalized['dspacing', 300:500][\n",
+    "            'two_theta', group\n",
+    "        ]\n",
+    "        for group in range(2, 6)\n",
+    "    }\n",
+    ")"
    ]
   }
  ],

--- a/docs/user-guide/groupby.ipynb
+++ b/docs/user-guide/groupby.ipynb
@@ -32,8 +32,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load event data. Here, we use `get_path` to find a data file that comes bundled with scippneutron.\n",
-    "# Normally, we would simply pass a file path to `scn.load`.\n",
+    "# Load event data. Here, we use `get_path` to find a data file that comes bundled\n",
+    "# with scippneutron. Normally, we would simply pass a file path to `scn.load`.\n",
     "events = scn.load(scn.data.get_path('PG3_4844_event.nxs'), load_pulse_times=False)"
    ]
   },
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bins = sc.Variable(dims=['tof'], values=np.arange(0.0, 17000.0, 50.0), unit=sc.units.us)\n",
+    "bins = sc.arange(dim='tof', start=0.0, stop=17000.0, step=50.0, unit='us')\n",
     "pos_hist = sc.histogram(events, bins=bins)"
    ]
   },
@@ -88,9 +88,7 @@
    "outputs": [],
    "source": [
     "pos_hist.coords['two_theta'] = scn.two_theta(pos_hist)\n",
-    "two_theta = sc.Variable(dims=['two_theta'],\n",
-    "                        unit=sc.units.rad,\n",
-    "                        values=np.linspace(0.0, np.pi, num=500))"
+    "two_theta = sc.linspace(dim='two_theta', unit='rad', start=0.0, stop=np.pi, num=500)"
    ]
   },
   {
@@ -106,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta_hist = sc.groupby(pos_hist, 'two_theta', bins=two_theta).sum('spectrum')"
+    "theta_hist = pos_hist.groupby('two_theta', bins=two_theta).sum('spectrum')"
    ]
   },
   {
@@ -122,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(theta_hist)"
+    "theta_hist.plot()"
    ]
   },
   {
@@ -141,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(sc.histogram(events, bins=bins))"
+    "sc.histogram(events, bins=bins).plot()"
    ]
   },
   {
@@ -159,9 +157,7 @@
    "outputs": [],
    "source": [
     "events.coords['two_theta'] = scn.two_theta(events)\n",
-    "theta = sc.Variable(dims=['two_theta'],\n",
-    "                    unit=sc.units.rad,\n",
-    "                    values=np.linspace(0.0, np.pi, num=500))"
+    "two_theta = sc.linspace(dim='two_theta', unit='rad', start=0.0, stop=np.pi, num=500)"
    ]
   },
   {
@@ -178,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta_events = sc.groupby(events, 'two_theta', bins=theta).concat('spectrum')"
+    "theta_events = events.groupby('two_theta', bins=two_theta).concat('spectrum')"
    ]
   },
   {
@@ -192,11 +188,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "sc.plot(sc.histogram(theta_events, bins=bins))"
+    "sc.histogram(theta_events, bins=bins).plot()"
    ]
   }
  ],

--- a/docs/user-guide/instrument-view.ipynb
+++ b/docs/user-guide/instrument-view.ipynb
@@ -94,7 +94,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scn.instrument_view(sample, cmap=\"magma\", vmax=2000.0 * sc.units.counts, norm=\"log\", pixel_size=0.03)"
+    "scn.instrument_view(\n",
+    "    sample, cmap=\"magma\", vmax=2000.0 * sc.units.counts, norm=\"log\", pixel_size=0.03\n",
+    ")"
    ]
   },
   {
@@ -150,12 +152,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_settings = {'center': gem_da.meta['sample_position'], 'color': '#000000', 'wireframe': True,\n",
-    "                   'size': sc.vector(value=[0.5, 0.5, 0.5], unit=sc.units.m), 'type': 'box'}\n",
-    "source_settings = {'center': gem_da.meta['source_position'], 'color': '#FFC133',\n",
-    "                   'size': sc.vector(value=[1000, 2000, 1000], unit=sc.units.mm), 'type': 'cylinder'}\n",
-    "scn.instrument_view(gem_da, pixel_size=0.05, \n",
-    "                    components={'sample': sample_settings, 'source': source_settings})"
+    "sample_settings = {\n",
+    "    'center': gem_da.meta['sample_position'],\n",
+    "    'color': '#000000',\n",
+    "    'wireframe': True,\n",
+    "    'size': sc.vector(value=[0.5, 0.5, 0.5], unit=sc.units.m),\n",
+    "    'type': 'box',\n",
+    "}\n",
+    "source_settings = {\n",
+    "    'center': gem_da.meta['source_position'],\n",
+    "    'color': '#FFC133',\n",
+    "    'size': sc.vector(value=[1000, 2000, 1000], unit=sc.units.mm),\n",
+    "    'type': 'cylinder',\n",
+    "}\n",
+    "scn.instrument_view(\n",
+    "    gem_da,\n",
+    "    pixel_size=0.05,\n",
+    "    components={'sample': sample_settings, 'source': source_settings},\n",
+    ")"
    ]
   },
   {

--- a/docs/user-guide/recipes.ipynb
+++ b/docs/user-guide/recipes.ipynb
@@ -112,7 +112,8 @@
    "outputs": [],
    "source": [
     "da['spectrum', index].plot()  # plot spectrum with given index\n",
-    "da['spectrum', sc.scalar(spectrum_number)]  # plot spectrum with given spectrum-number, provided da.coords['spectrum'] exists"
+    "# plot spectrum with given spectrum-number, provided da.coords['spectrum'] exists\n",
+    "da['spectrum', sc.scalar(spectrum_number)].plot()"
    ]
   },
   {
@@ -154,7 +155,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   },
   "nbsphinx": {
    "execute": "never"


### PR DESCRIPTION
- Ran `black` with disabled "string_normalization" on docs pages.
- Switch to modern scipp API in some places.
- 
Fixes #205 by addressing the last open item.