### PR TITLE
Change `nexus.Field` dim labels to use parent class dims

### DIFF
--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -162,7 +162,7 @@ def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:
     return select
 
 
-def to_plain_index(dims: List[str], select: ScippIndex, ignore_missing: bool = False):
+def to_plain_index(dims: List[str], select: ScippIndex):
     """
     Given a valid "scipp" index 'select', return an equivalent plain numpy-style index.
     """
@@ -171,7 +171,7 @@ def to_plain_index(dims: List[str], select: ScippIndex, ignore_missing: bool = F
         raise ValueError("Cannot process index {select}.")
     index = [slice(None)] * len(dims)
     for key, sel in select.items():
-        if not ignore_missing and key not in dims:
+        if key not in dims:
             raise ValueError(
                 f"'{key}' used for indexing not found in dataset dims {dims}.")
         index[dims.index(key)] = sel

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -159,6 +159,8 @@ def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:
     elif isinstance(select, int) or isinstance(select, slice):
         check_1d()
         return {dims[0]: select}
+    if not isinstance(select, dict):
+        raise ValueError("Cannot process index {select}.")
     return select
 
 
@@ -167,8 +169,6 @@ def to_plain_index(dims: List[str], select: ScippIndex):
     Given a valid "scipp" index 'select', return an equivalent plain numpy-style index.
     """
     select = _to_canonical_select(dims, select)
-    if not isinstance(select, dict):
-        raise ValueError("Cannot process index {select}.")
     index = [slice(None)] * len(dims)
     for key, sel in select.items():
         if key not in dims:

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -156,7 +156,7 @@ def to_plain_index(dims: List[str], select: ScippIndex, ignore_missing: bool = F
     if isinstance(select, tuple):
         check_1d()
         if len(select) != 1:
-            raise ValueError(f"Dataset a single dimension {dims}, "
+            raise ValueError(f"Dataset has single dimension {dims}, "
                              "but multiple indices {select} were specified.")
         return select[0]
     elif isinstance(select, int) or isinstance(select, slice):

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -164,7 +164,7 @@ def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:
     return select
 
 
-def to_plain_index(dims: List[str], select: ScippIndex):
+def to_plain_index(dims: List[str], select: ScippIndex) -> Union[int, tuple]:
     """
     Given a valid "scipp" index 'select', return an equivalent plain numpy-style index.
     """

--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -160,7 +160,7 @@ def _to_canonical_select(dims: List[str], select: ScippIndex) -> ScippIndex:
         check_1d()
         return {dims[0]: select}
     if not isinstance(select, dict):
-        raise ValueError("Cannot process index {select}.")
+        raise ValueError(f"Cannot process index {select}.")
     return select
 
 

--- a/src/scippneutron/file_loading/_detector_data.py
+++ b/src/scippneutron/file_loading/_detector_data.py
@@ -222,6 +222,13 @@ class NXevent_data(NXobject):
     def _getitem(self, index: ScippIndex) -> sc.DataArray:
         return _load_event_group(self._group, self._loader, quiet=True, select=index)
 
+    def _get_field_dims(self, name: str) -> Union[None, List[str]]:
+        if name in ['event_time_zero', 'event_index']:
+            return [_pulse_dimension]
+        if name in ['event_time_offset', 'event_id']:
+            return [_event_dimension]
+        return None
+
 
 def _load_event_group(group: Group, nexus: LoadFromNexus, quiet: bool,
                       select=tuple()) -> DetectorData:

--- a/src/scippneutron/file_loading/_monitor_data.py
+++ b/src/scippneutron/file_loading/_monitor_data.py
@@ -38,6 +38,17 @@ class NXmonitor(NXobject):
         # attribute in the file, so we pass this explicitly to NXdata.
         return NXdata(self._group, self._loader, signal='data')
 
+    def _get_field_dims(self, name: str) -> Union[None, List[str]]:
+        if self._is_events:
+            if name in [
+                    'event_time_zero', 'event_index', 'event_time_offset', 'event_id'
+            ]:
+                # Event field is direct child of this class
+                return self._nxbase._get_field_dims(name)
+            else:
+                return self.dims
+        return self._nxbase._get_field_dims(name)
+
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         """
         Load monitor data. Event-mode data takes precedence over histogram-mode data.

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -97,17 +97,11 @@ class NXdata(NXobject):
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         dims = self.dims
         index = to_plain_index(dims, select)
-        signal = self._loader.load_dataset(self._group,
-                                           self._signal_name,
-                                           dimensions=dims,
-                                           index=index)
+        signal = self[self._signal_name][index]
         if self._errors_name in self:
-            stddevs = self._loader.load_dataset(self._group,
-                                                self._errors_name,
-                                                dimensions=dims,
-                                                index=index)
+            stddevs = self[self._errors_name][index]
             signal.variances = sc.pow(stddevs, 2).values
-        da = sc.DataArray(data=signal)
+        da = sc.DataArray(data=signal.rename_dims(dict(zip(signal.dims, dims))))
 
         skip = self._skip
         skip += [self._signal_name, self._errors_name]
@@ -128,9 +122,7 @@ class NXdata(NXobject):
             else:
                 dims = self._guess_dims(da, name)
             index = to_plain_index(dims, select, ignore_missing=True)
-            da.coords[name] = self._loader.load_dataset(self._group,
-                                                        name,
-                                                        dimensions=dims,
-                                                        index=index)
+            coord = self[name][index]
+            da.coords[name] = coord.rename_dims(dict(zip(coord.dims, dims)))
 
         return da

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -53,7 +53,7 @@ class NXdata(NXobject):
             return name
         # Legacy NXdata defines signal not as group attribute, but attr on dataset
         for name in self.keys():
-            if self._get_child(name, use_field_dims=False).attrs.get('signal') == 1:
+            if self._get_child(name).attrs.get('signal') == 1:
                 return name
         return None
 
@@ -66,7 +66,7 @@ class NXdata(NXobject):
 
     @property
     def _signal(self) -> Dataset:
-        return self._get_child(self._signal_name, use_field_dims=False)
+        return self._get_child(self._signal_name)
 
     def _get_axes(self):
         """Return labels of named axes."""
@@ -86,7 +86,9 @@ class NXdata(NXobject):
         for d, s in zip(self.dims, self.shape):
             if self.shape.count(s) == 1:
                 lut[s] = d
-        shape = self._get_child(name, use_field_dims=False).shape
+        shape = self._get_child(name).shape
+        if self.shape == shape:
+            return self.dims
         try:
             dims = [lut[s] for s in shape]
         except KeyError:

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 from typing import List, Union
+from warnings import warn
 import scipp as sc
 import numpy as np
 from ._common import to_child_select, Dataset, Group
@@ -129,6 +130,10 @@ class NXdata(NXobject):
         for name, field in self.items():
             if (not isinstance(field, Field)) or (name in skip):
                 continue
-            da.coords[name] = self[name][to_child_select(self.dims, field.dims, select)]
+            try:
+                sel = to_child_select(self.dims, field.dims, select)
+                da.coords[name] = self[name][sel]
+            except sc.DimensionError as e:
+                warn(f"Skipped load of axis {name} due to: {e}")
 
         return da

--- a/src/scippneutron/file_loading/nxlog.py
+++ b/src/scippneutron/file_loading/nxlog.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
 
-from typing import Tuple, List, Dict
+from typing import Tuple, List, Dict, Union
 import scipp as sc
 from ._common import (BadSource, SkipSource, MissingDataset, Group,
                       convert_time_to_datetime64)
@@ -65,7 +65,7 @@ class NXlog(NXobject):
 
     @property
     def _nxbase(self) -> NXdata:
-        axes = ['.'] * self['value'].ndim
+        axes = ['.'] * self._get_child('value', use_field_dims=False).ndim
         # The outermost axis in NXlog is pre-defined to 'time' (if present). Note
         # that this may be overriden by an `axes` attribute, if defined for the group.
         if 'time' in self:
@@ -87,6 +87,9 @@ class NXlog(NXobject):
                 scaling_factor=self['time'].attrs.get('scaling_factor'),
                 group_path=self['time'].name)
         return data
