### PR TITLE
Refactor NXdetector

### DIFF
--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -184,7 +184,10 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
             det = det.flatten(to='detector_id')
             det.bins.coords['tof'] = det.bins.coords.pop('event_time_offset')
             det.bins.coords['pulse_time'] = det.bins.coords.pop('event_time_zero')
-            det.coords['detector_id'] = det.coords.pop('detector_number')
+            if 'detector_number' in det.coords:
+                det.coords['detector_id'] = det.coords.pop('detector_number')
+            else:
+                det.coords['detector_id'] = det.coords.pop('pixel_id')
             if 'pixel_offset' in det.coords:
                 add_position_and_transforms_to_data(
                     data=det,

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from __future__ import annotations
 from typing import List, Union
 from warnings import warn
 import scipp as sc
@@ -16,16 +17,21 @@ class NXdata(NXobject):
                  group: Group,
                  loader: LoadFromNexus = LoadFromHdf5(),
                  signal_name_default: str = None,
-                 signal=None,
+                 signal_override: Union[Field, EventField] = None,
                  axes: List[str] = None,
                  skip: List[str] = None):
         """
-        :param signal: Default signal name used, if no `signal` attribute found in file.
+        :param signal_name_default: Default signal name used, if no `signal`
+            attribute found in file.
+        :param signal_override Signal field-like to use instead of trying to read
+            signal from the file. This is used when there is no signal or to provide
+            a signal computed from NXevent_data
         :param axes: Default axes used, if no `axes` attribute found in file.
+        :param skip: Names of fields to skip when loading coords.
         """
         super().__init__(group, loader)
         self._signal_name_default = signal_name_default
-        self._signal_override = signal
+        self._signal_override = signal_override
         self._axes_default = axes
         self._skip = skip if skip is not None else []
 
@@ -71,7 +77,7 @@ class NXdata(NXobject):
             return f'{self._signal_name_default}_errors'
 
     @property
-    def _signal(self) -> Field:
+    def _signal(self) -> Union[Field, EventField]:
         if self._signal_override is not None:
             return self._signal_override
         return self[self._signal_name]

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -18,7 +18,7 @@ class NXdata(NXobject):
             group: Group,
             loader: LoadFromNexus = LoadFromHdf5(),
             signal_name_default: str = None,
-            signal_override: Union[Field, EventField] = None,  # noqa: F821
+            signal_override: Union[Field, _EventField] = None,  # noqa: F821
             axes: List[str] = None,
             skip: List[str] = None):
         """
@@ -78,7 +78,7 @@ class NXdata(NXobject):
             return f'{self._signal_name_default}_errors'
 
     @property
-    def _signal(self) -> Union[Field, EventField]:  # noqa: F821
+    def _signal(self) -> Union[Field, _EventField]:  # noqa: F821
         if self._signal_override is not None:
             return self._signal_override
         return self[self._signal_name]

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -68,12 +68,12 @@ class NXdata(NXobject):
         return self._get_child(self._signal_name)
 
     def _get_axes(self):
-        """Return labels of named axes."""
+        """Return labels of named axes. Does not include default 'dim_{i}' names."""
         if (axes := self.attrs.get('axes', self._axes_default)) is not None:
             # Unlike self.dims we *drop* entries that are '.'
             return [a for a in axes if a != '.']
-        elif 'axes' in self._signal.attrs:
-            return self._signal.attrs['axes'].split(',')
+        elif (axes := self._signal.attrs.get('axes')) is not None:
+            return axes.split(',')
         return []
 
     def _guess_dims(self, name: str):

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -149,6 +149,6 @@ class NXdata(NXobject):
                 sel = to_child_select(self.dims, field.dims, select)
                 da.coords[name] = self[name][sel]
             except sc.DimensionError as e:
-                warn(f"Skipped load of axis {name} due to: {e}")
+                warn(f"Skipped load of axis {field.name} due to:\n{e}")
 
         return da

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -54,7 +54,8 @@ class NXdata(NXobject):
             return name
         # Legacy NXdata defines signal not as group attribute, but attr on dataset
         for name in self.keys():
-            if self._get_child(name).attrs.get('signal') == 1:
+            # TODO What is the meaning of the attribute value?
+            if 'signal' in self._get_child(name).attrs:
                 return name
         return None
 

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -35,12 +35,11 @@ class NXdata(NXobject):
     def dims(self) -> List[str]:
         # Apparently it is not possible to define dim labels unless there are
         # corresponding coords. Special case of '.' entries means "no coord".
-        if self.attrs.get('axes', self._axes_default) is not None:
-            axes = self.attrs.get('axes', self._axes_default)
+        if (axes := self.attrs.get('axes', self._axes_default)) is not None:
             return [f'dim_{i}' if a == '.' else a for i, a in enumerate(axes)]
         # Legacy NXdata defines axes not as group attribute, but attr on dataset
-        if 'axes' in self._signal.attrs:
-            return self._signal.attrs['axes'].split(',')
+        if (axes := self._signal.attrs.get('axes')) is not None:
+            return axes.split(',')
         return [f'dim_{i}' for i in range(len(self.shape))]
 
     @property

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -13,13 +13,14 @@ from ._hdf5_nexus import LoadFromHdf5
 
 
 class NXdata(NXobject):
-    def __init__(self,
-                 group: Group,
-                 loader: LoadFromNexus = LoadFromHdf5(),
-                 signal_name_default: str = None,
-                 signal_override: Union[Field, EventField] = None,
-                 axes: List[str] = None,
-                 skip: List[str] = None):
+    def __init__(
+            self,
+            group: Group,
+            loader: LoadFromNexus = LoadFromHdf5(),
+            signal_name_default: str = None,
+            signal_override: Union[Field, EventField] = None,  # noqa: F821
+            axes: List[str] = None,
+            skip: List[str] = None):
         """
         :param signal_name_default: Default signal name used, if no `signal`
             attribute found in file.
