### PR TITLE
Extend nexus loading utilities, add NXdata and NXdetector

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -16,16 +16,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install --yes clang-format-10
-      - run: find lib -type f -regex '.*\.\(cpp\|h\|tcc\)' -exec clang-format-10 -i {} +
-      - run: pip install cmake_format==0.6.9 flake8 yapf==0.30.0
-      - run: find . -type f -name CMakeLists.txt -or -name '*.cmake' -not -path "./lib/.tbb/*" | xargs cmake-format -i
-      - run: yapf --recursive --in-place .
-      - run: flake8 .
+        with:
+          ref: ${{ github.head_ref }}
+      # Run this before any other commands so that git diff does not pick up formatting changes.
       - run: |
           find . -type f -not -path '.git/*' -exec sed -ri "s/[0-9]{4} (Scipp contributors)/$(date +%Y) \1/g" {} +
           git diff --exit-code
+      - run: sudo apt-get install --yes clang-format-10
+      - run: find lib -type f -regex '.*\.\(cpp\|h\|tcc\)' -exec clang-format-10 -i {} +
+      - run: pip install cmake_format==0.6.9 flake8 nb-clean==2.1.0 yapf==0.30.0
+      - run: find . -type f -name CMakeLists.txt -or -name '*.cmake' -not -path "./lib/.tbb/*" | xargs cmake-format -i
+      - run: find . -type f -regex '.*\.ipynb' | xargs nb-clean clean --remove-empty-cells --preserve-cell-metadata
+      - run: yapf --recursive --in-place .
+      - run: flake8 .
       - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply automatic formatting
 
   build_and_test:
     needs: formatting
@@ -54,6 +60,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0  # history required so cmake can determine version
+          ref: ${{ github.head_ref }}
 
       - name: ccache
         if: ${{ !contains(matrix.os, 'windows') }}

--- a/docs/about/whats-new.ipynb
+++ b/docs/about/whats-new.ipynb
@@ -213,8 +213,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/1_exploring-data.ipynb
+++ b/docs/tutorials/1_exploring-data.ipynb
@@ -569,8 +569,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/2_working-with-masks.ipynb
+++ b/docs/tutorials/2_working-with-masks.ipynb
@@ -347,8 +347,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/3_understanding-event-data.ipynb
+++ b/docs/tutorials/3_understanding-event-data.ipynb
@@ -1081,8 +1081,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/powder-diffraction.ipynb
+++ b/docs/tutorials/powder-diffraction.ipynb
@@ -476,8 +476,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/coordinate-transformations.ipynb
+++ b/docs/user-guide/coordinate-transformations.ipynb
@@ -690,8 +690,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/from-mantid-to-scipp.ipynb
+++ b/docs/user-guide/from-mantid-to-scipp.ipynb
@@ -892,8 +892,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/groupby.ipynb
+++ b/docs/user-guide/groupby.ipynb
@@ -211,8 +211,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/instrument-view.ipynb
+++ b/docs/user-guide/instrument-view.ipynb
@@ -219,8 +219,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/recipes.ipynb
+++ b/docs/user-guide/recipes.ipynb
@@ -154,8 +154,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   },
   "nbsphinx": {
    "execute": "never"

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -2,13 +2,12 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Matthew Jones
 
-from typing import Union, Optional, Any
+from typing import Union, Optional, Any, Tuple, Dict, List
 import h5py
 from scipp.spatial import affine_transform, linear_transform, \
     rotation, translation
 import scipp as sc
 import numpy as np
-from typing import Dict
 
 
 class BadSource(Exception):
@@ -80,7 +79,13 @@ def _add_attr_to_loaded_data(attr_name: str,
         pass
 
 
-def to_plain_index(dims, select, ignore_missing=False):
+# Note that scipp does not support dicts yet, but this HDF5 code does, to
+# allow for loading blocks of 2d (or higher) data efficiently.
+ScippIndex = Union[type(Ellipsis), int, slice, Tuple[str, Union[int, slice]],
+                   Dict[str, Union[int, slice]]]
+
+
+def to_plain_index(dims: List[str], select: ScippIndex, ignore_missing: bool = False):
     """
     Given a valid "scipp" index 'select', return an equivalent plain numpy-style index.
     """

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -90,16 +90,19 @@ def to_plain_index(dims, select, ignore_missing=False):
                              "specify the dimension to index.")
 
     if select is Ellipsis:
-        return select
+        return tuple()
     if isinstance(select, tuple) and len(select) == 0:
-        return select
+        return tuple()
     if isinstance(select, tuple) and isinstance(select[0], str):
         key, sel = select
         select = {key: sel}
 
     if isinstance(select, tuple):
         check_1d()
-        return select
+        if len(select) != 1:
+            raise ValueError(f"Dataset a single dimension {dims}, "
+                             "but multiple indices {select} were specified.")
+        return select[0]
     elif isinstance(select, int) or isinstance(select, slice):
         check_1d()
         return select
@@ -110,5 +113,7 @@ def to_plain_index(dims, select, ignore_missing=False):
                 raise ValueError(
                     f"'{key}' used for indexing not found in dataset dims {dims}.")
             index[dims.index(key)] = sel
+        if len(index) == 1:
+            return index[0]
         return tuple(index)
     raise ValueError("Cannot process index {select}.")

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -224,9 +224,9 @@ class NXevent_data(NXobject):
                                           quiet=False,
                                           select=index)
         data = detector_data.event_data