+
+    def _get_field_dims(self, name: str) -> Union[None, List[str]]:
+        return self._nxbase._get_field_dims(name)
 
 
 def _load_log_data_from_group(group: Group, nexus: LoadFromNexus, select=tuple())\

--- a/src/scippneutron/file_loading/nxlog.py
+++ b/src/scippneutron/file_loading/nxlog.py
@@ -81,6 +81,9 @@ class NXlog(NXobject):
         # 'scaling_factor' that are not handled by NXdata. These are used
         # to transform to a datetime-coord.
         if 'time' in self:
+            if 'time' not in data.coords:
+                raise sc.DimensionError(
+                    "NXlog is time-dependent, but failed to load `time` dataset")
             data.coords['time'] = convert_time_to_datetime64(
                 raw_times=data.coords.pop('time'),
                 start=self['time'].attrs.get('start'),

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -126,7 +126,7 @@ class NXobject:
             self,
             name: NXobjectIndex,
             use_field_dims: bool = False) -> Union['__class__', Field, sc.DataArray]:
-        """Get item, with flag to control whether fields diems should be inferred"""
+        """Get item, with flag to control whether fields dims should be inferred"""
         if name is None:
             raise KeyError("None is not a valid index")
         if isinstance(name, str):

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -125,7 +125,7 @@ class NXobject:
     def _get_child(
             self,
             name: NXobjectIndex,
-            use_field_dims: bool = True) -> Union['__class__', Field, sc.DataArray]:
+            use_field_dims: bool = False) -> Union['__class__', Field, sc.DataArray]:
         """Get item, with flag to control whether fields diems should be inferred"""
         if name is None:
             raise KeyError("None is not a valid index")

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -120,8 +120,11 @@ class NXobject:
         nx_class = self._loader.get_string_attribute(group, 'NX_class')
         return _nx_class_registry().get(nx_class, NXobject)(group, self._loader)
 
