### PR TITLE
Add intersphinx mapping to scipp

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ rst_epilog = f"""
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'scipp': ('https://scipp.github.io/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None)
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,9 @@ rst_epilog = f"""
 """  # noqa: E501
 
 intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None)
 }
 

--- a/src/scippneutron/tof/conversions.py
+++ b/src/scippneutron/tof/conversions.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
-r"""
+"""
 Coordinate transformation graphs for time-of-flight neutron scattering data.
 
-Each graph is a ``dict`` and intended for use with ``sc.transform_coords``.
-Typically multiple graphs need to be combined for a full transformation, e.g., a
+Each graph is a :py:class:`dict` and intended for use with
+:py:func:`sc.transform_coords`.
+Typically, multiple graphs need to be combined for a full transformation, e.g., a
 "beamline" graph with an "elastic" graph.
 """
 


### PR DESCRIPTION
Also adds mappings to python and scipy which are used in scipp but were missing in scippneutron.

Fixes #243