@@ -77,7 +78,7 @@ class NXdata(NXobject):
             return f'{self._signal_name_default}_errors'
 
     @property
-    def _signal(self) -> Union[Field, EventField]:
+    def _signal(self) -> Union[Field, EventField]:  # noqa: F821
         if self._signal_override is not None:
             return self._signal_override
         return self[self._signal_name]

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -15,7 +15,7 @@ class NXdata(NXobject):
     def __init__(self,
                  group: Group,
                  loader: LoadFromNexus = LoadFromHdf5(),
-                 signal: str = None,
+                 signal_name_default: str = None,
                  axes: List[str] = None,
                  skip: List[str] = None):
         """
@@ -23,7 +23,7 @@ class NXdata(NXobject):
         :param axes: Default axes used, if no `axes` attribute found in file.
         """
         super().__init__(group, loader)
-        self._signal_name_default = signal
+        self._signal_name_default = signal_name_default
         self._axes_default = axes
         self._skip = skip if skip is not None else []
 

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -37,10 +37,9 @@ class NXdata(NXobject):
         # corresponding coords. Special case of '.' entries means "no coord".
         if (axes := self.attrs.get('axes', self._axes_default)) is not None:
             return [f'dim_{i}' if a == '.' else a for i, a in enumerate(axes)]
-        # Legacy NXdata defines axes not as group attribute, but attr on dataset
-        if (axes := self._signal.attrs.get('axes')) is not None:
-            return axes.split(',')
-        return [f'dim_{i}' for i in range(len(self.shape))]
+        # Legacy NXdata defines axes not as group attribute, but attr on dataset.
+        # This is handled by class Field.
+        return self._signal.dims
 
     @property
     def unit(self) -> Union[sc.Unit, None]:
@@ -48,8 +47,7 @@ class NXdata(NXobject):
 
     @property
     def _signal_name(self) -> str:
-        name = self.attrs.get('signal', self._signal_name_default)
-        if name is not None:
+        if (name := self.attrs.get('signal', self._signal_name_default)) is not None:
             return name
         # Legacy NXdata defines signal not as group attribute, but attr on dataset
         for name in self.keys():

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -140,7 +140,7 @@ class NXdetector(NXobject):
     @property
     def _signal(self) -> Union[Field, NXevent_data_by_pixel]:
         if self._is_events:
-            return NXevent_data_by_pixel(self._nxbase, self._event_select,
+            return NXevent_data_by_pixel(self.events, self._event_select,
                                          self._detector_number)
         else:
             return self._nxdata._signal
@@ -157,20 +157,14 @@ class NXdetector(NXobject):
                       signal=signal_override)
 
     @property
