### PR TITLE
Fix data streaming resource leak

### DIFF
--- a/docs/developer/data-stream.rst
+++ b/docs/developer/data-stream.rst
@@ -290,17 +290,20 @@ Try using ``scippneutron.data_stream``, for example
 
         import asyncio
         import scippneutron as scn
-        from scippneutron.data_streaming.data_stream import StartTime, StopTime
+        from scippneutron.data_streaming.data_stream import StartTime
 
         async def my_stream_func():
             detector_ids = sc.Variable(dims=["detector_id"],
                                        values=np.arange(32*288).astype(np.int32))
-            async for data in scn.data_stream('localhost:9092', run_info_topic="AMOR_runInfo",
-                                              start_time=StartTime.START_OF_RUN, stop_time=StopTime.END_OF_RUN,
+            async for data in scn.data_stream('localhost:9092',
+                                              run_info_topic="AMOR_runInfo",
+                                              start_time=StartTime.START_OF_RUN,
                                               interval=2. * sc.units.s):
                 events = sc.bin(data, groups=[detector_ids])
                 counts = events.bins.sum()
-                plot_data.values = plot_data.values + sc.fold(sc.flatten(counts, to="counts"), dim='counts', sizes={'y': 288, 'x': 32}).values
+                if "tof" in counts.dims:
+                    counts = counts["tof", 0].copy()
+                plot_data.values = plot_data.values + sc.fold(sc.flatten(counts, to="detector_id"), dim='detector_id', sizes={'y': 288, 'x': 32}).values
                 det_plot.redraw()
 
         streaming_task = asyncio.create_task(my_stream_func())

--- a/src/scippneutron/data_streaming/data_stream.py
+++ b/src/scippneutron/data_streaming/data_stream.py
@@ -225,12 +225,17 @@ async def _data_stream(
     # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
     # pytorch docs mention Queue problem:
     # https://pytorch.org/docs/stable/notes/multiprocessing.html
+    #
+    # Note also that daemonising this Process is important so that resources are
+    # properly freed when restarting the notebook kernel (or shutting down the
+    # notebook entirely).
     data_collect_process = mp.get_context("spawn").Process(
         target=data_consumption_manager,
         args=(start_time_ms, stop_time_ms, run_id, topics, kafka_broker, consumer_type,
               stream_info, interval_s, event_buffer_size, slow_metadata_buffer_size,
               fast_metadata_buffer_size, chopper_buffer_size, worker_instruction_queue,
-              data_queue, test_message_queue))
+              data_queue, test_message_queue),
+        daemon=True)
     try:
         data_stream_widget = DataStreamWidget(start_time_ms=start_time_ms,
                                               stop_time_ms=stop_time_ms,


### PR DESCRIPTION
Fixes a memory/thread leak in data streaming code when exiting a notebook while a streaming task in in progress. The code can still leak if the cell containing the streaming code is re-run but this seems much harder to fix and I have not come up with a good solution for this.