### PR TITLE
Fix for loading relative transforms

### DIFF
--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -12,6 +12,7 @@ from warnings import warn
 _nexus_class = "NX_class"
 _nexus_units = "units"
 _nexus_name = "name"
+_nexus_path = "path"
 _nexus_values = "values"
 _nexus_dataset = "dataset"
 _nexus_group = "group"
@@ -156,6 +157,7 @@ class LoadFromJson:
         for child in group[_nexus_children]:
             try:
                 if child[_nexus_name] == name:
+                    child[_nexus_path] = f"{self.get_path(group)}/{name}"
                     if child["type"] == _nexus_link:
                         child = self.get_object_by_path(self._root, child["target"])
                     if child["type"] in allowed_nexus_classes:
@@ -309,9 +311,8 @@ class LoadFromJson:
     def get_path(group: Dict) -> str:
         if isinstance(group, JSONGroup):
             return group.name
-        # TODO JSONGroup is apparently used inconsistently, fall back to returning name
-        # without path.
-        return group.get(_nexus_name, '/')
+        else:
+            return group.get(_nexus_path, '/')
 
     @staticmethod
     def get_dtype(dataset: Dict) -> str:

--- a/src/scippneutron/file_loading/_transformations.py
+++ b/src/scippneutron/file_loading/_transformations.py
@@ -124,12 +124,18 @@ def _get_transformations(transform_path: str, transformations: List[np.ndarray],
     if transform_path != '.':
         try:
             transform = nexus.get_object_by_path(group.file, transform_path)
-        except KeyError:
+        except MissingDataset:
             raise TransformationError(
                 f"Non-existent depends_on path '{transform_path}' found "
                 f"in transformations chain for {group_name}")
         next_depends_on = _append_transformation(transform, transformations, group_name,
                                                  nexus)
+
+        if not next_depends_on == "." and not next_depends_on.startswith("/"):
+            # Path is relative - convert it to an absolute path relative to the parent
+            # of the transform it was loaded from.
+            next_depends_on = f"/{transform.parent.name}/{next_depends_on}"
+
         _get_transformations(next_depends_on, transformations, group, group_name, nexus)
 
 

--- a/src/scippneutron/file_loading/_transformations.py
+++ b/src/scippneutron/file_loading/_transformations.py
@@ -134,7 +134,8 @@ def _get_transformations(transform_path: str, transformations: List[np.ndarray],
         if not next_depends_on == "." and not next_depends_on.startswith("/"):
             # Path is relative - convert it to an absolute path relative to the parent
             # of the transform it was loaded from.
-            next_depends_on = f"/{transform.parent.name}/{next_depends_on}"
+            parent = "/".join(nexus.get_path(transform).split("/")[:-1])
+            next_depends_on = f"{parent}/{next_depends_on}"
 
         _get_transformations(next_depends_on, transformations, group, group_name, nexus)
 


### PR DESCRIPTION
Fixes loading chained transforms from certain files.

I think this case was previously broken but hidden by a misleading warning, and then became completely broken during one of the recent merges.

Relevant part of NX standard is:

> If a relative path is given, it is relative to the group enclosing the depends_on specification.

from https://manual.nexusformat.org/classes/base_classes/NXtransformations.html