-    def _nxbase(self) -> Union[NXdata, NXevent_data]:
-        """Return class for loading underlying data."""
-        if self._is_events:
-            if 'event_time_offset' in self:
-                return NXevent_data(self._group, self._loader)
-            event_entries = self.by_nx_class()[NX_class.NXevent_data]
-            return next(iter(event_entries.values()))
-        return self._nxdata
-
-    @property
     def events(self) -> Union[None, NXevent_data]:
         """Return the underlying NXevent_data group, None if not event data."""
-        if self._is_events:
-            return self._nxbase
+        if not self._is_events:
+            return None
+        if 'event_time_offset' in self:
+            return NXevent_data(self._group, self._loader)
+        event_entries = self.by_nx_class()[NX_class.NXevent_data]
+        return next(iter(event_entries.values()))
 
     @property
     def select_events(self) -> EventSelector:
@@ -189,7 +183,7 @@ class NXdetector(NXobject):
                     'event_time_zero', 'event_index', 'event_time_offset', 'event_id'
             ]:
                 # Event field is direct child of this class
-                return self._nxbase._get_field_dims(name)
+                return self.events._get_field_dims(name)
             if name == 'detector_number':
                 return None  # TODO We can probably do better here
         return self._nxdata._get_field_dims(name)

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -135,10 +135,11 @@ class NXdetector(NXobject):
         return 'event_time_offset' in self
 
     @property
-    def _detector_number(self) -> Field:
-        if 'detector_number' in self:
-            return self['detector_number']
-        return self.get('pixel_id', None)
+    def _detector_number(self) -> Union[None, Field]:
+        for key in self._detector_number_fields:
+            if key in self:
+                return self[key]
+        return None
 
     @property
     def _signal(self) -> Union[Field, NXevent_data_by_pixel]:

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -23,8 +23,8 @@ class EventSelector:
         return det
 
 
-class NXevent_data_by_pixel:
-    """NXevent_data binned into pixels.
+class EventField:
+    """Field-like wrapper of NXevent_data binned into pixels.
 
     This has no equivalent in the NeXus format, but represents the conceptual
     event-data "signal" dataset of an NXdetector.
@@ -145,13 +145,12 @@ class NXdetector(NXobject):
         return None
 
     @property
-    def _signal(self) -> Union[Field, NXevent_data_by_pixel]:
+    def _signal(self) -> Union[Field, EventField]:
         return self._nxdata()._signal
 
     def _nxdata(self, use_event_signal=True) -> NXdata:
         if use_event_signal and self._is_events:
-            signal = NXevent_data_by_pixel(self.events, self._event_select,
-                                           self._detector_number)
+            signal = EventField(self.events, self._event_select, self._detector_number)
         else:
             signal = None
         # NXdata uses the 'signal' attribute to define the field name of the signal.
@@ -160,7 +159,7 @@ class NXdetector(NXobject):
         return NXdata(self._group,
                       self._loader,
                       signal_name_default='data' if 'data' in self else None,
-                      signal=signal,
+                      signal_override=signal,
                       skip=self._nxevent_data_fields)
 
     @property

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -3,7 +3,7 @@
 # @author Simon Heybrock
 from __future__ import annotations
 from copy import copy
-from typing import List, Union
+from typing import List, Optional, Union
 import scipp as sc
 from .nxobject import NX_class, NXobject, Field, ScippIndex, NexusStructureError
 from .nxdata import NXdata
@@ -32,7 +32,7 @@ class _EventField:
     def __init__(self,
                  nxevent_data: NXevent_data,
                  event_select: ScippIndex,
-                 detector_number: Field = None):
+                 detector_number: Optional[Field] = None):
         self._nxevent_data = nxevent_data
         self._event_select = event_select
         self._detector_number = detector_number
@@ -62,7 +62,7 @@ class _EventField:
     def __getitem__(self, select: ScippIndex) -> sc.DataArray:
         event_data = self._nxevent_data[self._event_select]
         if self._detector_number is None:
