### PR TITLE
Test time axis interpolation and trim start time

### DIFF
--- a/src/scippneutron/file_loading/_transformations.py
+++ b/src/scippneutron/file_loading/_transformations.py
@@ -101,7 +101,11 @@ def get_full_transformation_matrix(group: Group, nexus: LoadFromNexus) -> sc.Dat
                 transform, xnew) * _interpolate_transform(total_transform, xnew)
         else:
             total_transform = transform * total_transform
-
+    if isinstance(total_transform, sc.DataArray):
+        time_dependent = [t for t in transformations if isinstance(t, sc.DataArray)]
+        times = [da.coords['time'][0] for da in time_dependent]
+        latest_log_start = sc.reduce(times).max()
+        return total_transform['time', latest_log_start:].copy()
     return total_transform
 
 

--- a/src/scippneutron/file_loading/_transformations.py
+++ b/src/scippneutron/file_loading/_transformations.py
@@ -91,8 +91,8 @@ def get_full_transformation_matrix(group: Group, nexus: LoadFromNexus) -> sc.Dat
                 transform, sc.DataArray):
             xnew = sc.datetimes(values=np.unique(
                 sc.concat([
-                    total_transform.coords["time"].to(unit=sc.units.ns, copy=True),
-                    transform.coords["time"].to(unit=sc.units.ns, copy=True),
+                    total_transform.coords["time"].to(unit=sc.units.ns, copy=False),
+                    transform.coords["time"].to(unit=sc.units.ns, copy=False),
                 ],
                           dim="time").values),
                                 dims=["time"],

--- a/src/scippneutron/file_loading/_transformations.py
+++ b/src/scippneutron/file_loading/_transformations.py
@@ -40,19 +40,6 @@ def _rotation_matrix_from_axis_and_angle(axis: np.ndarray,
     return matrices
 
 
-def get_translation_from_affine(group: Group, nexus: LoadFromNexus) -> sc.Variable:
-    """
-    Get position of a component which has a "depends_on" dataset
-
-    :param group: The HDF5 group of the component, containing depends_on
-    :param nexus: wrap data access to hdf file or objects from json
-    :return: Position of the component as a vector variable
-    """
-    total_transform_matrix = get_full_transformation_matrix(group, nexus)
-    return total_transform_matrix * sc.vector(value=[0, 0, 0],
-                                              unit=total_transform_matrix.unit)
-
-
 def _interpolate_transform(transform, xnew):
     # scipy can't interpolate with a single value
     if transform.sizes["time"] == 1:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -145,7 +145,7 @@ class NXobject:
         return self._loader.get_path(self._group)
 
     def _ipython_key_completions_(self) -> List[str]:
-        return self.keys()
+        return list(self.keys())
 
     def keys(self) -> List[str]:
         return self._loader.keys(self._group)


### PR DESCRIPTION
The current implementation of loading NXtransformations uses extrapolation to fill in values before a log of transformation, i.e., while usually the *previous* log value is used (since everything after a motor move will see the effect of the translation/rotation), the *next* log value is used if the log for a transformation starts after that of another transformation. This risk some hard to spot bugs. Overall, we have the following options:

1. Keep current behavior, assuming that data acquisition logs transformation at the run start, or in small steps, i.e., error is likely small.
2. Use identity, which also risks bugs, maybe more visibly
3. Use NaN. This is inconvenient for the user.
4. Trim the time-dependence, i.e., start the transformation at the time when all transforms in the chain have a valid value.

Since 1.) is *usually* a good guess, but risks big hidden problems in some cases, we choose 4.): If good assumptions for 1.) apply, then the result is nearly identical, but it avoids the issue of big hidden bugs.

Also adding a test that exercises time interpolation.