### PR TITLE
Load pixel offset, string dataset, and more

### DIFF
--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -375,8 +375,12 @@ def load_detector_data(event_data_groups: List[Group], detector_groups: List[Gro
             # will not have a bin)
             event_id = data.event_data.bins.constituents['data'].coords[
                 _detector_dimension]
-            data.detector_ids = sc.array(dims=[_detector_dimension],
-                                         values=np.unique(event_id.values))
+            id_min = event_id.min()
+            id_max = event_id.max()
+            data.detector_ids = sc.arange(dim=_detector_dimension,
+                                          start=id_min.value,
+                                          stop=id_max.value + 1,
+                                          dtype=id_min.dtype)
 
         # Events in the NeXus file are effectively binned by pulse
         # (because they are recorded chronologically)

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -160,6 +160,9 @@ class LoadFromHdf5:
                             dimensions: Optional[List[str]] = [],
                             dtype: Optional[Any] = None,
                             index=tuple()) -> sc.Variable:
+        """
+        Same as `load_dataset` but dataset given directly instead of by group and name.
+        """
         if dtype is None:
             dtype = _ensure_supported_int_type(dataset.dtype.type)
         if h5py.check_string_dtype(dataset.dtype):

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -153,6 +153,8 @@ class LoadFromHdf5:
 
         if dtype is None:
             dtype = _ensure_supported_int_type(dataset.dtype.type)
+        if h5py.check_string_dtype(dataset.dtype):
+            dtype = sc.DType.string
 
         shape = list(dataset.shape)
         if isinstance(index, slice):
@@ -164,7 +166,9 @@ class LoadFromHdf5:
                             shape=shape,
                             dtype=dtype,
                             unit=self.get_unit(dataset))
-        if variable.values.flags["C_CONTIGUOUS"] and variable.values.size > 0:
+        if dtype == sc.DType.string:
+            variable.values = dataset[index].flatten()
+        elif variable.values.flags["C_CONTIGUOUS"] and variable.values.size > 0:
             dataset.read_direct(variable.values, source_sel=index)
         else:
             variable.values = dataset[index]

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -31,7 +31,8 @@ _filewriter_to_supported_numpy_dtype = {
     "uint8": np.int32,
     "uint16": np.int32,
     "uint32": np.int32,
-    "uint64": np.int64
+    "uint64": np.int64,
+    "string": np.str_
 }
 
 
@@ -236,7 +237,16 @@ class LoadFromJson:
         dataset = self.get_dataset_from_group(group, dataset_name)
         if dataset is None:
             raise MissingDataset()
+        return self.load_dataset_direct(dataset,
+                                        dimensions=dimensions,
+                                        dtype=dtype,
+                                        index=index)
 
+    def load_dataset_direct(self,
+                            dataset: Dict,
+                            dimensions: Optional[List[str]] = [],
+                            dtype: Optional[Any] = None,
+                            index=tuple()) -> sc.Variable:
         if dtype is None:
             dtype = self.supported_int_type(dataset)
 
@@ -246,7 +256,7 @@ class LoadFromJson:
                 units = sc.Unit(units)
             except sc.UnitError:
                 warn(f"Unrecognized unit '{units}' for value dataset "
-                     f"in '{group.name}'; setting unit as 'dimensionless'")
+                     f"in '{self.get_name(dataset)}'; setting unit as 'dimensionless'")
                 units = sc.units.dimensionless
         except MissingAttribute:
             units = sc.units.dimensionless

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -247,6 +247,9 @@ class LoadFromJson:
                             dimensions: Optional[List[str]] = [],
                             dtype: Optional[Any] = None,
                             index=tuple()) -> sc.Variable:
+        """
+        Same as `load_dataset` but dataset given directly instead of by group and name.
+        """
         if dtype is None:
             dtype = self.supported_int_type(dataset)
 

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -106,13 +106,13 @@ class NXdetector(NXobject):
         # Note that ._detector_data._load_detector provides a different loading
         # facility for NXdetector but handles only loading of detector_number,
         # as needed for event data loading
+        detector_number = self.detector_number(select)
         if self._is_events:
             # If there is a 'detector_number' field it is used to bin events into
             # detector pixels. Note that due to the nature of NXevent_data, which stores
             # events from all pixels and random order, we always have to load the entire
             # bank. Slicing with the provided 'select' is done while binning.
             event_data = self._nxbase[...]
-            detector_number = self.detector_number(select)
             if detector_number is None:
                 # Ideally we would prefer to use np.unique, but a quick experiment shows
                 # that this can easily be 100x slower, so it is not an option. In
@@ -135,6 +135,8 @@ class NXdetector(NXobject):
             da = event_data.fold(dim='event_id', sizes=detector_number.sizes)
         else:
             da = self._nxbase[select]