-            if select not in (Ellipsis, tuple()) and select != slice(None):
+            if select not in (Ellipsis, tuple(), slice(None)):
                 raise NexusStructureError(
                     "Cannot load slice of NXdetector since it contains event data "
                     "but no 'detector_number' field, i.e., the shape is unknown. "

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -24,6 +24,66 @@ class EventSelector:
         return det
 
 
+class NXevent_data_by_pixel:
+    """NXevent_data binned into pixels.
+
+    This has no equivalent in the NeXus format, but represents the conceptual
+    event-data "signal" of an NXdetector.
+    """
+    def __init__(self,
+                 nxevent_data: NXevent_data,
+                 event_select: ScippIndex,
+                 detector_number: Field = None):
+        self._nxevent_data = nxevent_data
+        self._event_select = event_select
+        self._detector_number = detector_number
+
+    @property
+    def dims(self):
+        if self._detector_number is None:
+            return ['detector_number']
+        return self._detector_number.dims
+
+    @property
+    def shape(self):
+        if self._detector_number is None:
+            raise NexusStructureError(
+                "Cannot get shape of NXdetector since no 'detector_number' "
+                "field found but detector contains event data.")
+        return self._detector_number.shape
+
+    def __getitem__(self, select) -> sc.Variable:
+        event_data = self._nxevent_data[self._event_select]
+        if self._detector_number is None:
+            if select not in (Ellipsis, tuple()) and select != slice(None):
+                raise NexusStructureError(
+                    "Cannot load slice of NXdetector since it contains event data "
+                    "but no 'detector_number' field, i.e., the shape is unknown. "
+                    "Use ellipsis or an empty tuple to load the full detector.")
+            # Ideally we would prefer to use np.unique, but a quick experiment shows
+            # that this can easily be 100x slower, so it is not an option. In
+            # practice most files have contiguous event_id values within a bank
+            # (NXevent_data).
+            id_min = event_data.bins.coords['event_id'].min()
+            id_max = event_data.bins.coords['event_id'].max()
+            detector_number = sc.arange(dim='detector_number',
+                                        unit=None,
+                                        start=id_min.value,
+                                        stop=id_max.value + 1,
+                                        dtype=id_min.dtype)
+        else:
+            detector_number = self._detector_number[select]
+        event_id = detector_number.flatten(to='event_id')
+        event_data.bins.coords['event_time_zero'] = sc.bins_like(
+            event_data, fill_value=event_data.coords['event_time_zero'])
+        # After loading raw NXevent_data it is guaranteed that the event table
+        # is contiguous and that there is no masking. We can therefore use the
+        # more efficient approach of binning from scratch instead of erasing the
+        # 'pulse' binning defined by NXevent_data.
+        event_data = sc.bin(event_data.bins.constituents['data'], groups=[event_id])
+        return event_data.fold(dim='event_id', sizes=detector_number.sizes)
+
+
 class NXdetector(NXobject):
     """A detector or detector bank providing an array of values or events.
 
@@ -37,43 +97,48 @@ class NXdetector(NXobject):
 
     @property
     def shape(self) -> List[int]:
-        if self._is_events:
-            if (signal := self._signal) is not None:
-                return signal.shape
-            if self._detector_number is None:
-                raise NexusStructureError(
-                    "Cannot get shape of NXdetector since no 'detector_number' "
-                    "field found but detector contains event data.")
-            return self._detector_number.shape
-        return self._nxbase.shape
+        return self._signal.shape
+        #if self._is_events:
+        #    if (signal := self._signal) is not None:
+        #        return signal.shape
+        #    if self._detector_number is None:
+        #        raise NexusStructureError(
+        #            "Cannot get shape of NXdetector since no 'detector_number' "
+        #            "field found but detector contains event data.")
+        #    return self._detector_number.shape
+        #return self._nxbase.shape
 
     @property
     def dims(self) -> List[str]:
-        if (signal := self._signal) is not None:
-            return signal.dims
-        if self._is_events:
-            default = [f'dim_{i}' for i in range(self.ndim)]
-            if len(default) == 1:
-                default = ['detector_number']
-            # The NeXus standard is lacking information on a number of details on
-            # NXdetector, but according to personal communication with Tobias Richter
-            # it is "intended" to partially "subclass" NXdata. That is, e.g., attributes
-            # defined for NXdata such as 'axes' may be used.
-            return self.attrs.get('axes', default)
-        return self._nxbase.dims
+        return self._signal.dims
+        #if (signal := self._signal) is not None:
+        #    return signal.dims
+        #if self._is_events:
+        #    default = [f'dim_{i}' for i in range(self.ndim)]
+        #    if len(default) == 1:
+        #        default = ['detector_number']
+        #    # The NeXus standard is lacking information on a number of details on
+        #    # NXdetector, but according to personal communication with Tobias Richter
+        #    # it is "intended" to partially "subclass" NXdata. That is, e.g., attributes
+        #    # defined for NXdata such as 'axes' may be used.
+        #    return self.attrs.get('axes', default)
+        #return self._nxbase.dims
 
     @property
     def ndim(self) -> int:
         if self._is_events:
-            if 'detector_number' not in self:
-                return 1
-            det_field = self._get_child('detector_number')
-            return det_field.ndim
-        return self['data'].ndim
+            return self._detector_number.ndim
+        return self._signal.ndim
+        #if self._is_events:
+        #    if 'detector_number' not in self:
+        #        return 1
+        #    det_field = self._get_child('detector_number')
+        #    return det_field.ndim
+        #return self['data'].ndim
 
     @property
     def unit(self) -> Union[sc.Unit, None]:
-        return self._nxbase.unit
+        return self._signal.unit
 
     @property
     def _is_events(self) -> bool:
@@ -92,10 +157,15 @@ class NXdetector(NXobject):
 
     @property
     def _signal(self) -> Union[Field, None]:
-        nxdata = self._nxdata
-        name = nxdata._signal_name
-        if name is not None and name in nxdata:
-            return nxdata._signal
+        if self._is_events:
+            return NXevent_data_by_pixel(self._nxbase, self._event_select,
+                                         self._detector_number)
+        else:
+            return self._nxbase._signal
+        #nxdata = self._nxdata
+        #name = nxdata._signal_name
+        #if name is not None and name in nxdata:
+        #    return nxdata._signal
 
     @property
     def _nxdata(self) -> NXdata:
@@ -104,8 +174,7 @@ class NXdetector(NXobject):
         # attribute in the file, so we pass this explicitly to NXdata.
         return NXdata(self._group,
                       self._loader,
-                      signal='data' if 'data' in self else None,
-                      skip=['detector_number'])
+                      signal='data' if 'data' in self else None)
 
     @property
     def _nxbase(self) -> Union[NXdata, NXevent_data]:
@@ -183,48 +252,19 @@ class NXdetector(NXobject):
             ]:
                 # Event field is direct child of this class
                 return self._nxbase._get_field_dims(name)
-            elif self._signal is None:
-                return self.dims
-            else:
-                self._nxdata._get_field_dims(name)
-        return self._nxdata._get_field_dims(name)
+        if self._nxdata._signal_name is not None:
+            return self._nxdata._get_field_dims(name)
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         # Note that ._detector_data._load_detector provides a different loading
         # facility for NXdetector but handles only loading of detector_number,
         # as needed for event data loading
         coords = {
-            'detector_number': self.detector_number(select),
+            #'detector_number': self.detector_number(select),
             'pixel_offset': self.pixel_offset(select)
         }
         if self._is_events:
-            # If there is a 'detector_number' field it is used to bin events into
-            # detector pixels. Note that due to the nature of NXevent_data, which stores
-            # events from all pixels and random order, we always have to load the entire
-            # bank. Slicing with the provided 'select' is done while binning.
-            event_data = self._nxbase[self._event_select]
-            if coords['detector_number'] is None:
-                # Ideally we would prefer to use np.unique, but a quick experiment shows
-                # that this can easily be 100x slower, so it is not an option. In
-                # practice most files have contiguous event_id values within a bank
-                # (NXevent_data).
-                id_min = event_data.bins.coords['event_id'].min()
-                id_max = event_data.bins.coords['event_id'].max()
-                coords['detector_number'] = sc.arange(dim='detector_number',
-                                                      unit=None,
-                                                      start=id_min.value,
-                                                      stop=id_max.value + 1,
-                                                      dtype=id_min.dtype)
-            event_id = coords['detector_number'].flatten(to='event_id')
-            event_data.bins.coords['event_time_zero'] = sc.bins_like(
-                event_data, fill_value=event_data.coords['event_time_zero'])
-            # After loading raw NXevent_data it is guaranteed that the event table
-            # is contiguous and that there is no masking. We can therefore use the
-            # more efficient approach of binning from scratch instead of erasing the
-            # 'pulse' binning defined by NXevent_data.
-            event_data = sc.bin(event_data.bins.constituents['data'], groups=[event_id])
-            del event_data.coords['event_id']  # same as detector_number
-            da = event_data.fold(dim='event_id', sizes=coords['detector_number'].sizes)
+            da = self._signal[select]
         else:
             da = self._nxbase[select]
         for name, coord in coords.items():

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -88,7 +88,10 @@ class NXevent_data_by_pixel:
         # more efficient approach of binning from scratch instead of erasing the
         # 'pulse' binning defined by NXevent_data.
         event_data = sc.bin(event_data.bins.constituents['data'], groups=[event_id])
-        event_data.coords['detector_number'] = event_data.coords.pop('event_id')
+        if self._detector_number is None:
+            event_data.coords['detector_number'] = event_data.coords.pop('event_id')
+        else:
+            del event_data.coords['event_id']
         return event_data.fold(dim='event_id', sizes=detector_number.sizes)
 
 

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -23,7 +23,7 @@ class EventSelector:
         return det
 
 
-class EventField:
+class _EventField:
     """Field-like wrapper of NXevent_data binned into pixels.
 
     This has no equivalent in the NeXus format, but represents the conceptual
@@ -145,12 +145,12 @@ class NXdetector(NXobject):
         return None
 
     @property
-    def _signal(self) -> Union[Field, EventField]:
+    def _signal(self) -> Union[Field, _EventField]:
         return self._nxdata()._signal
 
     def _nxdata(self, use_event_signal=True) -> NXdata:
         if use_event_signal and self._is_events:
-            signal = EventField(self.events, self._event_select, self._detector_number)
+            signal = _EventField(self.events, self._event_select, self._detector_number)
         else:
             signal = None
         # NXdata uses the 'signal' attribute to define the field name of the signal.

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -142,7 +142,7 @@ class NXdetector(NXobject):
         # attribute in the file, so we pass this explicitly to NXdata.
         return NXdata(self._group,
                       self._loader,
-                      signal='data' if 'data' in self else None)
+                      signal_name_default='data' if 'data' in self else None)
 
     @property
     def _nxbase(self) -> Union[NXdata, NXevent_data]:

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -81,6 +81,7 @@ class NXevent_data_by_pixel:
         # more efficient approach of binning from scratch instead of erasing the
         # 'pulse' binning defined by NXevent_data.
         event_data = sc.bin(event_data.bins.constituents['data'], groups=[event_id])