-    def __getitem__(self,
-                    name: NXobjectIndex) -> Union['__class__', Field, sc.DataArray]:
+    def _get_child(
+            self,
+            name: NXobjectIndex,
+            use_field_dims: bool = True) -> Union['__class__', Field, sc.DataArray]:
+        """Get item, with flag to control whether fields diems should be inferred"""
         if name is None:
             raise KeyError("None is not a valid index")
         if isinstance(name, str):
@@ -131,8 +134,13 @@ class NXobject:
             if self._loader.is_group(item):
                 return self._make(item)
             else:
-                return Field(item, self._loader, dims=self._get_field_dims(name))
+                dims = self._get_field_dims(name) if use_field_dims else None
+                return Field(item, self._loader, dims=dims)
         return self._getitem(name)
+
+    def __getitem__(self,
+                    name: NXobjectIndex) -> Union['__class__', Field, sc.DataArray]:
+        return self._get_child(name, use_field_dims=True)
 
     def _getitem(self, index: ScippIndex) -> NoReturn:
         raise NotImplementedError(f'Loading {self.nx_class} is not supported.')

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -10,6 +10,7 @@ from typing import List, Union, NoReturn, Any, Dict, Tuple
 from ._nexus import LoadFromNexus
 from ._hdf5_nexus import LoadFromHdf5
 from ._common import Group, Dataset, MissingAttribute, ScippIndex
+from ._common import to_plain_index
 
 NXobjectIndex = Union[str, ScippIndex]
 
@@ -70,7 +71,8 @@ class Field:
         self._loader = loader
         self._dims = [f'dim_{i}' for i in range(self.ndim)] if dims is None else dims
 
