### PR TITLE
Lower-level Nexus access utilities

### DIFF
--- a/src/scippneutron/__init__.py
+++ b/src/scippneutron/__init__.py
@@ -27,3 +27,4 @@ from .instrument_view import instrument_view
 from .file_loading.load_nexus import load_nexus, load_nexus_json
 from .data_streaming.data_stream import data_stream
 from . import data
+from . import nexus

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -86,9 +86,8 @@ def to_plain_index(dims, select, ignore_missing=False):
     """
     def check_1d():
         if len(dims) != 1:
-            raise ValueError(
-                f"Dataset has multiple dimensions {dims}, specify the dimension to index."
-            )
+            raise ValueError(f"Dataset has multiple dimensions {dims}, "
+                             "specify the dimension to index.")
 
     if select is Ellipsis:
         return select

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -8,6 +8,7 @@ from scipp.spatial import affine_transform, linear_transform, \
     rotation, translation
 import scipp as sc
 import numpy as np
+from typing import Dict
 
 
 class BadSource(Exception):
@@ -42,6 +43,7 @@ class JSONGroup(dict):
         self.file = file
 
 
+Dataset = Union[h5py.Dataset, Dict]
 Group = Union[h5py.Group, JSONGroup]
 
 

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -210,7 +210,7 @@ def _load_event_group(group: Group,
     def shape(name):
         return nexus.get_shape(nexus.get_dataset_from_group(group,name))
 
-    max_index = shape("event_time_offset")[0]
+    max_index = shape("event_index")[0]
     single = False
     if select is Ellipsis:
         index = select
@@ -230,11 +230,11 @@ def _load_event_group(group: Group,
         group, "event_index", index)
     pulse_times = _load_pulse_times(group, nexus, index)
 
-    number_of_event_ids = shape("event_id")[0]
-    event_index[event_index < 0] = number_of_event_ids
+    num_event = shape("event_time_offset")[0]
+    event_index[event_index < 0] = num_event
 
     if len(event_index) > 0:
-        event_select = slice(event_index[0], event_index[-1] if last_loaded else max_index)
+        event_select = slice(event_index[0], event_index[-1] if last_loaded else num_event)
     else:
         event_select = slice(None)
 
@@ -266,7 +266,7 @@ def _load_event_group(group: Group,
         detector_data.detector_ids.dtype, event_id.dtype)
 
     if not last_loaded:
-        event_index = np.append(event_index, number_of_event_ids)
+        event_index = np.append(event_index, num_event)
 
     event_index = sc.array(dims=[_pulse_dimension],
                            values=event_index,

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -226,6 +226,7 @@ class NXevent_data(NXobject):
         data = detector_data.event_data
         data.bins.coords['id'] = data.bins.coords.pop('detector_id')
         data.bins.coords['time_offset'] = data.bins.coords.pop('tof')
+        data.coords['time_zero'] = data.coords.pop('pulse_time')
         return data
 
 
@@ -266,6 +267,8 @@ def _load_event_group(group: Group,
     pulse_times = _load_pulse_times(group, nexus, index)
 
     num_event = shape("event_time_offset")[0]
+    # Some files contain uint64 "max" indices, which turn into negatives during
+    # conversion to int64. This is a hack to get arround this.
     event_index[event_index < 0] = num_event
 
     if len(event_index) > 0:
@@ -274,8 +277,6 @@ def _load_event_group(group: Group,
     else:
         event_select = slice(None)
 
-    # Some files contain uint64 "max" indices, which turn into negatives during
-    # conversion to int64. This is a hack to get arround this.
     event_id = nexus.load_dataset(group,
                                   "event_id", [_event_dimension],
                                   index=event_select)

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -13,6 +13,7 @@ import scipp as sc
 from warnings import warn
 from ._transformations import get_full_transformation_matrix
 from ._nexus import LoadFromNexus
+from .nxobject import NXobject
 
 _bank_dimension = "bank"
 _detector_dimension = "detector_id"
@@ -199,6 +200,25 @@ def _load_detector(group: Group, nexus: LoadFromNexus) -> DetectorData:
         pixel_positions = _load_pixel_positions(group, detector_ids.shape[0], nexus)
 
     return DetectorData(detector_ids=detector_ids, pixel_positions=pixel_positions)
+
+
+class NXevent_data(NXobject):
+    def __init__(self, group: Group, loader: LoadFromNexus):
+        super().__init__(group, loader)
+
+    @property
+    def shape(self):
+        return self._loader.get_shape(
+            self._loader.get_dataset_from_group(self._group, "event_index"))
+
+    @property
+    def dims(self):
+        return [_pulse_dimension]
+
+    @property
+    def unit(self):
+        # Binned data, bins do not have a unit
+        return sc.units.one
 
 
 def _load_event_group(group: Group,

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -16,8 +16,8 @@ from ._nexus import LoadFromNexus
 _bank_dimension = "bank"
 _detector_dimension = "detector_id"
 _event_dimension = "event"
-_pulse_dimension = "time"
-_pulse_time = "time"
+_pulse_dimension = "pulse"
+_pulse_time = "pulse_time"
 _time_of_flight = "tof"
 
 

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -229,7 +229,6 @@ class NXevent_data(NXobject):
         return data
 
 
-
 def _load_event_group(group: Group,
                       nexus: LoadFromNexus,
                       detector_data: DetectorData,

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -220,6 +220,18 @@ class NXevent_data(NXobject):
         # Binned data, bins do not have a unit
         return sc.units.one
 
+    def _getitem(self, index):
+        detector_data = _load_event_group(self._group,
+                                          self._loader,
+                                          DetectorData(),
+                                          quiet=False,
+                                          select=index)
+        data = detector_data.event_data
+        data.bins.coords['id'] = data.bins.coords.pop('detector_id')
+        data.bins.coords['time_offset'] = data.bins.coords.pop('tof')
+        return data
+
+
 
 def _load_event_group(group: Group,
                       nexus: LoadFromNexus,

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -274,6 +274,10 @@ def _load_event_group(group: Group,
 
     if not last_loaded:
         event_index = np.append(event_index, num_event)
+    else:
+        # Not a bin-edge coord, all events in bin are associate with same (previous)
+        # pulse time value
+        pulse_times = pulse_times[:-1]
 
     event_index = sc.array(dims=[_pulse_dimension],
                            values=event_index,
@@ -290,6 +294,7 @@ def _load_event_group(group: Group,
     if single:
         begins = begins[_pulse_dimension, 0]
         ends = ends[_pulse_dimension, 0]
+        pulse_times = pulse_times[_pulse_dimension, 0]
 
     try:
         binned = sc.bins(data=events, dim=_event_dimension, begin=begins, end=ends)
@@ -302,7 +307,7 @@ def _load_event_group(group: Group,
 
     if not quiet:
         print(f"Loaded {len(event_id)} events from "
-              f"{group.name} containing {num_event} events")
+              f"{nexus.get_name(group)} containing {num_event} events")
 
     return detector_data
 

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -210,7 +210,7 @@ def _load_event_group(group: Group,
     def shape(name):
         return nexus.get_shape(nexus.get_dataset_from_group(group,name))
 
-    max_index = shape("event_index")[0]
+    max_index = shape("event_time_offset")[0]
     single = False
     if select is Ellipsis:
         index = select
@@ -233,7 +233,7 @@ def _load_event_group(group: Group,
     number_of_event_ids = shape("event_id")[0]
     event_index[event_index < 0] = number_of_event_ids
 
-    if event_index:
+    if len(event_index) > 0:
         event_select = slice(event_index[0], event_index[-1] if last_loaded else max_index)
     else:
         event_select = slice(None)

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipp
 
 from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group)
+from ._common import to_plain_index
 import scipp as sc
 from warnings import warn
 from ._transformations import get_full_transformation_matrix
@@ -206,18 +207,18 @@ def _load_event_group(group: Group,
                       quiet: bool,
                       select=...) -> DetectorData:
     _check_for_missing_fields(group, nexus)
+    index = to_plain_index([_pulse_dimension], select)
+    if isinstance(index, tuple):
+        index = index[0]
 
     def shape(name):
         return nexus.get_shape(nexus.get_dataset_from_group(group, name))
 
     max_index = shape("event_index")[0]
     single = False
-    if select is Ellipsis:
-        index = select
+    if index is Ellipsis:
         last_loaded = False
     else:
-        # TODO unused key, should this take plain indices, like load_dataset?
-        key, index = select
         if isinstance(index, int):
             single = True
             start, stop, _ = slice(index, None).indices(max_index)

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -203,9 +203,6 @@ def _load_detector(group: Group, nexus: LoadFromNexus) -> DetectorData:
 
 
 class NXevent_data(NXobject):
-    def __init__(self, group: Group, loader: LoadFromNexus):
-        super().__init__(group, loader)
-
     @property
     def shape(self):
         return self._loader.get_shape(

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -275,7 +275,7 @@ def _load_event_group(group: Group,
     if not last_loaded:
         event_index = np.append(event_index, num_event)
     else:
-        # Not a bin-edge coord, all events in bin are associate with same (previous)
+        # Not a bin-edge coord, all events in bin are associated with same (previous)
         # pulse time value
         pulse_times = pulse_times[:-1]
 

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -207,7 +207,7 @@ def _load_event_group(group: Group,
                       select=...) -> DetectorData:
     _check_for_missing_fields(group, nexus)
 
-    max_index = group["event_id"].shape[0]
+    max_index = group["event_index"].shape[0]
     single = False
     if select is Ellipsis:
         index = select
@@ -226,7 +226,7 @@ def _load_event_group(group: Group,
         group, "event_index", index)
     pulse_times = _load_pulse_times(group, nexus, index)
 
-    number_of_event_ids = max_index
+    number_of_event_ids = group["event_id"].shape[0]
     event_index[event_index < 0] = number_of_event_ids
 
     event_select = slice(event_index[0], event_index[-1] if last_loaded else max_index)

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -215,6 +215,13 @@ class LoadFromHdf5:
         return group.name
 
     @staticmethod
+    def get_dtype(dataset: h5py.Dataset) -> str:
+        """
+        The dtype of the dataset
+        """
+        return dataset.dtype
+
+    @staticmethod
     def get_shape(dataset: h5py.Dataset) -> List:
         """
         The shape of the dataset

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -86,6 +86,12 @@ def _ensure_supported_int_type(dataset_type: Any):
 
 
 class LoadFromHdf5:
+    def keys(self, group: h5py.Group):
+        return group.keys()
+
+    def values(self, group: h5py.Group):
+        return group.values()
+
     @staticmethod
     def find_by_nx_class(
             nx_class_names: Tuple[str, ...],
@@ -112,8 +118,6 @@ class LoadFromHdf5:
                     pass
 
         root.visititems(_match_nx_class)
-        # Also check if root itself is an NX_class
-        _match_nx_class(None, root)
         return found_groups
 
     @staticmethod
@@ -202,6 +206,13 @@ class LoadFromHdf5:
         Just the name of this group, not the full path
         """
         return group.name.split("/")[-1]
+
+    @staticmethod
+    def get_path(group: Union[h5py.Group, h5py.Dataset]) -> str:
+        """
+        The full path
+        """
+        return group.name
 
     @staticmethod
     def get_shape(dataset: h5py.Dataset) -> List:

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -160,9 +160,8 @@ class LoadFromHdf5:
                 variable.values = dataset
             return variable
         return sc.array(dims=dimensions,
-                        dtype=dtype,
                         unit=self.get_unit(dataset),
-                        values=dataset[index])
+                        values=dataset[index].astype(dtype))
 
     def load_dataset_from_group_as_numpy_array(self,
                                                group: h5py.Group,

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -204,6 +204,13 @@ class LoadFromHdf5:
         return group.name.split("/")[-1]
 
     @staticmethod
+    def get_shape(dataset: h5py.Dataset) -> List:
+        """
+        The shape of the dataset
+        """
+        return dataset.shape
+
+    @staticmethod
     def get_unit(node: Union[h5py.Dataset, h5py.Group]) -> str:
         try:
             units = node.attrs["units"]

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -193,8 +193,8 @@ class LoadFromHdf5:
         return dataset[index].astype(_ensure_supported_int_type(dataset.dtype.type))
 
     @staticmethod
-    def get_dataset_numpy_dtype(group: h5py.Group, dataset_name: str) -> Any:
-        return _ensure_supported_int_type(group[dataset_name].dtype.type)
+    def get_dataset_numpy_dtype(dataset: h5py.Dataset) -> Any:
+        return _ensure_supported_int_type(dataset.dtype.type)
 
     @staticmethod
     def get_name(group: Union[h5py.Group, h5py.Dataset]) -> str:

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -129,7 +129,7 @@ class LoadFromHdf5:
                      dataset_name: str,
                      dimensions: Optional[List[str]] = [],
                      dtype: Optional[Any] = None,
-                     index=...) -> sc.Variable:
+                     index=tuple()) -> sc.Variable:
         """
         Load an HDF5 dataset into a Scipp Variable (array or scalar)
         :param group: Group containing dataset to load
@@ -149,7 +149,7 @@ class LoadFromHdf5:
 
         if dtype is None:
             dtype = _ensure_supported_int_type(dataset.dtype.type)
-        if index is Ellipsis:
+        if index == slice(None):
             variable = sc.empty(dims=dimensions,
                                 shape=dataset.shape,
                                 dtype=dtype,
@@ -166,7 +166,7 @@ class LoadFromHdf5:
     def load_dataset_from_group_as_numpy_array(self,
                                                group: h5py.Group,
                                                dataset_name: str,
-                                               index=...):
+                                               index=tuple()):
         """
         Load a dataset into a numpy array
         Prefer use of load_dataset to load directly to a scipp variable,
@@ -179,10 +179,10 @@ class LoadFromHdf5:
             dataset = group[dataset_name]
         except KeyError:
             raise MissingDataset()
-        return self.load_dataset_as_numpy_array(dataset, index)
+        return self.load_dataset_as_numpy_array(dataset, index=index)
 
     @staticmethod
-    def load_dataset_as_numpy_array(dataset: h5py.Dataset, index=...):
+    def load_dataset_as_numpy_array(dataset: h5py.Dataset, index=tuple()):
         """
         Load a dataset into a numpy array
         Prefer use of load_dataset to load directly to a scipp variable,

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -149,7 +149,7 @@ class LoadFromHdf5:
 
         if dtype is None:
             dtype = _ensure_supported_int_type(dataset.dtype.type)
-        if index == slice(None):
+        if index == tuple():
             variable = sc.empty(dims=dimensions,
                                 shape=dataset.shape,
                                 dtype=dtype,

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -187,6 +187,12 @@ class LoadFromJson:
         return groups_with_requested_nx_class
 
     def get_child_from_group(self, group: Dict, child_name: str) -> Optional[Dict]:
+        if '/' in child_name:
+            child, remainder = child_name.split('/', maxsplit=1)
+            if child == '':
+                return self.get_child_from_group(group, remainder)
+            return self.get_child_from_group(self.get_child_from_group(group, child),
+                                             remainder)
         name = self.get_path(group).rstrip('/')
         return JSONGroup(group=self._get_child_from_group(group, child_name),
                          parent=group,

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -134,6 +134,13 @@ class LoadFromJson:
     def __init__(self, root: Dict):
         self._root = root
 
+    def keys(self, group: Dict):
+        children = group[_nexus_children]
+        return [child[_nexus_name] for child in children]
+
+    def values(self, group: Dict):
+        return group[_nexus_children]
+
     def _get_child_from_group(
             self,
             group: Dict,
@@ -265,6 +272,14 @@ class LoadFromJson:
 
     @staticmethod
     def get_name(group: Dict) -> str:
+        return group[_nexus_name]
+
+    @staticmethod
+    def get_path(group: Dict) -> str:
+        # WARNING It is impossible to get a full path in a simple manner,
+        # this is just the current name.
+        # TODO JSONGroup would provide this, but apparently it is used inconsistently,
+        # in some cases we end up with a plain dict so we cannot use group.name
         return group[_nexus_name]
 
     @staticmethod

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -198,7 +198,7 @@ class LoadFromJson:
                      group: Dict,
                      dataset_name: str,
                      dimensions: Optional[List[str]] = [],
-                     dtype: Optional[Any] = None) -> sc.Variable:
+                     dtype: Optional[Any] = None, index = tuple()) -> sc.Variable:
         """
         Load a dataset into a Scipp Variable (array or scalar)
         :param group: Group containing dataset to load
@@ -225,11 +225,11 @@ class LoadFromJson:
             units = sc.units.dimensionless
 
         return sc.array(dims=dimensions,
-                        values=np.asarray(dataset[_nexus_values]),
+                        values=np.asarray(dataset[_nexus_values])[index],
                         dtype=dtype,
                         unit=units)
 
-    def load_dataset_from_group_as_numpy_array(self, group: Dict, dataset_name: str):
+    def load_dataset_from_group_as_numpy_array(self, group: Dict, dataset_name: str, index=tuple()):
         """
         Load a dataset into a numpy array
         Prefer use of load_dataset to load directly to a scipp variable,
@@ -241,10 +241,10 @@ class LoadFromJson:
         dataset = self.get_dataset_from_group(group, dataset_name)
         if dataset is None:
             raise MissingDataset()
-        return self.load_dataset_as_numpy_array(dataset)
+        return self.load_dataset_as_numpy_array(dataset, index=index)
 
     @staticmethod
-    def load_dataset_as_numpy_array(dataset: Dict):
+    def load_dataset_as_numpy_array(dataset: Dict, index=tuple()):
         """
         Load a dataset into a numpy array
         Prefer use of load_dataset to load directly to a scipp variable,
@@ -258,7 +258,7 @@ class LoadFromJson:
         except KeyError:
             dtype = _filewriter_to_supported_numpy_dtype[dataset[_nexus_dataset]
                                                          ["dtype"]]
-        return np.array(dataset[_nexus_values]).astype(dtype)
+        return np.asarray(dataset[_nexus_values])[index].astype(dtype)
 
     def get_dataset_numpy_dtype(self, group: Dict, dataset_name: str) -> Any:
         dataset = self.get_dataset_from_group(group, dataset_name)

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -230,12 +230,7 @@ class LoadFromJson:
             raise MissingDataset()
 
         if dtype is None:
-            try:
-                dtype = _filewriter_to_supported_numpy_dtype[dataset[_nexus_dataset]
-                                                             ["type"]]
-            except KeyError:
-                dtype = _filewriter_to_supported_numpy_dtype[dataset[_nexus_dataset]
-                                                             ["dtype"]]
+            dtype = self.get_dtype(dataset)
 
         try:
             units = _get_attribute_value(dataset, _nexus_units)
@@ -295,6 +290,13 @@ class LoadFromJson:
         # TODO JSONGroup is apparently used inconsistently, fall back to returning name
         # without path.
         return group.get(_nexus_name, '/')
+
+    @staticmethod
+    def get_dtype(dataset: Dict) -> str:
+        try:
+            return dataset[_nexus_dataset]["type"]
+        except KeyError:
+            return dataset[_nexus_dataset]["dtype"]
 
     @staticmethod
     def get_shape(dataset: Dict) -> List:

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -269,6 +269,13 @@ class LoadFromJson:
         return group[_nexus_name]
 
     @staticmethod
+    def get_shape(dataset: Dict) -> List:
+        """
+        The shape of the dataset
+        """
+        return np.asarray(dataset[_nexus_values]).shape
+
+    @staticmethod
     def get_unit(dataset: Dict) -> str:
         try:
             unit = _get_attribute_value(dataset, _nexus_units)

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -187,7 +187,11 @@ class LoadFromJson:
         return groups_with_requested_nx_class
 
     def get_child_from_group(self, group: Dict, child_name: str) -> Optional[Dict]:
-        return self._get_child_from_group(group, child_name)
+        name = self.get_path(group).rstrip('/')
+        return JSONGroup(group=self._get_child_from_group(group, child_name),
+                         parent=group,
+                         name=f'{name}/{child_name}',
+                         file={_nexus_children: [group]})
 
     def get_dataset_from_group(self, group: Dict, dataset_name: str) -> Optional[Dict]:
         """
@@ -280,11 +284,11 @@ class LoadFromJson:
 
     @staticmethod
     def get_path(group: Dict) -> str:
-        # WARNING It is impossible to get a full path in a simple manner,
-        # this is just the current name.
-        # TODO JSONGroup would provide this, but apparently it is used inconsistently,
-        # in some cases we end up with a plain dict so we cannot use group.name
-        return group[_nexus_name]
+        if isinstance(group, JSONGroup):
+            return group.name
+        # TODO JSONGroup is apparently used inconsistently, fall back to returning name
+        # without path.
+        return group.get(_nexus_name, '/')
 
     @staticmethod
     def get_shape(dataset: Dict) -> List:

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -194,7 +194,10 @@ class LoadFromJson:
             return self.get_child_from_group(self.get_child_from_group(group, child),
                                              remainder)
         name = self.get_path(group).rstrip('/')
-        return JSONGroup(group=self._get_child_from_group(group, child_name),
+        child = self._get_child_from_group(group, child_name)
+        if child is None:
+            return child
+        return JSONGroup(group=child,
                          parent=group,
                          name=f'{name}/{child_name}',
                          file={_nexus_children: [group]})

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -260,8 +260,7 @@ class LoadFromJson:
                                                          ["dtype"]]
         return np.asarray(dataset[_nexus_values])[index].astype(dtype)
 
-    def get_dataset_numpy_dtype(self, group: Dict, dataset_name: str) -> Any:
-        dataset = self.get_dataset_from_group(group, dataset_name)
+    def get_dataset_numpy_dtype(self, dataset: Dict) -> Any:
         return _filewriter_to_supported_numpy_dtype[dataset[_nexus_dataset]["type"]]
 
     @staticmethod

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -205,7 +205,8 @@ class LoadFromJson:
                      group: Dict,
                      dataset_name: str,
                      dimensions: Optional[List[str]] = [],
-                     dtype: Optional[Any] = None, index = tuple()) -> sc.Variable:
+                     dtype: Optional[Any] = None,
+                     index=tuple()) -> sc.Variable:
         """
         Load a dataset into a Scipp Variable (array or scalar)
         :param group: Group containing dataset to load
@@ -236,7 +237,10 @@ class LoadFromJson:
                         dtype=dtype,
                         unit=units)
 
-    def load_dataset_from_group_as_numpy_array(self, group: Dict, dataset_name: str, index=tuple()):
+    def load_dataset_from_group_as_numpy_array(self,
+                                               group: Dict,
+                                               dataset_name: str,
+                                               index=tuple()):
         """
         Load a dataset into a numpy array
         Prefer use of load_dataset to load directly to a scipp variable,

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -115,18 +115,14 @@ class NXlog(NXobject):
         pass
 
     def _getitem(self, index):