+        event_data.coords['detector_number'] = event_data.coords['event_id']
         return event_data.fold(dim='event_id', sizes=detector_number.sizes)
 
 

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -28,7 +28,7 @@ class NXevent_data_by_pixel:
     """NXevent_data binned into pixels.
 
     This has no equivalent in the NeXus format, but represents the conceptual
-    event-data "signal" of an NXdetector.
+    event-data "signal" dataset of an NXdetector.
     """
     def __init__(self,
                  nxevent_data: NXevent_data,
@@ -52,7 +52,11 @@ class NXevent_data_by_pixel:
                 "field found but detector contains event data.")
         return self._detector_number.shape
 
-    def __getitem__(self, select) -> sc.Variable:
+    @property
+    def unit(self):
+        self._nxevent_data.unit
+
+    def __getitem__(self, select: ScippIndex) -> sc.DataArray:
         event_data = self._nxevent_data[self._event_select]
         if self._detector_number is None:
             if select not in (Ellipsis, tuple()) and select != slice(None):

--- a/src/scippneutron/file_loading/nxevent_data.py
+++ b/src/scippneutron/file_loading/nxevent_data.py
@@ -124,10 +124,9 @@ class NXevent_data(NXobject):
 
         try:
             binned = sc.bins(data=events, dim=_event_dimension, begin=begins, end=ends)
