### PR TITLE
Retry 3 times if pooch download fails

### DIFF
--- a/src/scippneutron/data/__init__.py
+++ b/src/scippneutron/data/__init__.py
@@ -14,6 +14,7 @@ def _make_pooch():
     return pooch.create(
         path=pooch.os_cache('scippneutron'),
         env='SCIPPNEUTRON_DATA_DIR',
+        retry_if_failed=3,
         base_url='https://public.esss.dk/groups/scipp/scippneutron/{version}/',
         version=_version,
         registry={


### PR DESCRIPTION
We have recently had failing CI builds because the checksums of downloaded files did not match. But only in some workers and not others. Hopefully, this PR makes the download less flaky.

The number 3 is completely arbitrary. But since we do not see many failures, we should not need many retries.

Will do the same in the other repos if this PR is accepted.