-        name, var = _load_log_data_from_group(self._group,
-                                              self._loader,
-                                              select=index)
+        name, var = _load_log_data_from_group(self._group, self._loader, select=index)
         da = var.value
         da.name = name
         return da
 
 
-
-def _load_log_data_from_group(group: Group,
-                              nexus: LoadFromNexus,
-                              select =tuple()) -> Tuple[str, sc.Variable]:
+def _load_log_data_from_group(
+        group: Group, nexus: LoadFromNexus, select=tuple()) -> Tuple[str, sc.Variable]:
     property_name = nexus.get_name(group)
     value_dataset_name = "value"
     time_dataset_name = "time"
@@ -134,7 +130,9 @@ def _load_log_data_from_group(group: Group,
     index = to_plain_index(["time"], select)
 
     try:
-        values = nexus.load_dataset_from_group_as_numpy_array(group, value_dataset_name, index=index)
+        values = nexus.load_dataset_from_group_as_numpy_array(group,
+                                                              value_dataset_name,
+                                                              index=index)
     except MissingDataset:
         if nexus.contains_stream(group):
             raise SkipSource("Log is missing value dataset but contains stream")
@@ -154,7 +152,9 @@ def _load_log_data_from_group(group: Group,
     try:
         dimension_label = "time"
         is_time_series = True
-        raw_times = nexus.load_dataset(group, time_dataset_name, [dimension_label], index=index)
+        raw_times = nexus.load_dataset(group,
+                                       time_dataset_name, [dimension_label],
+                                       index=index)
 
         time_dataset = nexus.get_dataset_from_group(group, time_dataset_name)
         try:
@@ -188,13 +188,15 @@ def _load_log_data_from_group(group: Group,
         property_data = sc.scalar(values,
                                   unit=unit,
                                   dtype=nexus.get_dataset_numpy_dtype(
-                                      group, value_dataset_name))
+                                      nexus.get_dataset_from_group(
+                                          group, value_dataset_name)))
     else:
         property_data = sc.Variable(values=values,
                                     unit=unit,
                                     dims=[dimension_label],
                                     dtype=nexus.get_dataset_numpy_dtype(
-                                        group, value_dataset_name))
+                                        nexus.get_dataset_from_group(
+                                            group, value_dataset_name)))
 
     if is_time_series:
         # If property has timestamps, create a DataArray

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -102,9 +102,6 @@ def _add_log_to_data(log_data_name: str, log_data: sc.Variable, group_path: str,
 
 
 class NXlog(NXobject):
-    def __init__(self, group: Group, loader: LoadFromNexus):
-        super().__init__(group, loader)
-
     @property
     def shape(self):
         pass

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -121,8 +121,8 @@ class NXlog(NXobject):
         return da
 
 
-def _load_log_data_from_group(
-        group: Group, nexus: LoadFromNexus, select=tuple()) -> Tuple[str, sc.Variable]:
+def _load_log_data_from_group(group: Group, nexus: LoadFromNexus, select=tuple())\
+        -> Tuple[str, sc.Variable]:
     property_name = nexus.get_name(group)
     value_dataset_name = "value"
     time_dataset_name = "time"

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -126,7 +126,8 @@ def _load_log_data_from_group(
     property_name = nexus.get_name(group)
     value_dataset_name = "value"
     time_dataset_name = "time"
-    # TODO This is wrong if the log just has a single value. Can we check the shape in advance?
+    # TODO This is wrong if the log just has a single value. Can we check
+    # the shape in advance?
     index = to_plain_index(["time"], select)
 
     try:
@@ -195,7 +196,8 @@ def _load_log_data_from_group(
                                     unit=unit,
                                     dims=[dimension_label],
                                     dtype=nexus.get_dataset_numpy_dtype(
-                                        nexus.get_dataset_from_group(group, value_dataset_name)))
+                                        nexus.get_dataset_from_group(
+                                            group, value_dataset_name)))
 
     if is_time_series:
         # If property has timestamps, create a DataArray

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -170,7 +170,7 @@ def _load_log_data_from_group(
         times = _convert_nxlog_time_to_datetime64(raw_times=raw_times,
                                                   log_start=log_start_time,
                                                   scaling_factor=scaling_factor,
-                                                  group_path=group.name)
+                                                  group_path=nexus.get_path(group))
 
         if tuple(times.shape) != values.shape:
             raise BadSource(f"NXlog '{property_name}' has time and value "
@@ -195,8 +195,7 @@ def _load_log_data_from_group(
                                     unit=unit,
                                     dims=[dimension_label],
                                     dtype=nexus.get_dataset_numpy_dtype(
-                                        nexus.get_dataset_from_group(
-                                            group, value_dataset_name)))
+                                        nexus.get_dataset_from_group(group, value_dataset_name)))
 
     if is_time_series:
         # If property has timestamps, create a DataArray

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -8,6 +8,7 @@ import scipp as sc
 from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group)
 from ._common import to_plain_index
 from ._nexus import LoadFromNexus
