### PR TITLE
Use new dtypes

### DIFF
--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -5,6 +5,7 @@
 from typing import Union, Optional, Any
 import h5py
 import scipp as sc
+import scipp.spatial
 import numpy as np
 
 
@@ -55,10 +56,10 @@ def _add_attr_to_loaded_data(attr_name: str,
 
     try:
         if dtype is not None:
-            if dtype == sc.dtype.vector_3_float64:
+            if dtype == sc.dtype.vector3:
                 data[attr_name] = sc.vector(value=value, unit=unit)
-            elif dtype == sc.dtype.matrix_3_float64:
-                data[attr_name] = sc.matrix(value=value, unit=unit)
+            elif dtype == sc.dtype.linear_transform3:
+                data[attr_name] = sc.spatial.linear_transform(value=value, unit=unit)
             else:
                 data[attr_name] = sc.Variable(value=value, dtype=dtype, unit=unit)
         else:

--- a/src/scippneutron/file_loading/_positions.py
+++ b/src/scippneutron/file_loading/_positions.py
@@ -30,7 +30,7 @@ def load_position_of_unique_component(groups: List[Group],
                               data,
                               position,
                               unit=units,
-                              dtype=sc.dtype.vector_3_float64)
+                              dtype=sc.dtype.vector3)
 
 
 def load_positions_of_components(groups: List[Group],
@@ -50,13 +50,13 @@ def load_positions_of_components(groups: List[Group],
                                       data,
                                       position,
                                       unit=units,
-                                      dtype=sc.dtype.vector_3_float64)
+                                      dtype=sc.dtype.vector3)
         else:
             _add_coord_to_loaded_data(f"{nexus.get_name(group)}_position",
                                       data,
                                       position,
                                       unit=units,
-                                      dtype=sc.dtype.vector_3_float64)
+                                      dtype=sc.dtype.vector3)
 
 
 def _get_position_of_component(
@@ -105,7 +105,7 @@ def _add_coord_to_loaded_data(attr_name: str,
 
     try:
         if dtype is not None:
-            if dtype == sc.dtype.vector_3_float64:
+            if dtype == sc.dtype.vector3:
                 data[attr_name] = sc.vector(value=value, unit=unit)
             else:
                 data[attr_name] = sc.scalar(value, dtype=dtype, unit=unit)

--- a/src/scippneutron/file_loading/_sample.py
+++ b/src/scippneutron/file_loading/_sample.py
@@ -41,10 +41,10 @@ def load_ub_matrices_of_components(groups: List[Group], data: Union[sc.DataArray
                                          data,
                                          matrix,
                                          unit=units,
-                                         dtype=sc.dtype.matrix_3_float64)
+                                         dtype=sc.dtype.linear_transform3)
             else:
                 _add_attr_to_loaded_data(f"{nexus.get_name(group)}_{sc_property}",
                                          data,
                                          matrix,
                                          unit=units,
-                                         dtype=sc.dtype.matrix_3_float64)
+                                         dtype=sc.dtype.linear_transform3)

--- a/src/scippneutron/instrument_view.py
+++ b/src/scippneutron/instrument_view.py
@@ -148,7 +148,7 @@ def _instrument_view_shape_types():
 
 
 def _as_vector(var):
-    if var.dtype == sc.dtype.vector_3_float64:
+    if var.dtype == sc.dtype.vector3:
         return var
     else:
         return sc.geometry.position(x=var, y=var, z=var)

--- a/tests/test_load_nexus.py
+++ b/tests/test_load_nexus.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 import scippneutron
 import scipp as sc
+import scipp.spatial
 from typing import List, Type, Union, Callable
 from scippneutron.file_loading.load_nexus import _load_nexus_json
 from dateutil.parser import parse as parse_date
@@ -1349,7 +1350,8 @@ def test_loads_sample_ub_matrix(load_function: Callable):
     print(loaded_data["sample_ub_matrix"].data)
     assert sc.identical(
         loaded_data["sample_ub_matrix"].data,
-        sc.matrix(value=np.ones(shape=[3, 3]), unit=sc.units.angstrom**-1))
+        sc.spatial.linear_transform(value=np.ones(shape=[3, 3]),
+                                    unit=sc.units.angstrom**-1))
     assert "sample_u_matrix" not in loaded_data
 
 
@@ -1358,8 +1360,9 @@ def test_loads_sample_u_matrix(load_function: Callable):
     builder.add_component(Sample("sample", orientation_matrix=np.ones(shape=[3, 3])))
     loaded_data = load_function(builder)
     assert "sample_u_matrix" in loaded_data
-    assert sc.identical(loaded_data["sample_u_matrix"].data,
-                        sc.matrix(value=np.ones(shape=[3, 3]), unit=sc.units.one))
+    assert sc.identical(
+        loaded_data["sample_u_matrix"].data,
+        sc.spatial.linear_transform(value=np.ones(shape=[3, 3]), unit=sc.units.one))
     assert "sample_ub_matrix" not in loaded_data
 
 
@@ -1371,9 +1374,11 @@ def test_loads_multiple_sample_ub_matrix(load_function: Callable):
     loaded_data = load_function(builder)
     assert sc.identical(
         loaded_data["sample1_ub_matrix"].data,
-        sc.matrix(value=np.ones(shape=[3, 3]), unit=sc.units.angstrom**-1))
-    assert sc.identical(loaded_data["sample2_ub_matrix"].data,
-                        sc.matrix(value=np.identity(3), unit=sc.units.angstrom**-1))
+        sc.spatial.linear_transform(value=np.ones(shape=[3, 3]),
+                                    unit=sc.units.angstrom**-1))
+    assert sc.identical(
+        loaded_data["sample2_ub_matrix"].data,
+        sc.spatial.linear_transform(value=np.identity(3), unit=sc.units.angstrom**-1))
     assert "sample3_ub_matrix" not in loaded_data
 
 

--- a/tests/test_mantid.py
+++ b/tests/test_mantid.py
@@ -11,6 +11,7 @@ import tempfile
 import importlib
 
 import scipp as sc
+import scipp.spatial
 import scippneutron as scn
 
 from .mantid_helper import mantid_is_available
@@ -577,10 +578,11 @@ class TestMantidConversion(unittest.TestCase):
         d = scn.mantid.from_mantid(ws)
         assert sc.identical(
             d.attrs['sample_ub'],
-            sc.matrix(value=ws.sample().getOrientedLattice().getUB(),
-                      unit=sc.units.angstrom**-1))
-        assert sc.identical(d.attrs['sample_u'],
-                            sc.matrix(value=ws.sample().getOrientedLattice().getU()))
+            sc.spatial.linear_transform(value=ws.sample().getOrientedLattice().getUB(),
+                                        unit=sc.units.angstrom**-1))
+        assert sc.identical(
+            d.attrs['sample_u'],
+            sc.spatial.linear_transform(value=ws.sample().getOrientedLattice().getU()))
 
     def test_sample_without_ub(self):
         import mantid.simpleapi as mantid


### PR DESCRIPTION
Use the new transform dtypes/creation functions in scippneutron.

This is expected to fail against release version of scipp currently but is needed for `main`.