-        except sc.SliceError:
+        except sc.SliceError as e:
             raise BadSource(
-                f"Event index in NXevent_data at {self.name}/event_index "
-                "was not ordered. The index must be ordered to load pulse times.")
+                f"Invalid index in NXevent_data at {self.name}/event_index:\n{e}.")
 
         return sc.DataArray(data=binned, coords={'event_time_zero': event_time_zero})
 

--- a/src/scippneutron/file_loading/nxlog.py
+++ b/src/scippneutron/file_loading/nxlog.py
@@ -24,7 +24,7 @@ class NXlog(NXobject):
 
     @property
     def _nxbase(self) -> NXdata:
-        axes = ['.'] * self._get_child('value', use_field_dims=False).ndim
+        axes = ['.'] * self._get_child('value').ndim
         # The outermost axis in NXlog is pre-defined to 'time' (if present). Note
         # that this may be overriden by an `axes` attribute, if defined for the group.
         if 'time' in self:

--- a/src/scippneutron/file_loading/nxlog.py
+++ b/src/scippneutron/file_loading/nxlog.py
@@ -32,7 +32,7 @@ class NXlog(NXobject):
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXlog uses a "hard-coded" signal name 'value', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
-        return NXdata(self._group, self._loader, signal='value', axes=axes)
+        return NXdata(self._group, self._loader, signal_name_default='value', axes=axes)
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         data = self._nxbase[select]