+from .nxobject import NXobject
 from warnings import warn
 
 
@@ -98,6 +99,32 @@ def _add_log_to_data(log_data_name: str, log_data: sc.Variable, group_path: str,
     if name_changed:
         warn(f"Name of log group at {'/'.join(group_path)} is not unique: "
              f"{log_data_name} used as attribute name.")
+
+
+class NXlog(NXobject):
+    def __init__(self, group: Group, loader: LoadFromNexus):
+        super().__init__(group, loader)
+
+    @property
+    def shape(self):
+        pass
+
+    @property
+    def dims(self):
+        pass
+
+    @property
+    def unit(self):
+        pass
+
+    def _getitem(self, index):
+        name, var = _load_log_data_from_group(self._group,
+                                              self._loader,
+                                              select=index)
+        da = var.value
+        da.name = name
+        return da
+
 
 
 def _load_log_data_from_group(group: Group,

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -69,7 +69,7 @@ def load_monitor_data(monitor_groups: List[Group], nexus: LoadFromNexus) -> Dict
             monitor = load_monitor(group, nexus)
             monitor_name = group.name.split("/")[-1]
             monitor_data[monitor_name] = sc.scalar(value=monitor)
-        except ValueError as e:
+        except ValueError:
             warnings.warn(f"No event-mode or histogram-mode monitor data found for "
                           f"NXMonitor group {group.name}. Skipping this group.")
 

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -64,7 +64,7 @@ def load_monitor(group: Group, nexus: LoadFromNexus, select=...) -> sc.DataArray
 
     # Look for event mode data structures in NXMonitor. Event-mode data takes
     # precedence over histogram-mode-data if available.
-    if nexus.dataset_in_group(group, "event_id")[0]:
+    if nexus.dataset_in_group(group, "event_index")[0]:
         events = load_detector_data([group], [], nexus, True, True)
         warnings.warn(f"Event data present in NXMonitor group {group.name}. "
                       f"Histogram-mode monitor data from this group will be "
@@ -73,7 +73,7 @@ def load_monitor(group: Group, nexus: LoadFromNexus, select=...) -> sc.DataArray
     else:
         data = _load_data_from_histogram_mode_monitor(group, nexus, select=select)
         if data is None:
-            raise ValueError("No monitor data found in {group.name}")
+            raise ValueError(f"No monitor data found in {group.name}")
         return data
 
 

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -4,6 +4,27 @@ from ._common import Group, to_plain_index
 import scipp as sc
 from ._nexus import LoadFromNexus
 from ._detector_data import load_detector_data
+from .nxobject import NXobject
+
+
+class NXmonitor(NXobject):
+    def __init__(self, group: Group, loader: LoadFromNexus):
+        super().__init__(group, loader)
+
+    @property
+    def shape(self):
+        pass
+
+    @property
+    def dims(self):
+        pass
+
+    @property
+    def unit(self):
+        pass
+
+    def _getitem(self, index):
+        return load_monitor(self._group, self._loader, select=index)
 
 
 def _load_data_from_histogram_mode_monitor(group: Group,

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -6,37 +6,85 @@ from ._nexus import LoadFromNexus
 from ._detector_data import load_detector_data
 
 
-def _load_data_from_histogram_mode_monitor(group: Group, nexus: LoadFromNexus):
+def index_from_select(dims, select, ignore_missing=False):
+    def check_1d():
+        if len(dims) != 1:
+            raise ValueError(
+                f"Dataset has multiple dimensions {dims}, specify the dimension to index."
+            )
+
+    if select is Ellipsis:
+        return ...
+    if isinstance(select, tuple) and isinstance(select[0], str):
+        key, sel = select
+        select = {key: sel}
+
+    if isinstance(select, tuple):
+        check_1d()
+        return select
+    elif isinstance(select, int) or isinstance(select, slice):
+        check_1d()
+        return select
+    elif isinstance(select, dict):
+        index = [slice(None)] * len(dims)
+        for key, sel in select.items():
+            if not ignore_missing and key not in dims:
+                raise ValueError(
+                    f"'{key}' used for indexing not found in dataset dims {dims}.")
+            index[dims.index(key)] = sel
+        return tuple(index)
+    raise ValueError("Cannot process index {select}")
+
+
+def _load_data_from_histogram_mode_monitor(group: Group,
+                                           nexus: LoadFromNexus,
+                                           select=...):
     data_group = nexus.get_child_from_group(group, "data")
     if data_group is not None:
         dims = nexus.get_string_attribute(data_group, "axes").split(",")
-
-        data = nexus.load_dataset(group, "data", dimensions=dims)
-        coords = {dim: nexus.load_dataset(group, dim, dimensions=[dim]) for dim in dims}
+        index = index_from_select(dims, select)
+        data = nexus.load_dataset(group, "data", dimensions=dims, index=index)
+        coords = {
+            dim: nexus.load_dataset(group,
+                                    dim,
+                                    dimensions=[dim],
+                                    index=index_from_select([dim],
+                                                            select,
+                                                            ignore_missing=True))
+            for dim in dims
+        }
         return sc.DataArray(data=data, coords=coords)
     else:
         return None
 
 
+def load_monitor(group: Group, nexus: LoadFromNexus, select=...) -> sc.DataArray:
+
+    monitor_name = group.name.split("/")[-1]
+
+    # Look for event mode data structures in NXMonitor. Event-mode data takes
+    # precedence over histogram-mode-data if available.
+    if nexus.dataset_in_group(group, "event_id")[0]:
+        events = load_detector_data([group], [], nexus, True, True)
+        warnings.warn(f"Event data present in NXMonitor group {group.name}. "
+                      f"Histogram-mode monitor data from this group will be "
+                      f"ignored.")
+        return events
+    else:
+        data = _load_data_from_histogram_mode_monitor(group, nexus, select=select)
+        if data is None:
+            raise ValueError("No monitor data found in {group.name}")
+        return data
+
+
 def load_monitor_data(monitor_groups: List[Group], nexus: LoadFromNexus) -> Dict:
     monitor_data = {}
     for group in monitor_groups:
-        monitor_name = group.name.split("/")[-1]
-
-        # Look for event mode data structures in NXMonitor. Event-mode data takes
-        # precedence over histogram-mode-data if available.
-        if nexus.dataset_in_group(group, "event_id")[0]:
-            events = load_detector_data([group], [], nexus, True, True)
-            monitor_data[monitor_name] = sc.scalar(value=events)
-            warnings.warn(f"Event data present in NXMonitor group {group.name}. "
-                          f"Histogram-mode monitor data from this group will be "
-                          f"ignored.")
-        else:
-            data = _load_data_from_histogram_mode_monitor(group, nexus)
-            if data is not None:
-                monitor_data[monitor_name] = sc.scalar(value=data)
-            else:
-                warnings.warn(f"No event-mode or histogram-mode monitor data found for "
-                              f"NXMonitor group {group.name}. Skipping this group.")
+        try:
+            monitor = load_monitor(group, nexus)
+        except ValueError:
+            warnings.warn(f"No event-mode or histogram-mode monitor data found for "
+                          f"NXMonitor group {group.name}. Skipping this group.")
+        monitor_data[monitor_name] = sc.scalar(value=monitor)
 
     return monitor_data

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -8,9 +8,6 @@ from .nxobject import NXobject
 
 
 class NXmonitor(NXobject):
-    def __init__(self, group: Group, loader: LoadFromNexus):
-        super().__init__(group, loader)
-
     @property
     def shape(self):
         pass

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -82,9 +82,9 @@ class NXobject:
         return out
 
     @property
-    def NX_class(self):
-        nx_class = self._loader.get_string_attribute(self._group, 'NX_class')
-        return NX_class[nx_class]
+    def nx_class(self):
+        key = self._loader.get_string_attribute(self._group, 'NX_class')
+        return NX_class[key]
 
     def __repr__(self):
         return f'<{type(self).__name__} "{self._group.name}">'
@@ -92,7 +92,7 @@ class NXobject:
 
 class NXroot(NXobject):
     @property
-    def NX_class(self):
+    def nx_class(self):
         # Most files violate the standard and do not define NX_class on file root
         return 'NXroot'
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -28,13 +28,13 @@ class NXobject:
         self._loader = loader
 
     @classmethod
-    def subclass(cls, nx_class):
+    def _subclass(cls, nx_class):
         return cls._registry.get(nx_class, NXobject)
 
     @classmethod
     def make(cls, group, loader=LoadFromHdf5()):
         nx_class = loader.get_string_attribute(group, 'NX_class')
-        return cls.subclass(nx_class)(group, loader)
+        return cls._subclass(nx_class)(group, loader)
 
     # TODO Should probably remove this and forward desired method explictly
     def __getattr__(self, name):
@@ -52,7 +52,18 @@ class NXobject:
     def _getitem(self, index):
         # TODO Is it better to fall back to returning h5py.Group?
         # distinguish classes not implementing _getitem, vs missing classes!
-        print(f'Cannot load unsupported class {self.NX_class}')
+        print(f'Loading {self.NX_class} is not supported.')
+
+    def keys(self):
+        return self._group.keys()
+
+    def values(self):
+        # TODO Better check for dataset
+        # TODO use loader features, not h5py
+        return [
+            self.make(v, self._loader) if isinstance(v, h5py.Group) else v
+            for v in self._group.values()
+        ]
 
     @functools.lru_cache()
     def by_nx_class(self):
@@ -72,3 +83,7 @@ class NXobject:
 
     def __repr__(self):
         return f'<{type(self).__name__} "{self._group.name}">'
+
+
+class NXentry(NXobject):
+    pass

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+from enum import Enum, auto
+import functools
+import h5py
+
+from ..file_loading._hdf5_nexus import LoadFromHdf5
+
+class NX_class(Enum):
+    NXentry = auto()
+    NXlog = auto()
+    NXmonitor = auto()
+    NXevent_data = auto()
+
+
+
+class NXobject:
+    #nxobject = {}
+    #nxobject['NXlog'] = NXlog
+    #nxobject['NXmonitor'] = NXmonitor
+    #nxobject['NXevent_data'] = NXevent_data
+
+    def __init__(self, group: h5py.Group, loader=LoadFromHdf5()):
+        self._group = group
+        self._loader = loader
+
+    @staticmethod
+    def _subclass(name):
+        for cls in NXobject.__subclasses__():
+            if cls.__name__ == name:
+                return cls
+        return NXobject
+
+    @staticmethod
+    def make(group, loader=LoadFromHdf5()):
+        nx_class = loader.get_string_attribute(group, 'NX_class')
+        return NXobject._subclass(nx_class)(group, loader)
+
+    def __getattr__(self, name):
+        return getattr(self._group, name)
+
+    def __getitem__(self, index):
+        if isinstance(index, str):
+            item = self._group[index]
+            if hasattr(item, 'visititems'):
+                return NXobject.make(item)
+            else:
+                return item
+        return self._getitem(index)
+
+    def _getitem(self, index):
+        # TODO Is it better to fall back to returning h5py.Group?
+        # distinguish classes not implementing _getitem, vs missing classes!
+        print(f'Cannot load unsupported class {self.NX_class}')
+
+    @functools.lru_cache()
+    def by_nx_class(self):
+        keys = [c.name for c in NX_class]
+        classes = self._loader.find_by_nx_class(tuple(keys), self._group)
+        out = {}
+        for nx_class, groups in classes.items():
+            names = [self._loader.get_name(group) for group in groups]
+            if len(names) != len(set(names)):  # fall back to full path if duplicate
+                names = [group.name for group in groups]
+            out[NX_class[nx_class]] = {n: NXobject.make(g) for n, g in zip(names, groups)}
+        return out
+
+    @property
+    def NX_class(self):
+        nx_class = self._loader.get_string_attribute(self._group, 'NX_class')
+        return NX_class[nx_class]

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -33,7 +33,11 @@ class Field:
         return f'<Nexus field "{self._dataset.name}">'
 
     @property
-    def name(self):
+    def dtype(self):
+        return self._loader.get_dtype(self._dataset)
+
+    @property
+    def name(self) -> str:
         return self._loader.get_path(self._dataset)
 
     @property

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -5,6 +5,7 @@ from enum import Enum, auto
 import functools
 import h5py
 
+from ._nexus import LoadFromNexus
 from ..file_loading._hdf5_nexus import LoadFromHdf5
 from ._common import Group, Dataset
 
@@ -22,7 +23,7 @@ class Field:
 
     In HDF5 fields are represented as dataset.
     """
-    def __init__(self, dataset: Dataset, loader=LoadFromHdf5()):
+    def __init__(self, dataset: Dataset, loader: LoadFromNexus = LoadFromHdf5()):
         self._dataset = dataset
         self._loader = loader
 
@@ -34,7 +35,7 @@ class Field:
 
 
 class NXobject:
-    def __init__(self, group: h5py.Group, loader=LoadFromHdf5()):
+    def __init__(self, group: Group, loader: LoadFromNexus = LoadFromHdf5()):
         self._group = group
         self._loader = loader
 
@@ -93,8 +94,11 @@ class NXobject:
 class NXroot(NXobject):
     @property
     def nx_class(self):
-        # Most files violate the standard and do not define NX_class on file root
-        return 'NXroot'
+        # As an oversight in the NeXus standard and the reference implementation,
+        # the NX_class was never set to NXroot. This applies to essentially all
+        # files in existence before 2016, and files written by other implementations
+        # that were inspired by the reference implementation. We thus hardcode NXroot:
+        return NX_class['NXroot']
 
 
 class NXentry(NXobject):

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -3,7 +3,6 @@
 # @author Simon Heybrock
 from enum import Enum, auto
 import functools
-import h5py
 
 from ._nexus import LoadFromNexus
 from ..file_loading._hdf5_nexus import LoadFromHdf5
@@ -68,7 +67,7 @@ class NXobject:
         return self._getitem(name)
 
     def _getitem(self, index):
-        raise NotImplemented(f'Loading {self.nx_class} is not supported.')
+        raise NotImplementedError(f'Loading {self.nx_class} is not supported.')
 
     @property
     def name(self):

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from enum import Enum, auto
 import functools

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+
+# flake8: noqa
+
+from .nexus import File, Group, open_nexus

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 
 # flake8: noqa

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -4,4 +4,4 @@
 
 # flake8: noqa
 
-from .nexus import File, Group, open_nexus
+from .nexus import File, Group

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -4,4 +4,4 @@
 
 # flake8: noqa
 
-from .nexus import File, Group
+from .nexus import File, Group, NX_class

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -4,4 +4,4 @@
 
 # flake8: noqa
 
-from .nexus import File, NX_class
+from .nexus import File, NX_class, NXroot

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -4,4 +4,4 @@
 
 # flake8: noqa
 
-from .nexus import File, Group, NX_class
+from .nexus import File, NX_class

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -5,4 +5,4 @@
 # flake8: noqa
 
 from .nexus import File, NXroot
-from ..file_loading.nxobject import NX_class
+from ..file_loading.nxobject import NX_class, Field

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -4,4 +4,5 @@
 
 # flake8: noqa
 
-from .nexus import File, NX_class, NXroot
+from .nexus import File, NXroot
+from ..file_loading.nxobject import NX_class

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -2,10 +2,10 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 
-from contextlib import contextmanager, AbstractContextManager
+from contextlib import AbstractContextManager
 import h5py
 
-from ..file_loading.nxobject import NX_class, NXroot
+from ..file_loading.nxobject import NXroot
 
 
 class File(AbstractContextManager, NXroot):

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -5,17 +5,7 @@
 from contextlib import contextmanager, AbstractContextManager
 import h5py
 
-from ..file_loading.nxobject import NX_class, NXobject
-
-
-class NXroot(NXobject):
-    def __init_subclass__(cls):
-        pass
-
-    @property
-    def NX_class(self):
-        # Most files violate the standard and do not define NX_class on file root
-        return 'NXroot'
+from ..file_loading.nxobject import NX_class, NXroot
 
 
 class File(AbstractContextManager, NXroot):

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 
 from contextlib import AbstractContextManager

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -5,7 +5,7 @@
 from contextlib import contextmanager, AbstractContextManager
 import h5py
 
-from ..file_loading.nxobject import NXobject
+from ..file_loading.nxobject import NX_class, NXobject
 
 
 class File(AbstractContextManager, NXobject):

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -9,6 +9,9 @@ from ..file_loading.nxobject import NX_class, NXobject
 
 
 class NXroot(NXobject):
+    def __init_subclass__(cls):
+        pass
+
     @property
     def NX_class(self):
         # Most files violate the standard and do not define NX_class on file root

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
+
+from contextlib import contextmanager, AbstractContextManager
+import h5py
+
+from ..file_loading._log_data import _load_log_data_from_group
+from ..file_loading._hdf5_nexus import LoadFromHdf5
+
+
+class Dataset():
+    def __init__(self, dataset: h5py.Dataset):
+        self._dataset = dataset
+
+    def __getitem__(self, index):
+        if index is Ellipsis:
+            return self._dataset[index]
+        print(index)
+
+
+class Group():
+    def __init__(self, group: h5py.Group):
+        self._group = group
+
+    def __getitem__(self, index):
+        if isinstance(index, str):
+            item = self._group[index]
+            if hasattr(item, 'visititems'):
+                return Group(item)
+            else:
+                return Dataset(item)
+        name, var = _load_log_data_from_group(self._group, LoadFromHdf5(), index)
+        da = var.value
+        da.name = name
+        return da
+
+    @property
+    def NX_class(self):
+        return self._group.attrs['NX_class']
+
+    def keys(self):
+        return self._group.keys()
+
+
+class File(AbstractContextManager, Group):
+    def __init__(self, *args, **kwargs):
+        self._file = h5py.File(*args, **kwargs)
+        Group.__init__(self, self._file)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._file.close()

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -8,11 +8,17 @@ import h5py
 from ..file_loading.nxobject import NX_class, NXobject
 
 
-class File(AbstractContextManager, NXobject):
+class NXroot(NXobject):
+    @property
+    def NX_class(self):
+        # Most files violate the standard and do not define NX_class on file root
+        return 'NXroot'
+
+
+class File(AbstractContextManager, NXroot):
     def __init__(self, *args, **kwargs):
-        # TODO how can we make this an instance of the correct subclass?
         self._file = h5py.File(*args, **kwargs)
-        NXobject.__init__(self, self._file)
+        NXroot.__init__(self, self._file)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._file.close()
+        self._group.close()

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -25,6 +25,9 @@ class Group:
         self._group = group
         self._loader = LoadFromHdf5()
 
+    def __getattr__(self, name):
+        return getattr(self._group, name)
+
     def __getitem__(self, index):
         if isinstance(index, str):
             item = self._group[index]
@@ -53,15 +56,9 @@ class Group:
             return data
         print(f'Cannot load unsupported class {self.NX_class}')
 
-    def __getattr__(self, name):
-        return getattr(self._group, name)
-
     @property
     def NX_class(self):
         return NX_class[self._group.attrs['NX_class'].decode('UTF-8')]
-
-    def keys(self):
-        return self._group.keys()
 
     @property
     @functools.lru_cache()

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -10,14 +10,8 @@ import h5py
 from ..file_loading._log_data import _load_log_data_from_group
 from ..file_loading._monitor_data import load_monitor
 from ..file_loading._hdf5_nexus import LoadFromHdf5
-from ..file_loading._detector_data import _load_event_group, DetectorData
-
-
-class NX_class(Enum):
-    NXentry = auto()
-    NXlog = auto()
-    NXmonitor = auto()
-    NXevent_data = auto()
+from ..file_loading._detector_data import _load_event_group, DetectorData, NXevent_data
+from ..file_loading.nxobject import NX_class, NXobject
 
 
 class Group:
@@ -63,6 +57,7 @@ class Group:
     @property
     @functools.lru_cache()
     def shape(self):
+        return self._nxobject.shape
         # TODO Same code in _load_event_group, refactor to better abstraction
         if self.NX_class == NX_class.NXevent_data:
             return self._loader.get_shape(
@@ -82,10 +77,11 @@ class Group:
         return out
 
 
-class File(AbstractContextManager, Group):
+class File(AbstractContextManager, NXobject):
     def __init__(self, *args, **kwargs):
+        # TODO how can we make this an instance of the correct subclass?
         self._file = h5py.File(*args, **kwargs)
-        Group.__init__(self, self._file)
+        NXobject.__init__(self, self._file)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._file.close()

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -3,78 +3,9 @@
 # @author Simon Heybrock
 
 from contextlib import contextmanager, AbstractContextManager
-from enum import Enum, auto
-import functools
 import h5py
 
-from ..file_loading._log_data import _load_log_data_from_group
-from ..file_loading._monitor_data import load_monitor
-from ..file_loading._hdf5_nexus import LoadFromHdf5
-from ..file_loading._detector_data import _load_event_group, DetectorData, NXevent_data
-from ..file_loading.nxobject import NX_class, NXobject
-
-
-class Group:
-    def __init__(self, group: h5py.Group):
-        self._group = group
-        self._loader = LoadFromHdf5()
-
-    def __getattr__(self, name):
-        return getattr(self._group, name)
-
-    def __getitem__(self, index):
-        if isinstance(index, str):
-            item = self._group[index]
-            if hasattr(item, 'visititems'):
-                return Group(item)
-            else:
-                return item
-        if self.NX_class == NX_class.NXlog:
-            name, var = _load_log_data_from_group(self._group,
-                                                  self._loader,
-                                                  select=index)
-            da = var.value
-            da.name = name
-            return da
-        if self.NX_class == NX_class.NXmonitor:
-            return load_monitor(self._group, self._loader, select=index)
-        if self.NX_class == NX_class.NXevent_data:
-            detector_data = _load_event_group(self._group,
-                                              self._loader,
-                                              DetectorData(),
-                                              quiet=False,
-                                              select=index)
-            data = detector_data.event_data
-            data.bins.coords['id'] = data.bins.coords.pop('detector_id')
-            data.bins.coords['time_offset'] = data.bins.coords.pop('tof')
-            return data
-        print(f'Cannot load unsupported class {self.NX_class}')
-
-    @property
-    def NX_class(self):
-        return NX_class[self._group.attrs['NX_class'].decode('UTF-8')]
-
-    @property
-    @functools.lru_cache()
-    def shape(self):
-        return self._nxobject.shape
-        # TODO Same code in _load_event_group, refactor to better abstraction
-        if self.NX_class == NX_class.NXevent_data:
-            return self._loader.get_shape(
-                self._loader.get_dataset_from_group(self._group, "event_index"))
-        raise TypeError("Class has no shape.")
-
-    @functools.lru_cache()
-    def by_nx_class(self):
-        keys = [c.name for c in NX_class]
-        classes = self._loader.find_by_nx_class(tuple(keys), self._group)
-        out = {}
-        for nx_class, groups in classes.items():
-            names = [self._loader.get_name(group) for group in groups]
-            if len(names) != len(set(names)):  # fall back to full path if duplicate
-                names = [group.name for group in groups]
-            out[NX_class[nx_class]] = {n: Group(g) for n, g in zip(names, groups)}
-        return out
+from ..file_loading.nxobject import NXobject
 
 
 class File(AbstractContextManager, NXobject):

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -445,6 +445,13 @@ class NexusBuilder:
             return json.dump(root, json_file, indent=4, cls=NumpyEncoder)
 
     @contextmanager
+    def json(self):
+        try:
+            yield json.loads(self.json_string)
+        finally:
+            pass
+
+    @contextmanager
     def file(self) -> Iterator[h5py.File]:
         # "core" driver means file is "in-memory" not on disk.
         # backing_store=False prevents file being written to

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -1,23 +1,13 @@
 from .nexus_helpers import (
     NexusBuilder,
     EventData,
-    Detector,
     Log,
-    Sample,
-    Source,
-    Transformation,
-    TransformationType,
-    Link,
     Monitor,
-    Chopper,
-    in_memory_hdf5_file_with_two_nxentry,
 )
 import numpy as np
 import pytest
 from typing import Callable, Tuple
-import scippneutron as scn
 import scipp as sc
-from scippneutron.file_loading._detector_data import _load_event_group, DetectorData
 from scippneutron.file_loading._nexus import LoadFromNexus
 from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
 from scippneutron.file_loading._json_nexus import LoadFromJson
@@ -102,7 +92,6 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
         event_data = entry['events_0']
         assert set(event_data.keys()) == set(
             ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
-        items = dict(zip(event_data.keys(), event_data.values()))
         assert event_data.nx_class == nexus.NX_class.NXevent_data
 
 
@@ -119,8 +108,8 @@ def test_nxobject_by_nx_class_contains_everything(nexus_group: Tuple[Callable,
             ['events_0', 'events_1'])
 
 
-def test_nxobject_by_nx_class_of_child_contains_only_children(
-    nexus_group: Tuple[Callable, LoadFromNexus]):
+def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable,
+                                                                        LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -142,6 +142,34 @@ def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable
             ['events_0', 'events_1'])
 
 
+def test_nxobject_dataset_items_are_returned_as_Field(
+    nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
+        assert isinstance(field, nexus.Field)
+
+
+def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
+        assert field.dtype == 'int64'
+        assert field.name == '/entry/events_0/event_time_offset'
+        assert field.shape == (6, )
+        assert field.unit == sc.Unit('ns')
+
+
+def test_field_getitem_returns_numpy_array_with_correct_size_and_values(
+    nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
+        assert np.array_equal(field[...], [456, 743, 347, 345, 632, 23])
+        assert np.array_equal(field[1:], [743, 347, 345, 632, 23])
+        assert np.array_equal(field[:-1], [456, 743, 347, 345, 632])
+
+
 def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable,
                                                                         LoadFromNexus]):
     event_time_offsets = np.array([456, 743, 347, 345, 632, 23])

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -165,9 +165,12 @@ def test_field_getitem_returns_numpy_array_with_correct_size_and_values(
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
-        assert np.array_equal(field[...], [456, 743, 347, 345, 632, 23])
-        assert np.array_equal(field[1:], [743, 347, 345, 632, 23])
-        assert np.array_equal(field[:-1], [456, 743, 347, 345, 632])
+        assert np.array_equal(field[...],
+                              np.array([456, 743, 347, 345, 632, 23], dtype='int64'))
+        assert np.array_equal(field[1:],
+                              np.array([743, 347, 345, 632, 23], dtype='int64'))
+        assert np.array_equal(field[:-1],
+                              np.array([456, 743, 347, 345, 632], dtype='int64'))
 
 
 def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable,

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -154,7 +154,7 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
-        assert field.dtype == 'int64'
+        assert field.dtype == np.array(1).dtype
         assert field.name == '/entry/events_0/event_time_offset'
         assert field.shape == (6, )
         assert field.unit == sc.Unit('ns')

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -59,12 +59,10 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)
-        assert root.name == '/'
         assert root.nx_class == nexus.NX_class.NXroot
         assert set(root.keys()) == set(['entry', 'monitor'])
 
         monitor = root['monitor']
-        assert monitor.name == '/monitor'
         assert monitor.nx_class == nexus.NX_class.NXmonitor
         assert sc.identical(
             monitor[...],
@@ -75,12 +73,10 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
                          }))
 
         entry = root['entry']
-        assert entry.name == '/entry'
         assert entry.nx_class == nexus.NX_class.NXentry
         assert set(entry.keys()) == set(['events_0', 'events_1', 'log'])
 
         log = entry['log']
-        assert log.name == '/entry/log'
         assert log.nx_class == nexus.NX_class.NXlog
         assert sc.identical(
             log[...],
@@ -94,10 +90,30 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
                 }))
 
         event_data = entry['events_0']
-        assert event_data.name == '/entry/events_0'
         assert set(event_data.keys()) == set(
             ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
         assert event_data.nx_class == nexus.NX_class.NXevent_data
+
+
+def test_nxobject_name_property_is_full_path(nexus_group: Tuple[Callable,
+                                                                LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        root = nexus.NXroot(f, loader)
+        assert root.name == '/'
+        assert root['monitor'].name == '/monitor'
+        assert root['entry'].name == '/entry'
+        assert root['entry']['log'].name == '/entry/log'
+        assert root['entry']['events_0'].name == '/entry/events_0'
+
+
+def test_nxobject_grandchild_can_be_accessed_using_path(
+    nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        root = nexus.NXroot(f, loader)
+        assert root['entry/log'].name == '/entry/log'
+        assert root['/entry/log'].name == '/entry/log'
 
 
 def test_nxobject_by_nx_class_contains_everything(nexus_group: Tuple[Callable,

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -59,10 +59,12 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)
+        assert root.name == '/'
         assert root.nx_class == nexus.NX_class.NXroot
         assert set(root.keys()) == set(['entry', 'monitor'])
 
         monitor = root['monitor']
+        assert monitor.name == '/monitor'
         assert monitor.nx_class == nexus.NX_class.NXmonitor
         assert sc.identical(
             monitor[...],
@@ -73,10 +75,12 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
                          }))
 
         entry = root['entry']
+        assert entry.name == '/entry'
         assert entry.nx_class == nexus.NX_class.NXentry
         assert set(entry.keys()) == set(['events_0', 'events_1', 'log'])
 
         log = entry['log']
+        assert log.name == '/entry/log'
         assert log.nx_class == nexus.NX_class.NXlog
         assert sc.identical(
             log[...],
@@ -90,6 +94,7 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
                 }))
 
         event_data = entry['events_0']
+        assert event_data.name == '/entry/events_0'
         assert set(event_data.keys()) == set(
             ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
         assert event_data.nx_class == nexus.NX_class.NXevent_data

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -108,7 +108,7 @@ def test_nxobject_name_property_is_full_path(nexus_group: Tuple[Callable,
 
 
 def test_nxobject_grandchild_can_be_accessed_using_path(
-    nexus_group: Tuple[Callable, LoadFromNexus]):
+        nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)
@@ -143,7 +143,7 @@ def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable
 
 
 def test_nxobject_dataset_items_are_returned_as_Field(
-    nexus_group: Tuple[Callable, LoadFromNexus]):
+        nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
@@ -161,7 +161,7 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
 
 
 def test_field_getitem_returns_numpy_array_with_correct_size_and_values(
-    nexus_group: Tuple[Callable, LoadFromNexus]):
+        nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -1,0 +1,132 @@
+from .nexus_helpers import (
+    NexusBuilder,
+    EventData,
+    Detector,
+    Log,
+    Sample,
+    Source,
+    Transformation,
+    TransformationType,
+    Link,
+    Monitor,
+    Chopper,
+    in_memory_hdf5_file_with_two_nxentry,
+)
+import numpy as np
+import pytest
+from typing import Callable, Tuple
+import scippneutron as scn
+import scipp as sc
+from scippneutron.file_loading._detector_data import _load_event_group, DetectorData
+from scippneutron.file_loading._nexus import LoadFromNexus
+from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
+from scippneutron.file_loading._json_nexus import LoadFromJson
+from scippneutron import nexus
+
+
+def open_nexus(builder: NexusBuilder):
+    return builder.file
+
+
+def open_json(builder: NexusBuilder):
+    return builder.json
+
+
+@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+def nexus_group(request):
+    """
+    Each test with this fixture is executed with load_nexus_json
+    loading JSON output from the NexusBuilder, and with load_nexus
+    loading in-memory NeXus output from the NexusBuilder
+    """
+    return request.param
+
+
+def builder_with_events_monitor_and_log():
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_data = EventData(
+        event_id=np.array([1, 2, 3, 1, 3, 2]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=np.array([
+            1600766730000000000, 1600766731000000000, 1600766732000000000,
+            1600766733000000000
+        ]),
+        event_index=np.array([0, 3, 3, 5]),
+    )
+
+    builder = NexusBuilder()
+    builder.add_event_data(event_data)
+    builder.add_event_data(event_data)
+    builder.add_monitor(
+        Monitor("monitor",
+                data=np.array([1.]),
+                axes=[("time_of_flight", np.array([1.]))]))
+    builder.add_log(Log("log", np.array([1.1, 2.2, 3.3]), np.array([4.4, 5.5, 6.6])))
+    return builder
+
+
+def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        root = nexus.NXroot(f, loader)
+        assert root.nx_class == nexus.NX_class.NXroot
+        assert set(root.keys()) == set(['entry', 'monitor'])
+
+        monitor = root['monitor']
+        assert monitor.nx_class == nexus.NX_class.NXmonitor
+        assert sc.identical(
+            monitor[...],
+            sc.DataArray(sc.array(dims=['time_of_flight'], values=[1.0]),
+                         coords={
+                             'time_of_flight':
+                             sc.array(dims=['time_of_flight'], values=[1.0])
+                         }))
+
+        entry = root['entry']
+        assert entry.nx_class == nexus.NX_class.NXentry
+        assert set(entry.keys()) == set(['events_0', 'events_1', 'log'])
+
+        log = entry['log']
+        assert log.nx_class == nexus.NX_class.NXlog
+        assert sc.identical(
+            log[...],
+            sc.DataArray(
+                sc.array(dims=['time'], values=[1.1, 2.2, 3.3]),
+                coords={
+                    'time':
+                    sc.epoch(unit='ns') +
+                    sc.array(dims=['time'], unit='s', values=[4.4, 5.5, 6.6]).to(
+                        unit='ns', dtype='int64')
+                }))
+
+        event_data = entry['events_0']
+        assert set(event_data.keys()) == set(
+            ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
+        items = dict(zip(event_data.keys(), event_data.values()))
+        assert event_data.nx_class == nexus.NX_class.NXevent_data
+
+
+def test_nxobject_by_nx_class_contains_everything(nexus_group: Tuple[Callable,
+                                                                     LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        root = nexus.NXroot(f, loader)
+        classes = root.by_nx_class()
+        assert list(classes[nexus.NX_class.NXentry]) == ['entry']
+        assert list(classes[nexus.NX_class.NXmonitor]) == ['monitor']
+        assert list(classes[nexus.NX_class.NXlog]) == ['log']
+        assert set(classes[nexus.NX_class.NXevent_data]) == set(
+            ['events_0', 'events_1'])
+
+
+def test_nxobject_by_nx_class_of_child_contains_only_children(
+    nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        root = nexus.NXroot(f, loader)
+        classes = root['entry'].by_nx_class()
+        assert list(classes[nexus.NX_class.NXentry]) == []
+        assert list(classes[nexus.NX_class.NXmonitor]) == []
+        assert list(classes[nexus.NX_class.NXlog]) == ['log']
+        assert set(classes[nexus.NX_class.NXevent_data]) == set(
+            ['events_0', 'events_1'])

--- a/tests/test_nexus_loader_components.py
+++ b/tests/test_nexus_loader_components.py
@@ -1,0 +1,90 @@
+from .nexus_helpers import (
+    NexusBuilder,
+    EventData,
+    Detector,
+    Log,
+    Sample,
+    Source,
+    Transformation,
+    TransformationType,
+    Link,
+    Monitor,
+    Chopper,
+    in_memory_hdf5_file_with_two_nxentry,
+)
+import numpy as np
+import pytest
+from typing import Callable, Tuple
+import scippneutron as scn
+import scipp as sc
+from scippneutron.file_loading._detector_data import _load_event_group, DetectorData
+from scippneutron.file_loading._nexus import LoadFromNexus
+from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
+from scippneutron.file_loading._json_nexus import LoadFromJson
+
+
+def open_nexus(builder: NexusBuilder):
+    return builder.file
+
+
+def open_json(builder: NexusBuilder):
+    return builder.json
+
+
+@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+def nexus_group(request):
+    """
+    Each test with this fixture is executed with load_nexus_json
+    loading JSON output from the NexusBuilder, and with load_nexus
+    loading in-memory NeXus output from the NexusBuilder
+    """
+    return request.param
+
+
+def test_load_nx_event_data_selection_yields_correct_pulses(
+    nexus_group: Tuple[Callable, LoadFromNexus]):
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_data = EventData(
+        event_id=np.array([1, 2, 3, 1, 3, 2]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=np.array([
+            1600766730000000000, 1600766731000000000, 1600766732000000000,
+            1600766733000000000
+        ]),
+        event_index=np.array([0, 3, 3, 5]),
+    )
+
+    builder = NexusBuilder()
+    builder.add_event_data(event_data)
+    resource, loader = nexus_group
+
+    with resource(builder)() as f:
+        group = loader.get_child_from_group(loader.get_child_from_group(f, 'entry'),
+                                            'events_0')
+
+        class Load:
+            def __getitem__(self, select=...):
+                da = _load_event_group(group,
+                                       loader,
+                                       DetectorData(),
+                                       quiet=False,
+                                       select=select).event_data
+                return da.bins.size().values
+
+        assert np.array_equal(Load()[...], [3, 0, 2, 1])
+        assert np.array_equal(Load()['pulse', 0], 3)
+        assert np.array_equal(Load()['pulse', 1], 0)
+        assert np.array_equal(Load()['pulse', 3], 1)
+        assert np.array_equal(Load()['pulse', -1], 1)
+        assert np.array_equal(Load()['pulse', -2], 2)
+        assert np.array_equal(Load()['pulse', 0:0], [])
+        assert np.array_equal(Load()['pulse', 1:1], [])
+        assert np.array_equal(Load()['pulse', 1:-3], [])
+        assert np.array_equal(Load()['pulse', 3:3], [])
+        assert np.array_equal(Load()['pulse', -1:-1], [])
+        assert np.array_equal(Load()['pulse', 0:1], [3])
+        assert np.array_equal(Load()['pulse', 0:-3], [3])
+        assert np.array_equal(Load()['pulse', -1:], [1])
+        assert np.array_equal(Load()['pulse', -2:-1], [2])
+        assert np.array_equal(Load()['pulse', -2:], [2, 1])
+        assert np.array_equal(Load()['pulse', :-2], [3, 0])

--- a/tests/test_nexus_loader_components.py
+++ b/tests/test_nexus_loader_components.py
@@ -1,22 +1,10 @@
 from .nexus_helpers import (
     NexusBuilder,
     EventData,
-    Detector,
-    Log,
-    Sample,
-    Source,
-    Transformation,
-    TransformationType,
-    Link,
-    Monitor,
-    Chopper,
-    in_memory_hdf5_file_with_two_nxentry,
 )
 import numpy as np
 import pytest
 from typing import Callable, Tuple
-import scippneutron as scn
-import scipp as sc
 from scippneutron.file_loading._detector_data import _load_event_group, DetectorData
 from scippneutron.file_loading._nexus import LoadFromNexus
 from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
@@ -42,7 +30,7 @@ def nexus_group(request):
 
 
 def test_load_nx_event_data_selection_yields_correct_pulses(
-    nexus_group: Tuple[Callable, LoadFromNexus]):
+        nexus_group: Tuple[Callable, LoadFromNexus]):
     event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3, 2]),


### PR DESCRIPTION
This adds `nexus.Group`, which can used as follows:

```python
from scippneutron import nexus
from scippneutron.nexus import NX_class
f = nexus.File(filename)  # should use contextmanager, but that is cumbersome in a Jupyter notebook

f.by_nx_class()[NX_class.NXlog]['SampleTemp']  # nexus.Group (wrapping h5py.Group), nothing loaded yet
f.by_nx_class()[NX_class.NXlog]['SampleTemp']['time', :3]
f.by_nx_class()[NX_class.NXlog]['proton_charge'][:1000]  # dim label redundant if single dim
f.by_nx_class()[NX_class.NXmonitor]['monitor1'][...]  # load everything
f.by_nx_class()[NX_class.NXevent_data]['bank42_events']['pulse', :20000]
```

The implementation right now is a draft. I am considering the following changes:

- `nexus.Group` implementation has cumbersome branching bases on `NX_class`. My current idea would be to turn this into a base-class, `NXobject`, which can be implemented, e.g., by `NXlog`, `NXmonitor`, and `NXevent_data`.
- The child classes provide properties such as `dims, `shape`, and `unit`.
- Child classes provide `__getitem__` to actually load the class. This would forward to the current internal functions for loading such groups.

Does it make sense to introduce such an inheritance-based design? Or is there a better option?