-        data.bins.coords['id'] = data.bins.coords.pop('detector_id')
-        data.bins.coords['time_offset'] = data.bins.coords.pop('tof')
-        data.coords['time_zero'] = data.coords.pop('pulse_time')
+        data.bins.coords['event_id'] = data.bins.coords.pop('detector_id')
+        data.bins.coords['event_time_offset'] = data.bins.coords.pop('tof')
+        data.coords['event_time_zero'] = data.coords.pop('pulse_time')
         return data
 
 

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -252,7 +252,7 @@ def _load_event_group(group: Group,
             single = True
             start, stop, _ = slice(index, None).indices(max_index)
             if start == stop:
-                raise IndexError('')
+                raise IndexError('Index {start} is out of range')
             index = slice(start, start + 1)
         start, stop, stride = index.indices(max_index)
         if stop + stride > max_index:
@@ -319,12 +319,13 @@ def _load_event_group(group: Group,
     # institutions. We try to make sure here that it is what would be the first index of
     # the next pulse. In other words, ensure that event_index includes the bin edge for
     # the last pulse.
-    begins = event_index[_pulse_dimension, :-1]
-    ends = event_index[_pulse_dimension, 1:]
     if single:
-        begins = begins[_pulse_dimension, 0]
-        ends = ends[_pulse_dimension, 0]
+        begins = event_index[_pulse_dimension, 0]
+        ends = event_index[_pulse_dimension, 1]
         pulse_times = pulse_times[_pulse_dimension, 0]
+    else:
+        begins = event_index[_pulse_dimension, :-1]
+        ends = event_index[_pulse_dimension, 1:]
 
     try:
         binned = sc.bins(data=events, dim=_event_dimension, begin=begins, end=ends)

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -237,8 +237,6 @@ def _load_event_group(group: Group,
                       select=tuple()) -> DetectorData:
     _check_for_missing_fields(group, nexus)
     index = to_plain_index([_pulse_dimension], select)
-    if isinstance(index, tuple) and index != tuple():
-        index = index[0]
 
     def shape(name):
         return nexus.get_shape(nexus.get_dataset_from_group(group, name))

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -217,7 +217,9 @@ class NXevent_data(NXobject):
         return None
 
     def _getitem(self, index):
-        data = _load_event_group(self._group, self._loader, quiet=False, select=index)
+        data = _load_event_group(self._group, self._loader, quiet=True, select=index)
+        # Map back to original field names from NXevent_data since _load_event_group
+        # imposes names that based on assumptions and history.
         if 'detector_id' in data.bins.coords:
             data.bins.coords['event_id'] = data.bins.coords.pop('detector_id')
         data.bins.coords['event_time_offset'] = data.bins.coords.pop('tof')

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -13,7 +13,7 @@ import scipp as sc
 from warnings import warn
 from ._transformations import get_full_transformation_matrix
 from ._nexus import LoadFromNexus
-from .nxobject import NXobject
+from .nxobject import NXobject, ScippIndex
 
 _bank_dimension = "bank"
 _detector_dimension = "detector_id"
@@ -203,20 +203,20 @@ def _load_detector(group: Group, nexus: LoadFromNexus) -> DetectorData:
 
 class NXevent_data(NXobject):
     @property
-    def shape(self):
+    def shape(self) -> List[int]:
         return self._loader.get_shape(
             self._loader.get_dataset_from_group(self._group, "event_index"))
 
     @property
-    def dims(self):
+    def dims(self) -> List[str]:
         return [_pulse_dimension]
 
     @property
-    def unit(self):
+    def unit(self) -> None:
         # Binned data, bins do not have a unit
         return None
 
-    def _getitem(self, index):
+    def _getitem(self, index: ScippIndex) -> sc.DataArray:
         data = _load_event_group(self._group, self._loader, quiet=True, select=index)
         # Map back to original field names from NXevent_data since _load_event_group
         # imposes names that based on assumptions and history.

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -215,7 +215,7 @@ class NXevent_data(NXobject):
     @property
     def unit(self):
         # Binned data, bins do not have a unit
-        return sc.units.one
+        return None
 
     def _getitem(self, index):
         detector_data = _load_event_group(self._group,

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -234,10 +234,10 @@ def _load_event_group(group: Group,
                       nexus: LoadFromNexus,
                       detector_data: DetectorData,
                       quiet: bool,
-                      select=...) -> DetectorData:
+                      select=tuple()) -> DetectorData:
     _check_for_missing_fields(group, nexus)
     index = to_plain_index([_pulse_dimension], select)
-    if isinstance(index, tuple):
+    if isinstance(index, tuple) and index != tuple():
         index = index[0]
 
     def shape(name):
@@ -245,7 +245,7 @@ def _load_event_group(group: Group,
 
     max_index = shape("event_index")[0]
     single = False
-    if index is Ellipsis:
+    if index is Ellipsis or index == tuple():
         last_loaded = False
     else:
         if isinstance(index, int):

--- a/src/scippneutron/file_loading/_log_data.py
+++ b/src/scippneutron/file_loading/_log_data.py
@@ -8,7 +8,7 @@ import scipp as sc
 from ._common import (BadSource, SkipSource, MissingDataset, MissingAttribute, Group)
 from ._common import to_plain_index
 from ._nexus import LoadFromNexus
-from .nxobject import NXobject
+from .nxobject import NXobject, ScippIndex
 from warnings import warn
 
 
@@ -114,7 +114,7 @@ class NXlog(NXobject):
     def unit(self):
         pass
 
-    def _getitem(self, index):
+    def _getitem(self, index: ScippIndex) -> sc.DataArray:
         name, var = _load_log_data_from_group(self._group, self._loader, select=index)
         da = var.value
         da.name = name
@@ -180,6 +180,7 @@ def _load_log_data_from_group(group: Group, nexus: LoadFromNexus, select=tuple()
         dimension_label = property_name
         is_time_series = False
 
+    # TODO Is NXlog similar to NXdata such that we could use that for loading?
     if np.ndim(values) > 1:
         raise BadSource(f"NXlog '{property_name}' has {value_dataset_name} "
                         f"dataset with more than 1 dimension, handling "

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -25,16 +25,6 @@ class NXmonitor(NXobject):
         return load_monitor(self._group, self._loader, select=index)
 
 
-def _load_data_from_histogram_mode_monitor(group: Group,
-                                           nexus: LoadFromNexus,
-                                           select=tuple()):
-    data_group = nexus.get_child_from_group(group, "data")
-    if data_group is not None:
-        return NXdata(group, nexus)[select]
-    else:
-        return None
-
-
 def load_monitor(group: Group, nexus: LoadFromNexus, select=tuple()) -> sc.DataArray:
     # Look for event mode data structures in NXMonitor. Event-mode data takes
     # precedence over histogram-mode-data if available.
@@ -44,11 +34,10 @@ def load_monitor(group: Group, nexus: LoadFromNexus, select=tuple()) -> sc.DataA
                       f"Histogram-mode monitor data from this group will be "
                       f"ignored.")
         return events
-    else:
-        data = _load_data_from_histogram_mode_monitor(group, nexus, select=select)
-        if data is None:
-            raise ValueError(f"No monitor data found in {group.name}")
-        return data
+    try:
+        return NXdata(group, nexus)[select]
+    except KeyError:
+        raise ValueError(f"No monitor data found in {group.name}")
 
 
 def load_monitor_data(monitor_groups: List[Group], nexus: LoadFromNexus) -> Dict:

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -30,6 +30,9 @@ class NXmonitor(NXobject):
         """Branch between event-mode and histogram-mode monitor."""
         if self._is_events:
             return NXevent_data(self._group, self._loader)
+        # NXdata uses the 'signal' attribute to define the field name of the signal.
+        # NXmonitor uses a "hard-coded" signal name 'data', without specifying the
+        # attribute in the file, so we pass this explicitly to NXdata.
         return NXdata(self._group, self._loader, signal='data')
 
     def _getitem(self, select):

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -4,21 +4,21 @@ from ._common import Group
 import scipp as sc
 from ._nexus import LoadFromNexus
 from ._detector_data import load_detector_data, NXevent_data
-from .nxobject import NXobject
+from .nxobject import NXobject, ScippIndex
 from .nxdata import NXdata
 
 
 class NXmonitor(NXobject):
     @property
-    def shape(self):
+    def shape(self) -> List[int]:
         return self._nxbase.shape
 
     @property
-    def dims(self):
+    def dims(self) -> List[str]:
         return self._nxbase.dims
 
     @property
-    def unit(self):
+    def unit(self) -> Union[sc.Unit, None]:
         return self._nxbase.unit
 
     @property
@@ -35,7 +35,7 @@ class NXmonitor(NXobject):
         # attribute in the file, so we pass this explicitly to NXdata.
         return NXdata(self._group, self._loader, signal='data')
 
-    def _getitem(self, select):
+    def _getitem(self, select: ScippIndex) -> sc.DataArray:
         """
         Load monitor data. Event-mode data takes precedence over histogram-mode data.
         """

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -11,15 +11,16 @@ from .nxdata import NXdata
 class NXmonitor(NXobject):
     @property
     def shape(self):
-        return NXdata(self._group, self._loader).shape
+        # TODO branch to NXevent_data
+        return NXdata(self._group, self._loader, signal='data').shape
 
     @property
     def dims(self):
-        return NXdata(self._group, self._loader).dims
+        return NXdata(self._group, self._loader, signal='data').dims
 
     @property
     def unit(self):
-        return NXdata(self._group, self._loader).unit
+        return NXdata(self._group, self._loader, signal='data').unit
 
     @property
     def _is_events(self) -> bool:
@@ -37,7 +38,7 @@ class NXmonitor(NXobject):
                           f"Histogram-mode monitor data from this group will be "
                           f"ignored.")
             return events
-        return NXdata(self._group, self._loader)[select]
+        return NXdata(self._group, self._loader, signal='data')[select]
 
 
 def load_monitor_data(monitor_groups: List[Group], nexus: LoadFromNexus) -> Dict:

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -27,8 +27,9 @@ class NXmonitor(NXobject):
         return self._loader.dataset_in_group(self._group, "event_time_offset")[0]
 
     def _getitem(self, select):
-        # Look for event mode data structures in NXMonitor. Event-mode data takes
-        # precedence over histogram-mode-data if available.
+        """
+        Load monitor data. Event-mode data takes precedence over histogram-mode data.
+        """
         if self._is_events:
             warnings.warn(f"Event data present in NXmonitor group {self.name}. "
                           f"Histogram-mode monitor data from this group will be "
@@ -38,6 +39,9 @@ class NXmonitor(NXobject):
 
 
 def load_monitor_data(monitor_groups: List[Group], nexus: LoadFromNexus) -> Dict:
+    """
+    Load monitor data. Event-mode data takes precedence over histogram-mode data.
+    """
     monitor_data = {}
     for group in monitor_groups:
         try:

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -1,10 +1,11 @@
 from typing import List, Dict
 import warnings
-from ._common import Group, to_plain_index
+from ._common import Group
 import scipp as sc
 from ._nexus import LoadFromNexus
 from ._detector_data import load_detector_data
 from .nxobject import NXobject
+from .nxdata import NXdata
 
 
 class NXmonitor(NXobject):
@@ -29,19 +30,7 @@ def _load_data_from_histogram_mode_monitor(group: Group,
                                            select=tuple()):
     data_group = nexus.get_child_from_group(group, "data")
     if data_group is not None:
-        dims = nexus.get_string_attribute(data_group, "axes").split(",")
-        index = to_plain_index(dims, select)
-        data = nexus.load_dataset(group, "data", dimensions=dims, index=index)
-        coords = {
-            dim: nexus.load_dataset(group,
-                                    dim,
-                                    dimensions=[dim],
-                                    index=to_plain_index([dim],
-                                                         select,
-                                                         ignore_missing=True))
-            for dim in dims
-        }
-        return sc.DataArray(data=data, coords=coords)
+        return NXdata(group, nexus)[select]
     else:
         return None
 

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -23,7 +23,7 @@ class NXmonitor(NXobject):
 
     @property
     def _is_events(self) -> bool:
-        return self._loader.dataset_in_group(self._group, "event_time_offset")[0]
+        return 'event_time_offset' in self
 
     @property
     def _nxbase(self) -> Union[NXdata, NXevent_data]:

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -48,9 +48,9 @@ class NXdata(NXobject):
     @property
     def _errors_name(self) -> str:
         if self._signal_name_default is None:
-            return f'{self._signal_name_default}_errors'
-        else:
             return 'errors'
+        else:
+            return f'{self._signal_name_default}_errors'
 
     @property
     def _signal(self) -> Dataset:

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -1,0 +1,34 @@
+import scipp as sc
+from ._common import to_plain_index
+from .nxobject import NXobject
+
+
+class NXdata(NXobject):
+    @property
+    def shape(self):
+        pass
+
+    @property
+    def dims(self):
+        pass
+
+    @property
+    def unit(self):
+        pass
+
+    def _getitem(self, select):
+        signal_name = self.attrs.get('signal', 'data')
+        dims = self[signal_name].attrs['axes'].split(",")
+        index = to_plain_index(dims, select)
+        signal = self._loader.load_dataset(self._group,
+                                           signal_name,
+                                           dimensions=dims,
+                                           index=index)
+        da = sc.DataArray(data=signal)
+        for dim in dims:
+            index = to_plain_index([dim], select, ignore_missing=True)
+            da.coords[dim] = self._loader.load_dataset(self._group,
+                                                       dim,
+                                                       dimensions=[dim],
+                                                       index=index)
+        return da

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -19,7 +19,12 @@ class NXdata(NXobject):
 
     @property
     def dims(self):
-        return self._signal.attrs['axes'].split(",")
+        # TODO Apparently it is not possible to define dim labels unless there are
+        # corresponding coords. Handle special case of '.' entries meaning "no coord".
+        if 'axes' in self.attrs:
+            return self.attrs['axes']
+        # Legacy NXdata defines axes not as group attribute, but attr on dataset
+        return self._signal.attrs['axes'].split(',')
 
     @property
     def unit(self):
@@ -61,7 +66,7 @@ class NXdata(NXobject):
                                                 index=index)
             signal.variances = sc.pow(stddevs, 2).values
         da = sc.DataArray(data=signal)
-        for dim in dims:
+        for dim in self.dims:
             index = to_plain_index([dim], select, ignore_missing=True)
             da.coords[dim] = self._loader.load_dataset(self._group,
                                                        dim,

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -1,6 +1,7 @@
+from typing import List, Union
 import scipp as sc
-from ._common import to_plain_index, Group
-from .nxobject import NXobject
+from ._common import to_plain_index, Dataset, Group
+from .nxobject import NXobject, ScippIndex
 from ._nexus import LoadFromNexus
 from ._hdf5_nexus import LoadFromHdf5
 
@@ -14,11 +15,11 @@ class NXdata(NXobject):
         self._signal_name_default = signal
 
     @property
-    def shape(self):
+    def shape(self) -> List[int]:
         return self._signal.shape
 
     @property
-    def dims(self):
+    def dims(self) -> List[str]:
         # Apparently it is not possible to define dim labels unless there are
         # corresponding coords. Special case of '.' entries means "no coord".
         if 'axes' in self.attrs:
@@ -28,11 +29,11 @@ class NXdata(NXobject):
         return self._signal.attrs['axes'].split(',')
 
     @property
-    def unit(self):
+    def unit(self) -> Union[sc.Unit, None]:
         return self._signal.unit
 
     @property
-    def _signal_name(self):
+    def _signal_name(self) -> str:
         name = self.attrs.get('signal', self._signal_name_default)
         if name is not None:
             return name
@@ -43,17 +44,17 @@ class NXdata(NXobject):
         return None
 
     @property
-    def _errors_name(self):
+    def _errors_name(self) -> str:
         if self._signal_name_default is None:
             return f'{self._signal_name_default}_errors'
         else:
             return 'errors'
 
     @property
-    def _signal(self):
+    def _signal(self) -> Dataset:
         return self[self._signal_name]
 
-    def _getitem(self, select):
+    def _getitem(self, select: ScippIndex) -> sc.DataArray:
         dims = self.dims
         index = to_plain_index(dims, select)
         signal = self._loader.load_dataset(self._group,

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -67,11 +67,15 @@ class NXdata(NXobject):
                                                 index=index)
             signal.variances = sc.pow(stddevs, 2).values
         da = sc.DataArray(data=signal)
-        for dim in self.dims:
-            if dim in self:
-                index = to_plain_index([dim], select, ignore_missing=True)
-                da.coords[dim] = self._loader.load_dataset(self._group,
-                                                           dim,
-                                                           dimensions=[dim],
-                                                           index=index)
+        if 'axes' in self.attrs:
+            # Unlike self.dims we *drop* entries that are '.'
+            coords = [a for a in self.attrs['axes'] if a != '.']
+        else:
+            coords = self._signal.attrs['axes'].split(',')
+        for dim in coords:
+            index = to_plain_index([dim], select, ignore_missing=True)
+            da.coords[dim] = self._loader.load_dataset(self._group,
+                                                       dim,
+                                                       dimensions=[dim],
+                                                       index=index)
         return da

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -26,7 +26,9 @@ class NXdata(NXobject):
             axes = self.attrs['axes']
             return [f'dim_{i}' if a == '.' else a for i, a in enumerate(axes)]
         # Legacy NXdata defines axes not as group attribute, but attr on dataset
-        return self._signal.attrs['axes'].split(',')
+        if 'axes' in self._signal.attrs:
+            return self._signal.attrs['axes'].split(',')
+        return [f'dim_{i}' for i in range(len(self.shape))]
 
     @property
     def unit(self) -> Union[sc.Unit, None]:

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -6,22 +6,30 @@ from .nxobject import NXobject
 class NXdata(NXobject):
     @property
     def shape(self):
-        pass
+        return self._signal.shape
 
     @property
     def dims(self):
-        pass
+        return self._signal.attrs['axes'].split(",")
 
     @property
     def unit(self):
-        pass
+        return self._signal.unit
+
+    @property
+    def _signal_name(self):
+        return self.attrs.get('signal', 'data')
+
+    @property
+    def _signal(self):
+        return self[self._signal_name]
 
     def _getitem(self, select):
-        signal_name = self.attrs.get('signal', 'data')
-        dims = self[signal_name].attrs['axes'].split(",")
+        dims = self.dims
         index = to_plain_index(dims, select)
+        # TODO Handle errors
         signal = self._loader.load_dataset(self._group,
-                                           signal_name,
+                                           self._signal_name,
                                            dimensions=dims,
                                            index=index)
         da = sc.DataArray(data=signal)

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -5,22 +5,28 @@ from .nxdata import NXdata
 class NXdetector(NXobject):
     @property
     def shape(self):
-        pass
+        return self._nxbase.shape
 
     @property
     def dims(self):
-        pass
+        return self._nxbase.dims
 
     @property
     def unit(self):
-        pass
+        return self._nxbase.unit
+
+    @property
+    def _nxbase(self) -> NXdata:
+        """Return class for loading underlying data.
+
+        Raises if no data found."""
+        signal_name = self.attrs.get('signal', 'data')
+        if signal_name in self:
+            return NXdata(self._group, self._loader, signal='data')
+        raise NotImplementedError(f"NXdetector {self.name} does not contain data.")
 
     def _getitem(self, select):
         # Note that ._detector_data._load_detector provides a different loading
         # facility for NXdetector, but handles only loading of detector_number,
         # as needed for event data loading
-        signal_name = self.attrs.get('signal', 'data')
-        if signal_name in self:
-            return NXdata(self._group, self._loader)[select]
-        raise NotImplementedError(
-            f"NXdetector {self.name} does not contain data. Loading not implemented.")
+        return self._nxbase[select]

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -23,7 +23,14 @@ class NXdetector(NXobject):
     @property
     def dims(self) -> List[str]:
         if self._is_events and self._detector_number is not None:
-            return self.attrs.get('axes', ['detector_number'])
+            # The NeXus standard is lacking information on a number of details on
+            # NXdetector, but according to personal communication with Tobias Richter
+            # it is "intended" to partially "subclass" NXdata. That is, e.g., attributes
+            # defined for NXdata such as 'axes' may be used.
+            default = [f'dim_{i}' for i in range(len(self.shape))]
+            if len(default) == 1:
+                default = ['detector_number']
+            return self.attrs.get('axes', default)
         # If event data but no detector_number then this gives the underlying
         # dims of NXevent_data
         return self._nxbase.dims
@@ -76,7 +83,7 @@ class NXdetector(NXobject):
                 return self._nxbase[select]
             # If there is a 'detector_number' field it is used to bin events into
             # detector pixels. Note that due to the nature of NXevent_data, which stores
-            # events from all pixels and random order we, always have to load the entire
+            # events from all pixels and random order, we always have to load the entire
             # bank. Slicing with the provided 'select' is done while binning.
             event_data = self._nxbase[...]
             event_data.bins.coords['detector_number'] = event_data.bins.coords.pop(

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -1,16 +1,30 @@
-from .nxobject import NXobject
+import scipp as sc
+from .nxobject import NXobject, Field
 from .nxdata import NXdata
+from ._detector_data import NXevent_data
 
 
 class NXdetector(NXobject):
+    """A detector or detector bank providing an array of values or events.
+
+    If the detector stores event data then the 'detector_number' field (if present)
+    is used to map event do detector pixels. Otherwise this returns event data in the
+    same format as NXevent_data.
+    """
     @property
     def shape(self):
-        # TODO If there is no data this could probably be determined from the
-        # detector_number field, if present?
+        if self._is_events and self._detector_number is not None:
+            return self._detector_number.shape
+        # If event data but no detector_number then this gives the underlying
+        # shape of NXevent_data
         return self._nxbase.shape
 
     @property
     def dims(self):
+        if self._is_events and self._detector_number is not None:
+            return self.attrs.get('axes', ['detector_number'])
+        # If event data but no detector_number then this gives the underlying
+        # dims of NXevent_data
         return self._nxbase.dims
 
     @property
@@ -18,19 +32,55 @@ class NXdetector(NXobject):
         return self._nxbase.unit
 
     @property
-    def _nxbase(self) -> NXdata:
-        """Return class for loading underlying data.
+    def _is_events(self) -> bool:
+        # The standard is unclear on whether the 'data' field may be NXevent_data or
+        # whether the fields of NXevent_data should be stored directly within this
+        # NXdetector. Both cases are observed in the wild.
+        if 'data' in self:
+            return isinstance(self['data'], NXevent_data)
+        return 'event_time_offset' in self
 
-        Raises if no data found."""
+    @property
+    def _nxbase(self) -> NXdata:
+        """Return class for loading underlying data."""
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXdetector uses a "hard-coded" signal name 'data', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
-        if 'data' in self:
-            return NXdata(self._group, self._loader, signal='data')
-        raise NotImplementedError(f"NXdetector {self.name} does not contain data.")
+        if self._is_events:
+            if 'event_time_offset' in self:
+                return NXevent_data(self._group, self._loader)
+            return self['data']
+        return NXdata(self._group, self._loader, signal='data')
+
+    @property
+    def _detector_number(self) -> Field:
+        return self.get('detector_number', None)
+
+    @property
+    def detector_number(self) -> sc.Variable:
+        """Read and return the 'detector_number' field, None if it does not exist."""
+        if self._detector_number is None:
+            return None
+        return sc.array(dims=self.dims, values=self._detector_number[...])
 
     def _getitem(self, select):
         # Note that ._detector_data._load_detector provides a different loading
         # facility for NXdetector but handles only loading of detector_number,
         # as needed for event data loading
+        if self._is_events:
+            if self.detector_number is None:
+                # If there is no 'detector_data' then self.dims is the same as that of
+                # the underlying event data. Slicing here thus corresponds to slicing
+                # NXevent_data.
+                return self._nxbase[select]
+            # If there is a 'detector_number' field it is used to bin events into
+            # detector pixels. Note that due to the nature of NXevent_data, which stores
+            # events from all pixels and random order we, always have to load the entire
+            # bank. Slicing with the provided 'select' is done while binning.
+            event_data = self._nxbase[...]
+            event_data.bins.coords['detector_number'] = event_data.bins.coords.pop(
+                'event_id')
+            return sc.bin(event_data,
+                          groups=[self.detector_number[select]],
+                          erase=['pulse'])
         return self._nxbase[select]

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -1,8 +1,9 @@
 from typing import List, Union
 import scipp as sc
-from .nxobject import NXobject, Field, ScippIndex
+from .nxobject import NX_class, NXobject, Field, ScippIndex
 from .nxdata import NXdata
 from ._detector_data import NXevent_data
+from ._common import BadSource
 
 
 class NXdetector(NXobject):
@@ -46,6 +47,8 @@ class NXdetector(NXobject):
         # NXdetector. Both cases are observed in the wild.
         if 'data' in self:
             return isinstance(self['data'], NXevent_data)
+        if len(self.by_nx_class()[NX_class.NXevent_data]) > 0:
+            return True
         return 'event_time_offset' in self
 
     @property
@@ -57,7 +60,11 @@ class NXdetector(NXobject):
         if self._is_events:
             if 'event_time_offset' in self:
                 return NXevent_data(self._group, self._loader)
-            return self['data']
+            event_entries = self.by_nx_class()[NX_class.NXevent_data]
+            if len(event_entries) != 1:
+                raise BadSource("No unique NXevent_data entry in NXdetector. "
+                                f"Found {len(event_entries)}.")
+            return next(iter(event_entries.values()))
         return NXdata(self._group, self._loader, signal='data')
 
     @property
@@ -90,7 +97,7 @@ class NXdetector(NXobject):
                 id_max = event_data.bins.coords['event_id'].max()
                 detector_numbers = sc.arange(dim='detector_number',
                                              start=id_min.value,
-                                             stop=id_max.value,
+                                             stop=id_max.value + 1,
                                              dtype=id_min.dtype)
             else:
                 detector_numbers = self.detector_number[select]

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -61,9 +61,6 @@ class NXdetector(NXobject):
             if 'event_time_offset' in self:
                 return NXevent_data(self._group, self._loader)
             event_entries = self.by_nx_class()[NX_class.NXevent_data]
-            if len(event_entries) != 1:
-                raise NexusStructureError("No unique NXevent_data entry in NXdetector. "
-                                          f"Found {len(event_entries)}.")
             return next(iter(event_entries.values()))
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXdetector uses a "hard-coded" signal name 'data', without specifying the

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -14,26 +14,34 @@ class NXdetector(NXobject):
     """
     @property
     def shape(self) -> List[int]:
-        if self._is_events and self._detector_number is not None:
+        if self._is_events:
+            if self._detector_number is None:
+                raise NexusStructureError(
+                    "Cannot get shape of NXdetector since no 'detector_number' "
+                    "field found but detector contains event data.")
             return self._detector_number.shape
-        # If event data but no detector_number then this gives the underlying
-        # shape of NXevent_data
         return self._nxbase.shape
 
     @property
     def dims(self) -> List[str]:
-        if self._is_events and self._detector_number is not None:
+        if self._is_events:
+            default = [f'dim_{i}' for i in range(self.ndim)]
+            if len(default) == 1:
+                default = ['detector_number']
             # The NeXus standard is lacking information on a number of details on
             # NXdetector, but according to personal communication with Tobias Richter
             # it is "intended" to partially "subclass" NXdata. That is, e.g., attributes
             # defined for NXdata such as 'axes' may be used.
-            default = [f'dim_{i}' for i in range(len(self.shape))]
-            if len(default) == 1:
-                default = ['detector_number']
             return self.attrs.get('axes', default)
-        # If event data but no detector_number then this gives the underlying
-        # dims of NXevent_data
         return self._nxbase.dims
+
+    @property
+    def ndim(self) -> int:
+        if self._is_events:
+            if self._detector_number is None:
+                return 1
+            return self._detector_number.ndim
+        return self['data'].ndim
 
     @property
     def unit(self) -> Union[sc.Unit, None]:

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -1,0 +1,26 @@
+from .nxobject import NXobject
+from .nxdata import NXdata
+
+
+class NXdetector(NXobject):
+    @property
+    def shape(self):
+        pass
+
+    @property
+    def dims(self):
+        pass
+
+    @property
+    def unit(self):
+        pass
+
+    def _getitem(self, select):
+        # Note that ._detector_data._load_detector provides a different loading
+        # facility for NXdetector, but handles only loading of detector_number,
+        # as needed for event data loading
+        signal_name = self.attrs.get('signal', 'data')
+        if signal_name in self:
+            return NXdata(self._group, self._loader)[select]
+        raise NotImplementedError(
+            f"NXdetector {self.name} does not contain data. Loading not implemented.")

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -29,6 +29,6 @@ class NXdetector(NXobject):
 
     def _getitem(self, select):
         # Note that ._detector_data._load_detector provides a different loading
-        # facility for NXdetector, but handles only loading of detector_number,
+        # facility for NXdetector but handles only loading of detector_number,
         # as needed for event data loading
         return self._nxbase[select]

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -5,6 +5,8 @@ from .nxdata import NXdata
 class NXdetector(NXobject):
     @property
     def shape(self):
+        # TODO If there is no data this could probably be determined from the
+        # detector_number field, if present?
         return self._nxbase.shape
 
     @property

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -22,8 +22,10 @@ class NXdetector(NXobject):
         """Return class for loading underlying data.
 
         Raises if no data found."""
-        signal_name = self.attrs.get('signal', 'data')
-        if signal_name in self:
+        # NXdata uses the 'signal' attribute to define the field name of the signal.
+        # NXdetector uses a "hard-coded" signal name 'data', without specifying the
+        # attribute in the file, so we pass this explicitly to NXdata.
+        if 'data' in self:
             return NXdata(self._group, self._loader, signal='data')
         raise NotImplementedError(f"NXdetector {self.name} does not contain data.")
 

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -1,5 +1,6 @@
+from typing import List, Union
 import scipp as sc
-from .nxobject import NXobject, Field
+from .nxobject import NXobject, Field, ScippIndex
 from .nxdata import NXdata
 from ._detector_data import NXevent_data
 
@@ -12,7 +13,7 @@ class NXdetector(NXobject):
     same format as NXevent_data.
     """
     @property
-    def shape(self):
+    def shape(self) -> List[int]:
         if self._is_events and self._detector_number is not None:
             return self._detector_number.shape
         # If event data but no detector_number then this gives the underlying
@@ -20,7 +21,7 @@ class NXdetector(NXobject):
         return self._nxbase.shape
 
     @property
-    def dims(self):
+    def dims(self) -> List[str]:
         if self._is_events and self._detector_number is not None:
             return self.attrs.get('axes', ['detector_number'])
         # If event data but no detector_number then this gives the underlying
@@ -28,7 +29,7 @@ class NXdetector(NXobject):
         return self._nxbase.dims
 
     @property
-    def unit(self):
+    def unit(self) -> Union[sc.Unit, None]:
         return self._nxbase.unit
 
     @property
@@ -63,7 +64,7 @@ class NXdetector(NXobject):
             return None
         return sc.array(dims=self.dims, values=self._detector_number[...])
 
-    def _getitem(self, select):
+    def _getitem(self, select: ScippIndex) -> sc.DataArray:
         # Note that ._detector_data._load_detector provides a different loading
         # facility for NXdetector but handles only loading of detector_number,
         # as needed for event data loading

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -11,12 +11,13 @@ from ._common import Group, Dataset, MissingAttribute
 
 
 class NX_class(Enum):
-    NXroot = auto()
+    NXdata = auto()
+    NXdetector = auto()
     NXentry = auto()
+    NXevent_data = auto()
     NXlog = auto()
     NXmonitor = auto()
-    NXevent_data = auto()
-    NXdata = auto()
+    NXroot = auto()
 
 
 class Attrs:
@@ -105,6 +106,9 @@ class NXobject:
     def _getitem(self, index):
         raise NotImplementedError(f'Loading {self.nx_class} is not supported.')
 
+    def __contains__(self, name) -> bool:
+        return self._loader.dataset_in_group(self._group, name)[0]
+
     @property
     def attrs(self):
         return Attrs(self._group, self._loader)
@@ -163,7 +167,9 @@ def _nx_class_registry():
     from ..file_loading._detector_data import NXevent_data
     from ..file_loading._log_data import NXlog
     from ..file_loading.nxdata import NXdata
+    from ..file_loading.nxdetector import NXdetector
     return {
         cls.__name__: cls
-        for cls in [NXroot, NXentry, NXevent_data, NXlog, NXmonitor, NXdata]
+        for cls in
+        [NXroot, NXentry, NXevent_data, NXlog, NXmonitor, NXdata, NXdetector]
     }

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+import scipp as sc
 from enum import Enum, auto
 import functools
 from typing import Union
@@ -79,9 +80,10 @@ class Field:
         return self._loader.get_shape(self._dataset)
 
     @property
-    def unit(self):
-        # TODO Prefer to return None if no such attr, provided that scipp supports this
-        return self._loader.get_unit(self._dataset)
+    def unit(self) -> Union[sc.Unit, None]:
+        if 'units' in self.attrs:
+            return sc.Unit(self._loader.get_unit(self._dataset))
+        return None
 
 
 class NXobject:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -94,6 +94,8 @@ class NXobject:
     def __getitem__(self, name):
         if isinstance(name, str):
             item = self._loader.get_child_from_group(self._group, name)
+            if item is None:
+                raise KeyError(f"Unable to open object (object '{name}' doesn't exist")
             if self._loader.is_group(item):
                 return self._make(item)
             else:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -124,6 +124,9 @@ class NXobject:
     def name(self):
         return self._loader.get_path(self._group)
 
+    def _ipython_key_completions_(self):
+        return self.keys()
+
     def keys(self):
         return self._loader.keys(self._group)
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -103,7 +103,7 @@ class NXobject:
         if isinstance(name, str):
             item = self._loader.get_child_from_group(self._group, name)
             if item is None:
-                raise KeyError(f"Unable to open object (object '{name}' doesn't exist")
+                raise KeyError(f"Unable to open object (object '{name}' doesn't exist)")
             if self._loader.is_group(item):
                 return self._make(item)
             else:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -116,6 +116,9 @@ class NXobject:
     def __contains__(self, name) -> bool:
         return self._loader.dataset_in_group(self._group, name)[0]
 
+    def get(self, name, default=None):
+        return self[name] if name in self else default
+
     @property
     def attrs(self):
         return Attrs(self._group, self._loader)
@@ -178,11 +181,11 @@ class NXentry(NXobject):
 
 @functools.lru_cache()
 def _nx_class_registry():
-    from ..file_loading._monitor_data import NXmonitor
-    from ..file_loading._detector_data import NXevent_data
-    from ..file_loading._log_data import NXlog
-    from ..file_loading.nxdata import NXdata
-    from ..file_loading.nxdetector import NXdetector
+    from ._monitor_data import NXmonitor
+    from ._detector_data import NXevent_data
+    from ._log_data import NXlog
+    from .nxdata import NXdata
+    from .nxdetector import NXdetector
     return {
         cls.__name__: cls
         for cls in

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -43,7 +43,7 @@ class Attrs:
     def __getitem__(self, name: str) -> Any:
         attr = self._loader.get_attribute(self._node, name)
         # Is this check for string attributes sufficient? Is there a better way?
-        if isinstance(attr, str) or isinstance(attr, bytes):
+        if isinstance(attr, (str, bytes)):
             return self._loader.get_string_attribute(self._node, name)
         return attr
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -85,6 +85,10 @@ class Field:
         return self._loader.get_path(self._dataset)
 
     @property
+    def ndim(self) -> int:
+        return len(self.shape)
+
+    @property
     def shape(self) -> List[int]:
         return self._loader.get_shape(self._dataset)
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -14,6 +14,12 @@ from ._common import Group, Dataset, MissingAttribute, ScippIndex
 NXobjectIndex = Union[str, ScippIndex]
 
 
+class NexusStructureError(Exception):
+    """Invalid or unsupported class and field structure in Nexus.
+    """
+    pass
+
+
 class NX_class(Enum):
     NXdata = auto()
     NXdetector = auto()

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -5,13 +5,12 @@ import numpy as np
 import scipp as sc
 from enum import Enum, auto
 import functools
-from typing import List, Union, Tuple, NoReturn, Any, Dict
+from typing import List, Union, NoReturn, Any, Dict
 
 from ._nexus import LoadFromNexus
 from ._hdf5_nexus import LoadFromHdf5
-from ._common import Group, Dataset, MissingAttribute
+from ._common import Group, Dataset, MissingAttribute, ScippIndex
 
-ScippIndex = Tuple[str, Union[int, slice]]
 NXobjectIndex = Union[str, ScippIndex]
 
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -144,9 +144,14 @@ class NXobject:
         return out
 
     @property
-    def nx_class(self):
-        key = self._loader.get_string_attribute(self._group, 'NX_class')
-        return NX_class[key]
+    def nx_class(self) -> NX_class:
+        """The value of the NX_class attribute of the group.
+
+        In case of the subclass NXroot this returns 'NXroot' even if the attribute
+        is not actually set. This is support the majority of all legacy files, which
+        do not have this attribute.
+        """
+        return NX_class[self.attrs['NX_class']]
 
     def __repr__(self):
         return f'<{type(self).__name__} "{self._group.name}">'

--- a/src/scippneutron/nexus/__init__.py
+++ b/src/scippneutron/nexus/__init__.py
@@ -6,3 +6,4 @@
 
 from .nexus import File, NXroot
 from ..file_loading.nxobject import NX_class, Field
+from ..file_loading.nxobject import NexusStructureError

--- a/src/scippneutron/nexus/nexus.py
+++ b/src/scippneutron/nexus/nexus.py
@@ -13,5 +13,12 @@ class File(AbstractContextManager, NXroot):
         self._file = h5py.File(*args, **kwargs)
         NXroot.__init__(self, self._file)
 
+    def __enter__(self):
+        self._file.__enter__()
+        return self
+
     def __exit__(self, exc_type, exc_value, traceback):
-        self._group.close()
+        self._file.close()
+
+    def close(self):
+        self._file.close()

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -85,6 +85,7 @@ class Detector:
     z_offsets: Optional[np.ndarray] = None
     offsets_unit: Optional[Union[str, bytes]] = None
     depends_on: Optional[Transformation] = None
+    data: Optional[np.ndarray] = None
 
 
 @dataclass
@@ -281,13 +282,16 @@ class JsonWriter:
         return new_dataset
 
     @staticmethod
-    def add_attribute(parent: Dict, name: str, value: Union[str, bytes, np.ndarray]):
+    def add_attribute(parent: Dict, name: str, value: Union[str, bytes, list,
+                                                            np.ndarray]):
         if isinstance(value, (str, bytes)):
             attr_info = {"string_size": len(value), "type": "string"}
         elif isinstance(value, float):
             attr_info = {"size": 1, "type": "float64"}
         elif isinstance(value, int):
             attr_info = {"size": 1, "type": "int64"}
+        elif isinstance(value, list):
+            attr_info = {"size": len(value), "type": "string"}
         else:
             attr_info = {
                 "size": value.shape,
@@ -568,6 +572,18 @@ class NexusBuilder:
             detector_name = f"detector_{detector_index}"
             detector_group = self._add_detector_group_to_file(
                 detector, parent_group, detector_name)
+            if detector.data is not None:
+                da = detector.data
+                ds = self._writer.add_dataset(detector_group, "data", data=da.values)
+                self._writer.add_attribute(ds, "axes", ','.join(da.dims))
+                self._writer.add_attribute(ds, "units", str(da.unit))
+                self._writer.add_attribute(detector_group, "axes", list(da.coords))
+                for key, coord in da.coords.items():
+                    ds = self._writer.add_dataset(detector_group,
+                                                  key,
+                                                  data=coord.values)
+                    self._writer.add_attribute(ds, "units", str(coord.unit))
+
             if detector.event_data is not None:
                 self._add_event_data_group_to_file(detector.event_data, detector_group,
                                                    "events")

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -575,9 +575,9 @@ class NexusBuilder:
             if detector.data is not None:
                 da = detector.data
                 ds = self._writer.add_dataset(detector_group, "data", data=da.values)
-                self._writer.add_attribute(ds, "axes", ','.join(da.dims))
                 self._writer.add_attribute(ds, "units", str(da.unit))
-                self._writer.add_attribute(detector_group, "axes", list(da.coords))
+                axes = [dim if dim in da.coords else '.' for dim in da.dims]
+                self._writer.add_attribute(detector_group, "axes", axes)
                 for key, coord in da.coords.items():
                     ds = self._writer.add_dataset(detector_group,
                                                   key,

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -95,6 +95,15 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert event_data.nx_class == nexus.NX_class.NXevent_data
 
 
+def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        root = nexus.NXroot(f, loader)
+        with pytest.raises(KeyError):
+            root['abcde']
+
+
 def test_nxobject_name_property_is_full_path(nexus_group: Tuple[Callable,
                                                                 LoadFromNexus]):
     resource, loader = nexus_group

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -125,8 +125,8 @@ def test_nxobject_grandchild_can_be_accessed_using_path(
         assert root['/entry/log'].name == '/entry/log'
 
 
-def test_nxobject_by_nx_class_contains_everything(nexus_group: Tuple[Callable,
-                                                                     LoadFromNexus]):
+def test_nxobject_by_nx_class_of_root_contains_everything(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -60,7 +60,7 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)
         assert root.nx_class == nexus.NX_class.NXroot
-        assert set(root.keys()) == set(['entry', 'monitor'])
+        assert set(root.keys()) == {'entry', 'monitor'}
 
         monitor = root['monitor']
         assert monitor.nx_class == nexus.NX_class.NXmonitor
@@ -74,7 +74,7 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
 
         entry = root['entry']
         assert entry.nx_class == nexus.NX_class.NXentry
-        assert set(entry.keys()) == set(['events_0', 'events_1', 'log'])
+        assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
         log = entry['log']
         assert log.nx_class == nexus.NX_class.NXlog
@@ -134,8 +134,7 @@ def test_nxobject_by_nx_class_contains_everything(nexus_group: Tuple[Callable,
         assert list(classes[nexus.NX_class.NXentry]) == ['entry']
         assert list(classes[nexus.NX_class.NXmonitor]) == ['monitor']
         assert list(classes[nexus.NX_class.NXlog]) == ['log']
-        assert set(classes[nexus.NX_class.NXevent_data]) == set(
-            ['events_0', 'events_1'])
+        assert set(classes[nexus.NX_class.NXevent_data]) == {'events_0', 'events_1'}
 
 
 def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable,

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -184,6 +184,14 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert field.unit == sc.Unit('ns')
 
 
+def test_field_unit_is_none_if_no_units_attribute(nexus_group: Tuple[Callable,
+                                                                     LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        field = nexus.NXroot(f, loader)['entry/log']
+        assert field.unit is None
+
+
 def test_field_getitem_returns_numpy_array_with_correct_size_and_values(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -55,14 +55,26 @@ def builder_with_events_monitor_and_log():
     return builder
 
 
-def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
+def test_nxobject_root(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f, loader)
         assert root.nx_class == nexus.NX_class.NXroot
         assert set(root.keys()) == {'entry', 'monitor'}
 
-        monitor = root['monitor']
+
+def test_nxobject_entry(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        entry = nexus.NXroot(f, loader)['entry']
+        assert entry.nx_class == nexus.NX_class.NXentry
+        assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
+
+
+def test_nxobject_monitor(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        monitor = nexus.NXroot(f, loader)['monitor']
         assert monitor.nx_class == nexus.NX_class.NXmonitor
         assert sc.identical(
             monitor[...],
@@ -72,11 +84,11 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
                              sc.array(dims=['time_of_flight'], values=[1.0])
                          }))
 
-        entry = root['entry']
-        assert entry.nx_class == nexus.NX_class.NXentry
-        assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
-        log = entry['log']
+def test_nxobject_log(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        log = nexus.NXroot(f, loader)['entry']['log']
         assert log.nx_class == nexus.NX_class.NXlog
         assert sc.identical(
             log[...],
@@ -89,7 +101,11 @@ def test_nxobject_tree_traversal(nexus_group: Tuple[Callable, LoadFromNexus]):
                         unit='ns', dtype='int64')
                 }))
 
-        event_data = entry['events_0']
+
+def test_nxobject_event_data(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        event_data = nexus.NXroot(f, loader)['entry']['events_0']
         assert set(event_data.keys()) == set(
             ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
         assert event_data.nx_class == nexus.NX_class.NXevent_data

--- a/tests/test_nexus_loader_components.py
+++ b/tests/test_nexus_loader_components.py
@@ -5,7 +5,7 @@ from .nexus_helpers import (
 import numpy as np
 import pytest
 from typing import Callable, Tuple
-from scippneutron.file_loading._detector_data import _load_event_group, DetectorData
+from scippneutron.file_loading._detector_data import _load_event_group
 from scippneutron.file_loading._nexus import LoadFromNexus
 from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
 from scippneutron.file_loading._json_nexus import LoadFromJson
@@ -52,11 +52,7 @@ def test_load_nx_event_data_selection_yields_correct_pulses(
 
         class Load:
             def __getitem__(self, select=...):
-                da = _load_event_group(group,
-                                       loader,
-                                       DetectorData(),
-                                       quiet=False,
-                                       select=select).event_data
+                da = _load_event_group(group, loader, quiet=False, select=select)
                 return da.bins.size().values
 
         assert np.array_equal(Load()[...], [3, 0, 2, 1])

--- a/tests/test_nxdetector.py
+++ b/tests/test_nxdetector.py
@@ -68,8 +68,9 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         loaded = detector[...]
-        assert sc.identical(loaded.bins.size().data,
-                            sc.array(dims=['detector_number'], values=[2, 3, 1, 0]))
+        assert sc.identical(
+            loaded.bins.size().data,
+            sc.array(dims=['detector_number'], dtype='int32', values=[2, 3, 1, 0]))
 
 
 def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in_file(
@@ -90,5 +91,6 @@ def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         loaded = detector[...]
-        assert sc.identical(loaded.bins.size().data,
-                            sc.array(dims=['detector_number'], values=[2, 3, 0, 1]))
+        assert sc.identical(
+            loaded.bins.size().data,
+            sc.array(dims=['detector_number'], dtype='int32', values=[2, 3, 0, 1]))

--- a/tests/test_nxdetector.py
+++ b/tests/test_nxdetector.py
@@ -1,5 +1,5 @@
 from .test_nexus import open_nexus, open_json
-from .nexus_helpers import NexusBuilder, Detector
+from .nexus_helpers import NexusBuilder, Detector, EventData
 import numpy as np
 import pytest
 from typing import Callable, Tuple
@@ -47,3 +47,48 @@ def test_loads_data_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         loaded = detector[...]
         assert sc.identical(loaded, da.rename_dims({'yy': 'dim_1'}))
+
+
+def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_data = EventData(
+        event_id=np.array([1, 2, 3, 1, 2, 2]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=np.array([
+            1600766730000000000, 1600766731000000000, 1600766732000000000,
+            1600766733000000000
+        ]),
+        event_index=np.array([0, 3, 3, 5]),
+    )
+    builder = NexusBuilder()
+    builder.add_detector(
+        Detector(detector_numbers=np.array([1, 2, 3, 4]), event_data=event_data))
+    resource, loader = nexus_group
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        loaded = detector[...]
+        assert sc.identical(loaded.bins.size().data,
+                            sc.array(dims=['detector_number'], values=[2, 3, 1, 0]))
+
+
+def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in_file(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_data = EventData(
+        event_id=np.array([1, 2, 4, 1, 2, 2]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=np.array([
+            1600766730000000000, 1600766731000000000, 1600766732000000000,
+            1600766733000000000
+        ]),
+        event_index=np.array([0, 3, 3, 5]),
+    )
+    builder = NexusBuilder()
+    builder.add_detector(Detector(event_data=event_data))
+    resource, loader = nexus_group
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        loaded = detector[...]
+        assert sc.identical(loaded.bins.size().data,
+                            sc.array(dims=['detector_number'], values=[2, 3, 0, 1]))

--- a/tests/test_nxdetector.py
+++ b/tests/test_nxdetector.py
@@ -21,7 +21,7 @@ def test_raises_if_no_data_found(nexus_group: Tuple[Callable, LoadFromNexus]):
     builder.add_detector(Detector(detector_numbers=np.array([1, 2, 3, 4])))
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(KeyError):
             detector[...]
 
 
@@ -33,7 +33,7 @@ def test_loads_data_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         loaded = detector[...]
-        assert sc.identical(loaded, da)
+        assert sc.identical(loaded, da.rename_dims({'xx': 'dim_0', 'yy': 'dim_1'}))
 
 
 def test_loads_data_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
@@ -46,4 +46,4 @@ def test_loads_data_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         loaded = detector[...]
-        assert sc.identical(loaded, da)
+        assert sc.identical(loaded, da.rename_dims({'yy': 'dim_1'}))

--- a/tests/test_nxdetector.py
+++ b/tests/test_nxdetector.py
@@ -86,7 +86,7 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         assert detector.dims == ['detector_number']
-        assert detector.shape == (4,)
+        assert detector.shape == (4, )
         loaded = detector[...]
         assert sc.identical(
             loaded.bins.size().data,
@@ -109,7 +109,7 @@ def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         assert detector.dims == ['detector_number']
         with pytest.raises(nexus.NexusStructureError):
-            assert detector.shape == (4,)
+            assert detector.shape == (4, )
         loaded = detector[...]
         assert sc.identical(
             loaded.bins.size().data,

--- a/tests/test_nxdetector.py
+++ b/tests/test_nxdetector.py
@@ -85,6 +85,8 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
     resource, loader = nexus_group
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
+        assert detector.dims == ['detector_number']
+        assert detector.shape == (4,)
         loaded = detector[...]
         assert sc.identical(
             loaded.bins.size().data,
@@ -97,14 +99,17 @@ def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in
     event_data = EventData(
         event_id=np.array([1, 2, 4, 1, 2, 2]),
         event_time_offset=event_time_offsets,
-        event_time_zero=np.array([1, 2, 3, 4]),
-        event_index=np.array([0, 3, 3, 5]),
+        event_time_zero=np.array([1, 2, 3]),
+        event_index=np.array([0, 3, 5]),
     )
     builder = NexusBuilder()
     builder.add_detector(Detector(event_data=event_data))
     resource, loader = nexus_group
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
+        assert detector.dims == ['detector_number']
+        with pytest.raises(nexus.NexusStructureError):
+            assert detector.shape == (4,)
         loaded = detector[...]
         assert sc.identical(
             loaded.bins.size().data,

--- a/tests/test_nxdetector.py
+++ b/tests/test_nxdetector.py
@@ -1,0 +1,49 @@
+from .test_nexus import open_nexus, open_json
+from .nexus_helpers import NexusBuilder, Detector
+import numpy as np
+import pytest
+from typing import Callable, Tuple
+import scipp as sc
+from scippneutron.file_loading._nexus import LoadFromNexus
+from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
+from scippneutron.file_loading._json_nexus import LoadFromJson
+from scippneutron import nexus
+
+
+@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+def nexus_group(request):
+    return request.param
+
+
+def test_raises_if_no_data_found(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    builder.add_detector(Detector(detector_numbers=np.array([1, 2, 3, 4])))
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        with pytest.raises(NotImplementedError):
+            detector[...]
+
+
+def test_loads_data_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
+    builder.add_detector(Detector(detector_numbers=np.array([1, 2, 3, 4]), data=da))
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        loaded = detector[...]
+        assert sc.identical(loaded, da)
+
+
+def test_loads_data_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='K', values=[[1.1, 2.2], [3.3, 4.4]]))
+    da.coords['xx'] = sc.array(dims=['xx'], unit='m', values=[0.1, 0.2])
+    builder.add_detector(Detector(detector_numbers=np.array([1, 2, 3, 4]), data=da))
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        loaded = detector[...]
+        assert sc.identical(loaded, da)

--- a/tools/make_tutorial_data.ipynb
+++ b/tools/make_tutorial_data.ipynb
@@ -83,8 +83,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There are a number of question marks attached to some of the functionality, pending answers on how to interpret the Nexus standard.

- Closes #257.
- Closes #226, at least for the basics. No support in `load_nexus` added, but this might not be what we want anyway.
- Closes #141, even though we may want to wrap things up further in the future. For now this should be a start and enables users to load individual components without forcing them into specific transformations and assembly of pieces from a file.