--- a/src/scippneutron/file_loading/nxmonitor.py
+++ b/src/scippneutron/file_loading/nxmonitor.py
@@ -34,7 +34,7 @@ class NXmonitor(NXobject):
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXmonitor uses a "hard-coded" signal name 'data', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
-        return NXdata(self._group, self._loader, signal='data')
+        return NXdata(self._group, self._loader, signal_name_default='data')
 
     def _get_field_dims(self, name: str) -> Union[None, List[str]]:
         if self._is_events:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -71,7 +71,13 @@ class Field:
                  dims=None):
         self._dataset = dataset
         self._loader = loader
-        self._dims = [f'dim_{i}' for i in range(self.ndim)] if dims is None else dims
+        if dims is None:
+            if (axes := self.attrs.get('axes')) is not None:
+                self._dims = axes.split(',')
+            else:
+                self._dims = [f'dim_{i}' for i in range(self.ndim)]
+        else:
+            self._dims = dims
 
     def __getitem__(self, select) -> sc.Variable:
         index = to_plain_index(self.dims, select)
@@ -133,8 +139,11 @@ class NXobject:
         self._loader = loader
 
     def _make(self, group) -> '__class__':
-        nx_class = self._loader.get_string_attribute(group, 'NX_class')
-        return _nx_class_registry().get(nx_class, NXobject)(group, self._loader)
+        try:
+            nx_class = self._loader.get_string_attribute(group, 'NX_class')
+            return _nx_class_registry().get(nx_class, NXobject)(group, self._loader)
+        except MissingAttribute:
+            return group  # Return underlying (h5py) group
 
     def _get_child(
             self,

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -71,13 +71,12 @@ class Field:
                  dims=None):
         self._dataset = dataset
         self._loader = loader
-        if dims is None:
-            if (axes := self.attrs.get('axes')) is not None:
-                self._dims = axes.split(',')
-            else:
-                self._dims = [f'dim_{i}' for i in range(self.ndim)]
-        else:
+        if dims is not None:
             self._dims = dims
+        elif (axes := self.attrs.get('axes')) is not None:
+            self._dims = axes.split(',')
+        else:
+            self._dims = [f'dim_{i}' for i in range(self.ndim)]
 
     def __getitem__(self, select) -> sc.Variable:
         index = to_plain_index(self.dims, select)

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -273,6 +273,12 @@ def test_can_load_nxdetector_from_bigfake():
         assert da.sizes == {'dim_0': 300, 'dim_1': 300}
 
 