-    def __getitem__(self, index) -> np.ndarray:
+    def __getitem__(self, select) -> np.ndarray:
+        index = to_plain_index(self.dims, select)
         return self._loader.load_dataset_direct(self._dataset,
                                                 dimensions=self.dims,
                                                 index=index)

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -201,6 +201,22 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert field.unit == sc.Unit('ns')
 
 
+def test_field_dim_labels(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    with resource(builder_with_events_monitor_and_log())() as f:
+        event_data = nexus.NXroot(f, loader)['entry/events_0']
+        assert event_data['event_time_offset'].dims == ['event']
+        assert event_data['event_time_zero'].dims == ['pulse']
+        assert event_data['event_index'].dims == ['pulse']
+        assert event_data['event_id'].dims == ['event']
+        log = nexus.NXroot(f, loader)['entry/log']
+        assert log['time'].dims == ['time']
+        assert log['value'].dims == ['time']
+        monitor = nexus.NXroot(f, loader)['monitor']
+        assert monitor['time_of_flight'].dims == ['time_of_flight']
+        assert monitor['data'].dims == ['time_of_flight']
+
+
 def test_field_unit_is_none_if_no_units_attribute(nexus_group: Tuple[Callable,
                                                                      LoadFromNexus]):
     resource, loader = nexus_group

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -71,8 +71,7 @@ def test_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_slice_of_1d(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     builder = NexusBuilder()
-    da = sc.DataArray(
-        sc.array(dims=['xx'], unit='m', values=[1, 2, 3]))
+    da = sc.DataArray(sc.array(dims=['xx'], unit='m', values=[1, 2, 3]))
     da.coords['xx'] = da.data
     da.coords['xx2'] = da.data
     da.coords['scalar'] = sc.scalar(1.2)

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -86,12 +86,13 @@ def test_raises_if_dim_guessing_finds_ambiguous_shape(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     builder = NexusBuilder()
-    da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
         data = nexus.NXroot(f, loader)['entry/data1']
-        with pytest.raises(nexus.NexusStructureError):
+        with pytest.raises(sc.DimensionError):
             data[...]
 
 

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -68,6 +68,35 @@ def test_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert sc.identical(loaded, da)
 
 
+def test_slice_of_1d(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx'], unit='m', values=[1, 2, 3]))
+    da.coords['xx'] = da.data
+    da.coords['xx2'] = da.data
+    da.coords['scalar'] = sc.scalar(1.2)
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        assert sc.identical(data['xx', :2], da['xx', :2])
+        assert sc.identical(data[:2], da['xx', :2])
+
+
+def test_slice_of_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
+    da.coords['xx'] = da.data['yy', 0]
+    da.coords['xx2'] = da.data['yy', 1]
+    da.coords['yy'] = da.data['xx', 0]
+    builder.add_data(Data(name='data1', data=da))
+    with resource(builder)() as f:
+        data = nexus.NXroot(f, loader)['entry/data1']
+        assert sc.identical(data['xx', :2], da['xx', :2])
+
+
 def test_guessed_dim_for_2d_coord_not_matching_axis_name(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -271,3 +271,21 @@ def test_can_load_nxdetector_from_bigfake():
     with nexus.File(scn.data.bigfake()) as f:
         da = f['entry/instrument/detector_1'][...]
         assert da.sizes == {'dim_0': 300, 'dim_1': 300}
+
+
+def test_event_data_field_dims_labels(nexus_group: Tuple[Callable, LoadFromNexus]):
+    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
+    event_data = EventData(
+        event_id=np.array([1, 2, 3, 1, 2, 2]),
+        event_time_offset=event_time_offsets,
+        event_time_zero=np.array([1, 2, 3, 4]),
+        event_index=np.array([0, 3, 3, 5]),
+    )
+    builder = NexusBuilder()
+    builder.add_detector(
+        Detector(detector_numbers=np.array([1, 2, 3, 4]), event_data=event_data))
+    resource, loader = nexus_group
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        assert detector['detector_number'].dims == ['detector_number']
+        assert detector['event_time_offset'].dims == ['event']

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -288,4 +288,3 @@ def test_event_data_field_dims_labels(nexus_group: Tuple[Callable, LoadFromNexus
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         assert detector['detector_number'].dims == ['detector_number']
-        assert detector['event_time_offset'].dims == ['event']


### PR DESCRIPTION
Previously accessing a field of a Nexus class used default dim labels such as `['dim_0', 'dim_1']`.

- Infer actual labels from containing Nexus class, where possible.
- Use slicing with labels also for fields. Previously this used plain numpy syntax, despite having (default) field labels, which was inconsistent.

Generally (with exceptions), this ensures that properties such as data or coords of a loaded group:

```python
group[some_index].data
group[some_index].coords[name]
```

are identical to loading the corresponding fields:

```python
group[data][some_index]
group[name][some_index]
```

(modulo restricting `some_index` to only index dims that the field contains).