+            if detector_number is not None:
+                da.coords['detector_number'] = detector_number
         pixel_offset = self.pixel_offset(select)
         if pixel_offset is not None:
             da.coords['pixel_offset'] = pixel_offset

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -106,9 +106,10 @@ class NXdetector(NXobject):
         # Note that ._detector_data._load_detector provides a different loading
         # facility for NXdetector but handles only loading of detector_number,
         # as needed for event data loading
-        coords = {}
-        coords['detector_number'] = self.detector_number(select)
-        coords['pixel_offset'] = self.pixel_offset(select)
+        coords = {
+            'detector_number': self.detector_number(select),
+            'pixel_offset': self.pixel_offset(select)
+        }
         if self._is_events:
             # If there is a 'detector_number' field it is used to bin events into
             # detector pixels. Note that due to the nature of NXevent_data, which stores

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -116,6 +116,11 @@ class NXdetector(NXobject):
             # bank. Slicing with the provided 'select' is done while binning.
             event_data = self._nxbase[...]
             if coords['detector_number'] is None:
+                if select not in (Ellipsis, tuple()):
+                    raise NexusStructureError(
+                        "Cannot load slice of NXdetector since it contains event data "
+                        "but no 'detector_number' field, i.e., the shape is unknown. "
+                        "Use ellipsis or an empty tuple to load the full detector.")
                 # Ideally we would prefer to use np.unique, but a quick experiment shows
                 # that this can easily be 100x slower, so it is not an option. In
                 # practice most files have contiguous event_id values within a bank
@@ -126,7 +131,6 @@ class NXdetector(NXobject):
                                                       start=id_min.value,
                                                       stop=id_max.value + 1,
                                                       dtype=id_min.dtype)
-                # TODO This is ignoring `select`!
             event_id = coords['detector_number'].flatten(to='event_id')
             # After loading raw NXevent_data it is guaranteed that the event table
             # is contiguous and that there is no masking. We can therefore use the

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -84,7 +84,8 @@ class NXdetector(NXobject):
         """Read and return the 'detector_number' field, None if it does not exist."""
         if self._detector_number is None:
             return None
-        return sc.array(dims=self.dims, values=self._detector_number[...])
+        var = self._detector_number[...]
+        return var.rename_dims(dict(zip(var.dims, self.dims)))
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         # Note that ._detector_data._load_detector provides a different loading

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -67,7 +67,9 @@ class Field:
         self._loader = loader
 
     def __getitem__(self, index) -> np.ndarray:
-        return self._loader.load_dataset_as_numpy_array(self._dataset, index)
+        values = self._loader.load_dataset_as_numpy_array(self._dataset, index)
+        dims = [f'dim_{i}' for i in range(self.ndim)]
+        return sc.array(dims=dims, unit=self.unit, values=values)
 
     def __repr__(self) -> str:
         return f'<Nexus field "{self._dataset.name}">'

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -67,9 +67,10 @@ class Field:
         self._loader = loader
 
     def __getitem__(self, index) -> np.ndarray:
-        values = self._loader.load_dataset_as_numpy_array(self._dataset, index)
         dims = [f'dim_{i}' for i in range(self.ndim)]
-        return sc.array(dims=dims, unit=self.unit, values=values)
+        return self._loader.load_dataset_direct(self._dataset,
+                                                dimensions=dims,
+                                                index=index)
 
     def __repr__(self) -> str:
         return f'<Nexus field "{self._dataset.name}">'