+def test_can_load_nxdetector_from_PG3():
+    with nexus.File(scn.data.get_path('PG3_4844_event.nxs')) as f:
+        da = f['entry/instrument/bank24'][...]
+        assert da.sizes == {'x_pixel_offset': 154, 'y_pixel_offset': 7}
+
+
 def test_event_data_field_dims_labels(nexus_group: Tuple[Callable, LoadFromNexus]):
     event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
     event_data = EventData(

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -272,8 +272,17 @@ def test_can_load_nxdetector_from_bigfake():
 
 def test_can_load_nxdetector_from_PG3():
     with nexus.File(scn.data.get_path('PG3_4844_event.nxs')) as f:
-        da = f['entry/instrument/bank24'][...]
+        det = f['entry/instrument/bank24']
+        da = det[...]
         assert da.sizes == {'x_pixel_offset': 154, 'y_pixel_offset': 7}
+        assert 'detector_number' not in da.coords
+        assert da.coords['pixel_id'].sizes == da.sizes
+        assert da.coords['distance'].sizes == da.sizes
+        assert da.coords['polar_angle'].sizes == da.sizes
+        assert da.coords['azimuthal_angle'].sizes == da.sizes
+        assert da.coords['x_pixel_offset'].sizes == {'x_pixel_offset': 154}
+        assert da.coords['y_pixel_offset'].sizes == {'y_pixel_offset': 7}
+        assert sc.identical(da.sum(), det.events[()].sum())  # no event lost in binning
 
 
 def test_event_data_field_dims_labels(nexus_group: Tuple[Callable, LoadFromNexus]):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -26,8 +26,8 @@ def test_raises_if_no_data_found(nexus_group: Tuple[Callable, LoadFromNexus]):
             detector[...]
 
 
-def test_raises_if_data_and_event_data_found(nexus_group: Tuple[Callable,
-                                                                LoadFromNexus]):
+def test_loads_events_when_data_and_events_found(nexus_group: Tuple[Callable,
+                                                                    LoadFromNexus]):
     resource, loader = nexus_group
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
     event_data = EventData(
@@ -38,13 +38,12 @@ def test_raises_if_data_and_event_data_found(nexus_group: Tuple[Callable,
     )
     builder = NexusBuilder()
     builder.add_detector(
-        Detector(detector_numbers=np.array([1, 2, 3, 4]),
+        Detector(detector_numbers=np.array([[1, 2], [3, 4]]),
                  data=da,
                  event_data=event_data))
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
-        with pytest.raises(nexus.NexusStructureError):
-            detector[...]
+        assert detector[...].bins is not None
 
 
 def test_loads_data_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -118,10 +118,7 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
         loaded = detector[...]
         assert sc.identical(
             loaded.bins.size().data,
-            sc.array(dims=['dim_0'],
-                     unit=None,
-                     dtype='int64',
-                     values=[2, 3, 1, 0]))
+            sc.array(dims=['dim_0'], unit=None, dtype='int64', values=[2, 3, 1, 0]))
         assert 'event_time_offset' in loaded.bins.coords
         assert 'event_time_zero' in loaded.bins.coords
 

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -113,12 +113,12 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
     resource, loader = nexus_group
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
-        assert detector.dims == ['detector_number']
+        assert detector.dims == ['dim_0']
         assert detector.shape == (4, )
         loaded = detector[...]
         assert sc.identical(
             loaded.bins.size().data,
-            sc.array(dims=['detector_number'],
+            sc.array(dims=['dim_0'],
                      unit=None,
                      dtype='int64',
                      values=[2, 3, 1, 0]))
@@ -287,7 +287,7 @@ def test_event_data_field_dims_labels(nexus_group: Tuple[Callable, LoadFromNexus
     resource, loader = nexus_group
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
-        assert detector['detector_number'].dims == ['detector_number']
+        assert detector['detector_number'].dims == ['dim_0']
 
 
 def test_nxevent_data_selection_yields_correct_pulses(

--- a/tests/test_load_nexus.py
+++ b/tests/test_load_nexus.py
@@ -681,7 +681,7 @@ def test_loads_pixel_positions_without_event_data(load_function: Callable):
         "Expected positions to be converted to metres"
 
 
-def test_skips_loading_pixel_positions_with_no_units(load_function: Callable):
+def test_loads_pixel_positions_with_no_units(load_function: Callable):
     pulse_times = np.array([
         1600766730000000000, 1600766731000000000, 1600766732000000000,
         1600766733000000000
@@ -707,10 +707,9 @@ def test_skips_loading_pixel_positions_with_no_units(load_function: Callable):
                  z_offsets=z_pixel_offset,
                  offsets_unit=None))
 
-    with pytest.warns(UserWarning):
-        loaded_data = load_function(builder)
+    loaded_data = load_function(builder)
 
-    assert loaded_data is None, "Load of NXdetector should be skipped"
+    assert loaded_data.coords['position'].unit is None
 
 
 def test_sample_position_at_origin_if_not_explicit_in_file(load_function: Callable):

--- a/tests/test_load_nexus.py
+++ b/tests/test_load_nexus.py
@@ -199,7 +199,7 @@ def test_does_not_load_events_if_index_not_ordered(load_function: Callable):
     builder.add_detector(
         Detector(detector_numbers=np.array([0, 1]), event_data=event_data_1))
 
-    with pytest.warns(UserWarning, match="Event index in NXevent_data at "):
+    with pytest.warns(UserWarning, match="Invalid index in NXevent_data at "):
         load_function(builder)
 
 


### PR DESCRIPTION
NXdetector suffers from ambiguities in definition of dimension labels and absence/presence of signal datasets and/or event data. The current implementation had gotten quite convoluted. This is an attempt to improve this.

By using more functionality from NXdata this thereby extends support of automatically loading additional datasets with metadata.

I am adding support for interpreting `pixel_id` as alternative name for `detector_number`. This is used at SNS, and I am unhappy about hard-coding this. I am not sure we want to keep this, but it is useful (and helped to uncover a number of issues with the old implementation) until we made up our minds about a potentially better solution.

The diff if `nxdetector.py` is probably not very enlightening, I recommend looking at the full file.