### PR TITLE
Load all NXdata axes

### DIFF
--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -92,8 +92,7 @@ class NXdata(NXobject):
             # since legacy files do not set this attribute.
             indices = self.attrs.get(f'{name}_indices')
             if indices is None:
-                if self.attrs.get('axes', self._axes_default) is not None:
-                    axes = self.attrs.get('axes', self._axes_default)
+                if (axes := self.attrs.get('axes', self._axes_default)) is not None:
                     # Unlike self.dims we *drop* entries that are '.'
                     axes = [a for a in axes if a != '.']
                 elif 'axes' in self._signal.attrs:

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -117,7 +117,7 @@ class NXdata(NXobject):
                     if len(shape) != 0:
                         raise NexusStructureError("Could not determine axis indices")
             else:
-                dims = np.array(da.dims)[indices]
+                dims = [np.array(da.dims)[indices]]
             index = to_plain_index(dims, select, ignore_missing=True)
             da.coords[name] = self._loader.load_dataset(self._group,
                                                         name,

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -87,7 +87,8 @@ class NXdata(NXobject):
 
         for name in items:
             # Newly written files should always contain indices attributes, but the
-            # standard recommends that readers should also make "best effort" guess.
+            # standard recommends that readers should also make "best effort" guess
+            # since legacy files do not set this attribute.
             indices = self.attrs.get(f'{name}_indices')
             if indices is None:
                 if self.attrs.get('axes', self._axes_default) is not None:
@@ -117,7 +118,7 @@ class NXdata(NXobject):
                     if len(shape) != 0:
                         raise NexusStructureError("Could not determine axis indices")
             else:
-                dims = [np.array(da.dims)[indices]]
+                dims = np.array(da.dims)[np.array(indices).flatten()]
             index = to_plain_index(dims, select, ignore_missing=True)
             da.coords[name] = self._loader.load_dataset(self._group,
                                                         name,

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -82,6 +82,7 @@ class NXdata(NXobject):
         da = sc.DataArray(data=signal)
 
         skip = [self._signal_name, self._errors_name]
+        skip += list(self.attrs.get('auxiliary_signals', []))
         items = [k for k in self.keys() if isinstance(self[k], Field)]
         items = [k for k in items if k not in skip]
 

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -119,16 +119,14 @@ class NXdata(NXobject):
             # Newly written files should always contain indices attributes, but the
             # standard recommends that readers should also make "best effort" guess
             # since legacy files do not set this attribute.
-            indices = self.attrs.get(f'{name}_indices')
-            if indices is None:
-                if name in self._get_axes():
-                    # If there are named axes then items of same name are "dimension
-                    # coordinates", i.e., have a dim matching their name.
-                    dims = [name]
-                else:
-                    dims = self._guess_dims(da, name)
-            else:
+            if (indices := self.attrs.get(f'{name}_indices')) is not None:
                 dims = np.array(da.dims)[np.array(indices).flatten()]
+            elif name in self._get_axes():
+                # If there are named axes then items of same name are "dimension
+                # coordinates", i.e., have a dim matching their name.
+                dims = [name]
+            else:
+                dims = self._guess_dims(da, name)
             index = to_plain_index(dims, select, ignore_missing=True)
             da.coords[name] = self._loader.load_dataset(self._group,
                                                         name,

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -68,6 +68,15 @@ class NXdata(NXobject):
     def _signal(self) -> Dataset:
         return self[self._signal_name]
 
+    def _get_axes(self):
+        """Return labels of named axes."""
+        if (axes := self.attrs.get('axes', self._axes_default)) is not None:
+            # Unlike self.dims we *drop* entries that are '.'
+            return [a for a in axes if a != '.']
+        elif 'axes' in self._signal.attrs:
+            return self._signal.attrs['axes'].split(',')
+        return []
+
     def _guess_dims(self, da: sc.DataArray, name: str):
         """Guess dims of non-signal dataset based on shape.
 
@@ -112,14 +121,7 @@ class NXdata(NXobject):
             # since legacy files do not set this attribute.
             indices = self.attrs.get(f'{name}_indices')
             if indices is None:
-                if (axes := self.attrs.get('axes', self._axes_default)) is not None:
-                    # Unlike self.dims we *drop* entries that are '.'
-                    axes = [a for a in axes if a != '.']
-                elif 'axes' in self._signal.attrs:
-                    axes = self._signal.attrs['axes'].split(',')
-                else:
-                    axes = None
-                if name in axes:
+                if name in self._get_axes():
                     # If there are named axes then items of same name are "dimension
                     # coordinates", i.e., have a dim matching their name.
                     dims = [name]

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -116,7 +116,8 @@ class NXdata(NXobject):
                             dims += [dim]
                             shape.pop(0)
                     if len(shape) != 0:
-                        raise NexusStructureError("Could not determine axis indices")
+                        raise NexusStructureError(
+                            "Could not determine axis indices for {self[name].name}")
             else:
                 dims = np.array(da.dims)[np.array(indices).flatten()]
             index = to_plain_index(dims, select, ignore_missing=True)

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -96,7 +96,10 @@ class NXdetector(NXobject):
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXdetector uses a "hard-coded" signal name 'data', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
-        return NXdata(self._group, self._loader, signal='data')
+        return NXdata(self._group,
+                      self._loader,
+                      signal='data',
+                      skip=['detector_number'])
 
     @property
     def events(self) -> Union[None, NXevent_data]:

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -1,3 +1,4 @@
+import scipp as sc
 from dataclasses import dataclass
 from typing import List, Union, Iterator, Optional, Dict, Any, Tuple
 import h5py
@@ -87,6 +88,13 @@ class Detector:
     offsets_unit: Optional[Union[str, bytes]] = None
     depends_on: Optional[Transformation] = None
     data: Optional[np.ndarray] = None
+
+
+@dataclass
+class Data:
+    name: str
+    data: sc.DataArray
+    attrs: dict = None
 
 
 @dataclass
@@ -365,6 +373,7 @@ class NexusBuilder:
         self._datasets: List[DatasetAtPath] = []
         self._streams = []
         self._monitors = []
+        self._datas = []
 
     def add_dataset_at_path(self, path: str, data: np.ndarray, attributes: Dict):
         self._datasets.append(DatasetAtPath(path, data, attributes))
@@ -379,6 +388,9 @@ class NexusBuilder:
 
     def add_detector(self, detector: Detector):
         self._detectors.append(detector)
+
+    def add_data(self, data: Data):
+        self._datas.append(data)
 
     def add_event_data(self, event_data: EventData):
         self._event_data.append(event_data)
@@ -497,6 +509,7 @@ class NexusBuilder:
         self._write_streams(nexus_file)
         self._write_links(nexus_file)
         self._write_monitors(nexus_file)
+        self._write_datas(parent_group)
 
     def create_file_on_disk(self, filename: str):
         """
@@ -639,6 +652,21 @@ class NexusBuilder:
             if not monitor.events or not axis_name == "event_index":
                 ds = self._writer.add_dataset(monitor_group, axis_name, axis_data)
                 self._writer.add_attribute(ds, "units", '')
+
+    def _write_datas(self, parent_group: Union[h5py.Group, Dict]):
+        for data in self._datas:
+            self._add_data_group_to_file(data, parent_group)
+
+    def _add_data_group_to_file(self, data: Data, parent_group: h5py.Group):
+        da = data.data
+        group = self._create_nx_class(data.name, "NXdata", parent_group)
+        self._writer.add_attribute(group, "axes", da.dims)
+        self._writer.add_attribute(group, "signal", "signal1")
+        signal = self._writer.add_dataset(group, "signal1", da.values)
+        self._writer.add_attribute(signal, "units", str(da.unit))
+        for name, coord in da.coords.items():
+            ds = self._writer.add_dataset(group, name, coord.values)
+            self._writer.add_attribute(ds, "units", str(coord.unit))
 
     def _write_logs(self, parent_group: Union[h5py.Group, Dict]):
         for log in self._logs:

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -667,7 +667,7 @@ class NexusBuilder:
         # Note: We are deliberately NOT adding AXISNAME_indices attributes for the
         # coords, since these were added late to the Nexus standard and therefore we
         # also need to support loading without the attributes. The attribute should be
-        # set manualy by the user if desired.
+        # set manually by the user if desired.
         for name, coord in da.coords.items():
             ds = self._writer.add_dataset(group, name, coord.values)
             self._writer.add_attribute(ds, "units", str(coord.unit))

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -664,9 +664,16 @@ class NexusBuilder:
         self._writer.add_attribute(group, "signal", "signal1")
         signal = self._writer.add_dataset(group, "signal1", da.values)
         self._writer.add_attribute(signal, "units", str(da.unit))
+        # Note: We are deliberately NOT adding AXISNAME_indices attributes for the
+        # coords, since these were added late to the Nexus standard and therefore we
+        # also need to support loading without the attributes. The attribute should be
+        # set manualy by the user if desired.
         for name, coord in da.coords.items():
             ds = self._writer.add_dataset(group, name, coord.values)
             self._writer.add_attribute(ds, "units", str(coord.unit))
+        if data.attrs is not None:
+            for k, v in data.attrs.items():
+                self._writer.add_attribute(group, k, v)
 
     def _write_logs(self, parent_group: Union[h5py.Group, Dict]):
         for log in self._logs:

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -45,6 +45,19 @@ def test_guessed_dim_for_coord_not_matching_axis_name(
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx2'] = da.data['yy', 1]
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -14,7 +14,7 @@ def nexus_group(request):
     return request.param
 
 
-def test_guessed_dims_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+def test_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     builder = NexusBuilder()
     da = sc.DataArray(
@@ -26,7 +26,7 @@ def test_guessed_dims_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]
         assert sc.identical(loaded, da)
 
 
-def test_guessed_dims_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+def test_with_coords_matching_axis_names(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     builder = NexusBuilder()
     da = sc.DataArray(
@@ -39,8 +39,8 @@ def test_guessed_dims_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert sc.identical(loaded, da)
 
 
-def test_guessed_dims_with_multiple_coords_per_dim(nexus_group: Tuple[Callable,
-                                                                      LoadFromNexus]):
+def test_guessed_dim_for_coord_not_matching_axis_name(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     builder = NexusBuilder()
     da = sc.DataArray(
@@ -49,6 +49,72 @@ def test_guessed_dims_with_multiple_coords_per_dim(nexus_group: Tuple[Callable,
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_guessed_dim_for_2d_coord_not_matching_axis_name(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx2'] = da.data
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_raises_if_dim_guessing_not_possible_due_to_transposition(
+        nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx2'] = sc.transpose(da.data)
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        with pytest.raises(nexus.NexusStructureError):
+            data[...]
+
+
+def test_integer_indices_attribute_for_coord(nexus_group: Tuple[Callable,
+                                                                LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
+    da.coords['yy2'] = da.data['xx', 0]
+    builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': 1}))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_list_indices_attribute_for_coord(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
+    da.coords['yy2'] = da.data['xx', 0]
+    builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': [1]}))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_transpose_indices_attribute_for_coord(nexus_group: Tuple[Callable,
+                                                                  LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
+    da.coords['xx2'] = sc.transpose(da.data)
+    builder.add_data(Data(name='data1', data=da, attrs={'xx2_indices': [1, 0]}))
     with resource(builder)() as f:
         data = nexus.NXroot(f, loader)['entry/data1']
         loaded = data[...]

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -1,0 +1,55 @@
+from .nexus_test import open_nexus, open_json
+from .nexus_helpers import NexusBuilder, Data
+from typing import Callable, Tuple
+import scipp as sc
+from scippneutron.file_loading._nexus import LoadFromNexus
+from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
+from scippneutron.file_loading._json_nexus import LoadFromJson
+from scippneutron import nexus
+import pytest
+
+
+@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+def nexus_group(request):
+    return request.param
+
+
+def test_guessed_dims_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_guessed_dims_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx'] = da.data['yy', 0]
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)
+
+
+def test_guessed_dims_with_multiple_coords_per_dim(nexus_group: Tuple[Callable,
+                                                                      LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx'] = da.data['yy', 0]
+    da.coords['xx2'] = da.data['yy', 1]
+    da.coords['yy'] = da.data['xx', 0]
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        assert sc.identical(loaded, da)

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -128,7 +128,7 @@ def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Tuple[Callable,
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['xx', 0]
-    # We flag 'xx' as auxiliary_signal. It should this not be loaded as a coord.
+    # We flag 'xx' as auxiliary_signal. It should thus not be loaded as a coord.
     builder.add_data(Data(name='data1', data=da, attrs={'auxiliary_signals': ['xx']}))
     with resource(builder)() as f:
         data = nexus.NXroot(f, loader)['entry/data1']

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -119,3 +119,19 @@ def test_transpose_indices_attribute_for_coord(nexus_group: Tuple[Callable,
         data = nexus.NXroot(f, loader)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
+
+
+def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Tuple[Callable,
+                                                                    LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx'] = da.data['xx', 0]
+    # We flag 'xx' as auxiliary_signal. It should this not be loaded as a coord.
+    builder.add_data(Data(name='data1', data=da, attrs={'auxiliary_signals': ['xx']}))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        loaded = data[...]
+        del da.coords['xx']
+        assert sc.identical(loaded, da)


### PR DESCRIPTION
Fixes #292, and attempts to load axes even if those attributes are not present, as recommended in https://manual.nexusformat.org/classes/base_classes/NXdata.html#nxdata-axisname-indices-attribute.