--- a/src/scippneutron/mantid.py
+++ b/src/scippneutron/mantid.py
@@ -610,7 +610,7 @@ def convert_EventWorkspace_to_data_array(ws,
     _, data_unit = validate_and_get_unit(ws.YUnit(), allow_empty=True)
 
     n_event = ws.getNumberEvents()
-    coord = sc.zeros(dims=['event'], shape=[n_event], unit=unit, dtype=sc.DType.float64)
+    coord = sc.empty(dims=['event'], shape=[n_event], unit=unit, dtype=sc.DType.float64)
     weights = sc.ones(dims=['event'],
                       shape=[n_event],
                       unit=data_unit,

--- a/src/scippneutron/mantid.py
+++ b/src/scippneutron/mantid.py
@@ -622,20 +622,22 @@ def convert_EventWorkspace_to_data_array(ws,
 
     begins = sc.zeros(dims=[spec_dim, dim], shape=[nHist, 1], dtype=sc.DType.int64)
     ends = begins.copy()
-    current = 0
-    for i in range(nHist):
-        sp = ws.getSpectrum(i)
-        size = sp.getNumberEvents()
-        coord['event', current:current + size].values = sp.getTofs()
-        if load_pulse_times:
-            pulse_times['event',
-                        current:current + size].values = sp.getPulseTimesAsNumpy()
-        if _contains_weighted_events(sp):
-            weights['event', current:current + size].values = sp.getWeights()
-            weights['event', current:current + size].variances = sp.getWeightErrors()
-        begins.values[i] = current
-        ends.values[i] = current + size
-        current += size
+    if n_event > 0:  # Skip expensive loop if there are no events
+        current = 0
+        for i in range(nHist):
+            sp = ws.getSpectrum(i)
+            size = sp.getNumberEvents()
+            coord['event', current:current + size].values = sp.getTofs()
+            if load_pulse_times:
+                pulse_times['event',
+                            current:current + size].values = sp.getPulseTimesAsNumpy()
+            if _contains_weighted_events(sp):
+                weights['event', current:current + size].values = sp.getWeights()
+                weights['event',
+                        current:current + size].variances = sp.getWeightErrors()
+            begins.values[i] = current
+            ends.values[i] = current + size
+            current += size
 
     proto_events = {'data': weights, 'coords': {dim: coord}}
     if load_pulse_times:

--- a/src/scippneutron/mantid.py
+++ b/src/scippneutron/mantid.py
@@ -627,6 +627,8 @@ def convert_EventWorkspace_to_data_array(ws,
         for i in range(nHist):
             sp = ws.getSpectrum(i)
             size = sp.getNumberEvents()
+            if size == 0:  # Skip expensive getters
+                continue
             coord['event', current:current + size].values = sp.getTofs()
             if load_pulse_times:
                 pulse_times['event',

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -222,7 +222,8 @@ numpy_to_filewriter_type = {
     np.uint8: "uint8",
     np.uint16: "uint16",
     np.uint32: "uint32",
-    np.uint64: "uint64"
+    np.uint64: "uint64",
+    np.str_: "string"
 }
 
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -179,7 +179,7 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
-        assert field.dtype == sc.DType.int64
+        assert field.dtype == 'int64'
         assert field.name == '/entry/events_0/event_time_offset'
         assert field.shape == (6, )
         assert field.unit == sc.Unit('ns')

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -192,17 +192,29 @@ def test_field_unit_is_none_if_no_units_attribute(nexus_group: Tuple[Callable,
         assert field.unit is None
 
 
-def test_field_getitem_returns_numpy_array_with_correct_size_and_values(
+def test_field_getitem_returns_variable_with_correct_size_and_values(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
-        assert np.array_equal(field[...],
-                              np.array([456, 743, 347, 345, 632, 23], dtype='int64'))
-        assert np.array_equal(field[1:],
-                              np.array([743, 347, 345, 632, 23], dtype='int64'))
-        assert np.array_equal(field[:-1],
-                              np.array([456, 743, 347, 345, 632], dtype='int64'))
+        assert sc.identical(
+            field[...],
+            sc.array(dims=['dim_0'],
+                     unit='ns',
+                     values=[456, 743, 347, 345, 632, 23],
+                     dtype='int64'))
+        assert sc.identical(
+            field[1:],
+            sc.array(dims=['dim_0'],
+                     unit='ns',
+                     values=[743, 347, 345, 632, 23],
+                     dtype='int64'))
+        assert sc.identical(
+            field[:-1],
+            sc.array(dims=['dim_0'],
+                     unit='ns',
+                     values=[456, 743, 347, 345, 632],
+                     dtype='int64'))
 
 
 def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable,

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -179,7 +179,7 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
-        assert field.dtype == np.array(1).dtype
+        assert field.dtype == sc.DType.int64
         assert field.name == '/entry/events_0/event_time_offset'
         assert field.shape == (6, )
         assert field.unit == sc.Unit('ns')

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -34,7 +34,7 @@ def nexus_group(request):
 
 
 def builder_with_events_monitor_and_log():
-    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23], dtype='int64')
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3, 2]),
         event_time_offset=event_time_offsets,


### PR DESCRIPTION
- Load `x_pixel_offset` and friends as `pixel_offset` in `NXdetector`.
- Fix a number of inconsistencies in `NXdetector`.
- Support loading datasets containing strings. I am very doubtful that it works in all cases since there appear to be multiple options for strings in HDF5.
- Refactor so `read_direct` is used in more cases (should be able to yield better performance).
- Avoid expensive `np.unique` when detector numbers are missing in `load_nexus`.
- Avoid expensive loop in `from_mantid` for empty `EventWorkspace`. This can significantly speed up loading metadata via Mantid, e.g., via `scn.load(filename, mantid_args={'MetaDataOnly':True})`.