### PR TITLE
Refactor to remove old NXlog loading code

### DIFF
--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -6,7 +6,7 @@ import scipp as sc
 
 from ..nexus import NXroot, NX_class
 
-from ._common import Group, MissingDataset, BadSource
+from ._common import Group, MissingDataset, BadSource, SkipSource
 from ._detector_data import load_detector_data
 from ._monitor_data import load_monitor_data
 from ._hdf5_nexus import LoadFromHdf5
@@ -200,8 +200,9 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
     for name, log in classes.get(NX_class.NXlog, {}).items():
         try:
             logs[name] = sc.scalar(log[()])
-        except (RuntimeError, KeyError, BadSource) as e:
-            warn(f"Skipped loading {log.name} due to:\n{e}")
+        except (RuntimeError, KeyError, BadSource, SkipSource) as e:
+            if not nexus.contains_stream(log._group):
+                warn(f"Skipped loading {log.name} due to:\n{e}")
     add_metadata(logs)
 
     if groups[nx_monitor]:

--- a/tests/test_load_nexus.py
+++ b/tests/test_load_nexus.py
@@ -498,18 +498,13 @@ def test_loads_data_from_multiple_logs_with_same_name(load_function: Callable):
 
     loaded_data = load_function(builder)
 
-    # Expect two logs
-    # The log group name for one of them should have been prefixed with
-    # its the parent group name to avoid duplicate log names
-    if np.allclose(loaded_data[name].data.values.values, values_1):
-        # Then the other log should be
-        assert np.allclose(loaded_data[f"detector_0_{name}"].data.values.values,
-                           values_2)
-    elif np.allclose(loaded_data[name].data.values.values, values_2):
-        # Then the other log should be
-        assert np.allclose(loaded_data[f"entry_{name}"].data.values.values, values_1)
-    else:
-        assert False
+    assert len(loaded_data) == 2
+    for key, da in loaded_data.items():
+        assert key.endswith('test_log')
+        if 'detector_0' in key:
+            assert np.allclose(da.value.values, values_2)
+        else:
+            assert np.allclose(da.value.values, values_1)
 
 
 def test_load_instrument_name(load_function: Callable):


### PR DESCRIPTION
First step for moving beyond the old Nexus loading code. Whether the added code in `_load_data` will stay like this, or will be refactored later to use a build is not clear yet. Existing tests pass, so I have to assume that this implementation is equivalent.

Similar steps for other Nexus classes will follow, but some classes are still missing or incomplete. I will try to do this step by step.