### PR TITLE
Add API for selecting events when loading NXdetector

### DIFF
--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
 from typing import List, Dict, Union
 import warnings
 from ._common import Group

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Simon Heybrock
 from typing import List, Union
 import scipp as sc
 from ._common import to_plain_index, Dataset, Group

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -12,12 +12,12 @@ from ._common import to_plain_index
 
 
 class EventSelector:
-    """A proxy object for creating and NXdetector based on a selection of events.
+    """A proxy object for creating an NXdetector based on a selection of events.
     """
     def __init__(self, detector):
         self._detector = detector
 
-    def __getitem__(self, select) -> NXdetector:
+    def __getitem__(self, select: ScippIndex) -> NXdetector:
         """Return an NXdetector based on a selection (slice) of events."""
         det = copy(self._detector)
         det._event_select = select

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -110,6 +110,9 @@ class NXdetector(NXobject):
         Return a proxy object for selecting a slice of the underlying NXevent_data
         group, while keeping wrapping the NXdetector.
         """
+        if not self._is_events:
+            raise NexusStructureError(
+                "Cannot select events in NXdetector not containing NXevent_data.")
         return EventSelector(self)
 
     @property

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -172,6 +172,27 @@ def test_select_events_slices_underlying_event_data(nexus_group: Tuple[Callable,
             sc.array(dims=['dim_0', 'dim_1'], dtype='int64', values=[[2, 3], [1, 0]]))
 
 
+def test_select_events_slice_does_not_affect_original_detector(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_data = EventData(
+        event_id=np.array([1, 2, 3, 1, 2, 2]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=np.array([1, 2, 3, 4]),
+        event_index=np.array([0, 3, 3, 5]),
+    )
+    builder = NexusBuilder()
+    builder.add_detector(
+        Detector(detector_numbers=np.array([[1, 2], [3, 4]]), event_data=event_data))
+    resource, loader = nexus_group
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector.select_events['pulse', 0][...]
+        assert sc.identical(
+            detector[...].bins.size().data,
+            sc.array(dims=['dim_0', 'dim_1'], dtype='int64', values=[[2, 3], [1, 0]]))
+
+
 def builder_with_events_and_no_detector_number():
     event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
     event_data = EventData(


### PR DESCRIPTION
`NXdetector` may wrap an `NXevent_data`. In that case the detector defines a mapping of events into pixels. The dimensions of the event data are `['pulse']`, i.e., data is binned by pulse. `NXdetector` maps this into pixel-based grouping. In principle we would then have both, i.e., `dims=['detector_number', 'pulse']` but in practice this is completely infeasible due to the massive bin count (each axis could have a length of 1 million). Therefore `NXdetector` *drops* the "pulse" binning and has `dims=['detector_number']`.

This unavoidable limitation prevents selecting a subset of events when loading an `NXdetector` (otherwise we could have used `det['pulse', :1000]`, but 'pulse' is not a dimension of `det`). The alternative would be to work directly with `NXevent_data`, performing binning into pixels by hand, but in practice this is too cumbersome and error prone.

Therefore this PR introduced a mechanism for selecting a range of events (pulses) for loading with `NXdetector`:

```python
event_data = det.select_events['pulse', :1000][:]
```
would load events of the first 1000 pulses, mapped into pixels.