### PR TITLE
Refactor code for loading NeXus transformations

### DIFF
--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -208,7 +208,7 @@ class LoadFromJson:
         return JSONGroup(group=child,
                          parent=group,
                          name=f'{name}/{child_name}',
-                         file={_nexus_children: [group]})
+                         file=self._root)
 
     def get_dataset_from_group(self, group: Dict, dataset_name: str) -> Optional[Dict]:
         """

--- a/src/scippneutron/file_loading/_nexus.py
+++ b/src/scippneutron/file_loading/_nexus.py
@@ -1,9 +1,7 @@
 from ._json_nexus import LoadFromJson
 from ._hdf5_nexus import LoadFromHdf5
-from typing import Union, Dict
-import h5py
+from typing import Union
 import scipp as sc
 
 LoadFromNexus = Union[LoadFromJson, LoadFromHdf5]
-GroupObject = Union[h5py.Group, Dict]
 ScippData = Union[sc.Dataset, sc.DataArray, None]

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -263,7 +263,7 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
                 items[name] = sc.scalar(process(group[()]))
                 loaded_groups.append(name)
             except (BadSource, SkipSource, TransformationError, sc.DimensionError,
-                    KeyError) as e:
+                    sc.UnitError, KeyError) as e:
                 if not nexus.contains_stream(group._group):
                     warn(f"Skipped loading {group.name} due to:\n{e}")
         add_metadata(items)

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -151,10 +151,8 @@ class NXobject:
                 dims = self._get_field_dims(name) if use_field_dims else None
                 return Field(item, self._loader, dims=dims)
         da = self._getitem(name)
-        if (depends_on := self.depends_on) is not None:
-            obj = depends_on.squeeze()  # TODO What is the meaning of the dim?
-            da.coords['depends_on'] = obj if isinstance(obj,
-                                                        sc.Variable) else sc.scalar(obj)
+        if (t := self.depends_on) is not None:
+            da.coords['depends_on'] = t if isinstance(t, sc.Variable) else sc.scalar(t)
         return da
 
     def __getitem__(self,

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -128,15 +128,16 @@ class Field:
 
 
 class DependsOn:
-    def __init__(self, field: Field):
-        self._field = field
+    def __init__(self, group: NXobject):
+        self._field = group
 
     def __getitem__(self, select) -> sc.Variable:
         index = to_plain_index([], select)
         if index != tuple():
             raise ValueError("Cannot select slice when loading 'depends_on'")
-        from .nxtransformations import get_full_transformation_matrix
-        return get_full_transformation_matrix(self._field._group, self._field._loader)
+        from .nxtransformations import get_full_transformation, make_transformation
+        if (t := make_transformation(self._field, self._field[()].value)) is not None:
+            return get_full_transformation(t)
 
 
 class NXobject:
@@ -242,7 +243,7 @@ class NXobject:
     @property
     def depends_on(self) -> DependsOn:
         if 'depends_on' in self:
-            return DependsOn(self)
+            return DependsOn(self['depends_on'])
         return None
 
     def __repr__(self) -> str:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 # @author Simon Heybrock
+from __future__ import annotations
 import scipp as sc
 from enum import Enum, auto
 import functools
@@ -191,6 +192,14 @@ class NXobject:
     @property
     def name(self) -> str:
         return self._loader.get_path(self._group)
+
+    @property
+    def file(self) -> NXroot:
+        return NXroot(self._group.file, self._loader)
+
+    @property
+    def parent(self) -> NXobject:
+        return self._make(self._group.parent)
 
     def _ipython_key_completions_(self) -> List[str]:
         return list(self.keys())

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -228,6 +228,7 @@ class NXobject:
     @property
     def depends_on(self) -> Union[sc.Variable, sc.DataArray, None]:
         if (depends_on := self.get('depends_on')) is not None:
+            # Imported late to avoid cyclic import
             from .nxtransformations import get_full_transformation
             return get_full_transformation(depends_on)
         return None

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -229,10 +229,9 @@ class NXobject:
 
     @property
     def depends_on(self) -> Union[sc.Variable, sc.DataArray, None]:
-        if (path := self.get('depends_on')) is not None:
-            from .nxtransformations import get_full_transformation, make_transformation
-            if (t := make_transformation(path, path[()].value)) is not None:
-                return get_full_transformation(t)
+        if (depends_on := self.get('depends_on')) is not None:
+            from .nxtransformations import get_full_transformation
+            return get_full_transformation(depends_on)
         return None
 
     def __repr__(self) -> str:

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -87,13 +87,10 @@ def _interpolate_transform(transform, xnew):
     # scipy can't interpolate with a single value
     if transform.sizes["time"] == 1:
         transform = sc.concat([transform, transform], dim="time")
-
-    transform = sc.interpolate.interp1d(transform,
-                                        "time",
-                                        kind="previous",
-                                        fill_value="extrapolate")(xnew=xnew)
-
-    return transform
+    return sc.interpolate.interp1d(transform,
+                                   "time",
+                                   kind="previous",
+                                   fill_value="extrapolate")(xnew=xnew)
 
 
 def get_full_transformation(depends_on: Field) -> Union[None, sc.DataArray]:

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -116,9 +116,9 @@ def get_full_transformation(depends_on: Field) -> Union[None, sc.DataArray]:
                 transform.coords["time"].to(unit='ns', copy=False)
             ],
                              dim="time")
-            xnew = sc.datetimes(values=np.unique(time.values), dims=["time"], unit='ns')
-            total_transform = _interpolate_transform(transform, xnew) \
-                * _interpolate_transform(total_transform, xnew)
+            time = sc.datetimes(values=np.unique(time.values), dims=["time"], unit='ns')
+            total_transform = _interpolate_transform(transform, time) \
+                * _interpolate_transform(total_transform, time)
         else:
             total_transform = transform * total_transform
     if isinstance(total_transform, sc.DataArray):

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -14,7 +14,7 @@ from cmath import isclose
 from ._nexus import LoadFromNexus, GroupObject
 from ._json_nexus import contains_stream
 from .nxlog import NXlog
-from .nxobject import Field, ScippIndex
+from .nxobject import Field, NXobject, ScippIndex
 
 
 class TransformationError(Exception):
@@ -37,9 +37,9 @@ class Transformation:
     def depends_on(self):
         if (path := self.attrs.get('depends_on')) is not None:
             if path.startswith('/'):
-                return self._obj[path]
+                return self._obj.file[path]
             elif path != '.':
-                return self._obj['..'][path]  # relative to parent group
+                return self._obj.parent[path]  # relative to parent group
         return None
 
     @property

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -4,16 +4,13 @@
 import warnings
 
 import numpy as np
-from ._common import MissingDataset, MissingAttribute, Group
-from typing import Union, List
+from ._common import MissingDataset, Group
+from typing import List
 import scipp as sc
 import scipp.spatial
 import scipp.interpolate
-import h5py
-from cmath import isclose
-from ._nexus import LoadFromNexus, GroupObject
+from ._nexus import LoadFromNexus
 from ._json_nexus import contains_stream
-from .nxlog import NXlog
 from .nxobject import Field, NXobject, ScippIndex
 
 
@@ -136,8 +133,11 @@ def get_full_transformation_matrix(group: Group, nexus: LoadFromNexus) -> sc.Dat
     return total_transform
 
 
-def _transformation_is_nx_log_stream(transform: Union[h5py.Dataset, GroupObject],
-                                     nexus: LoadFromNexus):
+def _transformation_is_nx_log_stream(t):
+    if (not isinstance(t, (Field, NXobject))):
+        return True
+    transform = t._group if isinstance(t, NXobject) else t._dataset
+    nexus = t._loader
     # Stream objects are only in the dict loaded from json
     if isinstance(transform, dict):
         # If transform is a group and contains a stream but not a value dataset
@@ -170,8 +170,7 @@ def _get_transformations(transform_path: str, transformations: List[np.ndarray],
         t = g.file[transform_path]
     else:
         t = g[transform_path]
-    if (not isinstance(t, (Field, NXobject))) or _transformation_is_nx_log_stream(
-            t._group if isinstance(t, NXobject) else t._dataset, t._loader):
+    if _transformation_is_nx_log_stream(t):
         warnings.warn("Streamed NXlog found in transformation "
                       "chain, getting its value from stream is "
                       "not yet implemented and instead it will be "
@@ -184,163 +183,6 @@ def _get_transformations(transform_path: str, transformations: List[np.ndarray],
     while t is not None:
         transformations.append(t[()])
         t = t.depends_on
-    return
-
     # TODO: this list of transformation should probably be cached in the future
     # to deal with changing beamline components (e.g. pixel positions) during a
     # live data stream (see https://github.com/scipp/scippneutron/issues/76).
-
-    if transform_path != '.':
-        try:
-            transform = nexus.get_object_by_path(group.file, transform_path)
-        except MissingDataset:
-            raise TransformationError(
-                f"Non-existent depends_on path '{transform_path}' found "
-                f"in transformations chain for {group_name}")
-        next_depends_on = _append_transformation(transform, transformations, group_name,
-                                                 nexus)
-
-        if not next_depends_on == "." and not next_depends_on.startswith("/"):
-            # Path is relative - convert it to an absolute path relative to the parent
-            # of the transform it was loaded from.
-            parent = "/".join(nexus.get_path(transform).split("/")[:-1])
-            next_depends_on = f"{parent}/{next_depends_on}"
-
-        _get_transformations(next_depends_on, transformations, group, group_name, nexus)
-
-
-def _append_transformation(transform: Union[h5py.Dataset, GroupObject],
-                           transformations: List[np.ndarray], group_name: str,
-                           nexus: LoadFromNexus) -> str:
-    if _transformation_is_nx_log_stream(transform, nexus):
-        warnings.warn("Streamed NXlog found in transformation "
-                      "chain, getting its value from stream is "
-                      "not yet implemented and instead it will be "
-                      "treated as a 0-distance translation")
-        transformations.append(
-            sc.spatial.affine_transform(value=np.identity(4, dtype=float),
-                                        unit=sc.units.m))
-    else:
-        try:
-            vector = nexus.get_attribute_as_numpy_array(transform,
-                                                        "vector").astype(float)
-            vector = _normalize(vector, nexus.get_name(transform))
-        except MissingAttribute:
-            raise TransformationError(f"Missing 'vector' attribute in transformation "
-                                      f"at {nexus.get_name(transform)}")
-
-        try:
-            offset = nexus.get_attribute_as_numpy_array(transform,
-                                                        "offset").astype(float)
-            try:
-                offset_unit = nexus.get_string_attribute(transform, "offset_units")
-            except MissingAttribute:
-                raise TransformationError(
-                    f"Found offset={offset} but no corresponding 'offset_units' "
-                    f"attribute at {nexus.get_name(transform)}")
-            offset = sc.vector(value=offset, unit=offset_unit)
-        except MissingAttribute:
-            offset = sc.vector(value=np.array([0., 0., 0.], dtype=float),
-                               unit=sc.units.m)
-
-        transform_type = nexus.get_string_attribute(transform, "transformation_type")
-        if transform_type == 'translation':
-            _append_translation(offset, transform, transformations, vector, group_name,
-                                nexus)
-        elif transform_type == 'rotation':
-            _append_rotation(offset, transform, transformations, vector, group_name,
-                             nexus)
-        else:
-            raise TransformationError(f"Unknown transformation type "
-                                      f"'{transform_type}'"
-                                      f" at {nexus.get_name(transform)}")
-    try:
-        depends_on = nexus.get_string_attribute(transform, "depends_on")
-    except MissingAttribute:
-        depends_on = "."
-    return depends_on
-
-
-def _normalize(vector: np.ndarray, transform_name: str) -> np.ndarray:
-    norm = np.linalg.norm(vector)
-    if isclose(norm, 0.):
-        raise TransformationError(
-            f"Magnitude of 'vector' attribute in transformation at "
-            f"{transform_name} is too close to zero")
-    return vector / norm
-
-
-def _append_translation(offset: sc.Variable, transform: GroupObject,
-                        transformations: List[np.ndarray],
-                        direction_unit_vector: np.ndarray, group_name: str,
-                        nexus: LoadFromNexus):
-    loaded_transform = _get_transformation_magnitude_and_unit(
-        group_name, transform, nexus)
-
-    loaded_transform_m = loaded_transform.to(dtype=sc.DType.float64,
-                                             unit=sc.units.m,
-                                             copy=False)
-
-    vectors = sc.vector(value=direction_unit_vector) * loaded_transform_m + offset
-    translations = sc.spatial.translations(dims=loaded_transform_m.dims,
-                                           values=vectors.values,
-                                           unit=sc.units.m)
-
-    if isinstance(loaded_transform, sc.DataArray):
-        t = sc.DataArray(data=translations,
-                         coords={"time": loaded_transform.coords["time"]})
-    else:
-        t = translations
-
-    transformations.append(t)
-
-
-def _get_transformation_magnitude_and_unit(group_name: str,
-                                           transform: Union[h5py.Dataset, GroupObject],
-                                           nexus: LoadFromNexus) -> sc.DataArray:
-    """
-    Gets a scipp data array containing magnitudes and timestamps of a transformation.
-    """
-    if nexus.is_group(transform):
-        try:
-            log = NXlog(transform, nexus)[()]
-        except sc.DimensionError:
-            raise TransformationError(f"Mismatched time and value dataset lengths "
-                                      f"for transformation at {group_name}")
-        except MissingDataset:
-            raise TransformationError(
-                f"Encountered {nexus.get_name(transform)} in transformation "
-                f"chain for {group_name} but it is a group without a value "
-                "dataset; not a valid transformation")
-    else:
-        magnitude = nexus.load_dataset_as_numpy_array(transform).astype(float).item()
-        unit = nexus.get_unit(transform)
-        log = sc.scalar(value=magnitude, unit=unit, dtype=sc.DType.float64)
-
-    if log.unit is None:
-        raise TransformationError(f"Missing units for transformation at "
-                                  f"{nexus.get_name(transform)}")
-    return log
-
-
-def _append_rotation(offset: sc.Variable, transform: GroupObject,
-                     transformations: List[np.ndarray], rotation_axis: np.ndarray,
-                     group_name: str, nexus: LoadFromNexus):
-    angles = _get_transformation_magnitude_and_unit(group_name, transform, nexus)
-    try:
-        angles = angles.to(dtype=sc.DType.float64, unit=sc.units.rad, copy=False)
-    except sc.UnitError:
-        raise TransformationError(f"Unit for rotation transformation must be radians "
-                                  f"or degrees, problem in {transform.name}")
-
-    offset = sc.spatial.translation(value=offset.values, unit=offset.unit)
-
-    rotvecs = sc.vector(value=rotation_axis) * angles.astype('float64', copy=False)
-    rotations = sc.spatial.rotations_from_rotvecs(rotvecs) * offset
-
-    if isinstance(angles, sc.DataArray):
-        t = sc.DataArray(data=rotations, coords={"time": angles.coords["time"]})
-    else:
-        t = rotations
-
-    transformations.append(t)

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -50,7 +50,7 @@ class Transformation:
             raise TransformationError(
                 f"Found {offset=} but no corresponding 'offset_units' "
                 f"attribute at {self.name}")
-        return sc.vector(value=offset, unit=offset_units)
+        return sc.spatial.translation(value=offset, unit=offset_units)
 
     @property
     def vector(self) -> sc.Variable:

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -58,7 +58,10 @@ class Transformation:
 
     def __getitem__(self, select: ScippIndex):
         transformation_type = self.attrs.get('transformation_type')
-        t = self._obj[select] * self.vector
+        # According to private communication with Tobias Richter, NeXus allows 0-D or
+        # shape=[1] for single values. It is unclear how and if this could be
+        # distinguished from a scan of length 1.
+        t = self._obj[select].squeeze() * self.vector
         v = t if isinstance(t, sc.Variable) else t.data
         if transformation_type == 'translation':
             v = v.to(unit='m', copy=False)

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -111,16 +111,14 @@ def get_full_transformation(depends_on: Field) -> Union[None, sc.DataArray]:
     for transform in transformations:
         if isinstance(total_transform, sc.DataArray) and isinstance(
                 transform, sc.DataArray):
-            xnew = sc.datetimes(values=np.unique(
-                sc.concat([
-                    total_transform.coords["time"].to(unit=sc.units.ns, copy=False),
-                    transform.coords["time"].to(unit=sc.units.ns, copy=False),
-                ],
-                          dim="time").values),
-                                dims=["time"],
-                                unit=sc.units.ns)
-            total_transform = _interpolate_transform(
-                transform, xnew) * _interpolate_transform(total_transform, xnew)
+            time = sc.concat([
+                total_transform.coords["time"].to(unit='ns', copy=False),
+                transform.coords["time"].to(unit='ns', copy=False)
+            ],
+                             dim="time")
+            xnew = sc.datetimes(values=np.unique(time.values), dims=["time"], unit='ns')
+            total_transform = _interpolate_transform(transform, xnew) \
+                * _interpolate_transform(total_transform, xnew)
         else:
             total_transform = transform * total_transform
     if isinstance(total_transform, sc.DataArray):

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -97,10 +97,6 @@ def get_full_transformation(transformation: Transformation) -> sc.DataArray:
     Get the 4x4 transformation matrix for a component, resulting
     from the full chain of transformations linked by "depends_on"
     attributes
-
-    :param group: The HDF5 group of the component, containing depends_on
-    :param nexus: wrap data access to hdf file or objects from json
-    :return: 4x4 active transformation matrix as a data array
     """
     transformations = _get_transformations(transformation)
 

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -1,0 +1,75 @@
+from .nexus_test import open_nexus, open_json
+from .nexus_helpers import NexusBuilder, Detector, Transformation, TransformationType
+import numpy as np
+import pytest
+from typing import Callable, Tuple
+import scipp as sc
+from scippneutron.file_loading._nexus import LoadFromNexus
+from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
+from scippneutron.file_loading._json_nexus import LoadFromJson
+from scippneutron import nexus
+from scippneutron.file_loading import nxtransformations
+
+
+@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+def nexus_group(request):
+    return request.param
+
+
+def builder_with_detector(*, depends_on):
+    builder = NexusBuilder()
+    da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
+    detector_numbers = np.array([[1, 2], [3, 4]])
+    builder.add_detector(
+        Detector(detector_numbers=detector_numbers, data=da, depends_on=depends_on))
+    return builder
+
+
+def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromNexus]):
+    resource, loader = nexus_group
+    offset = sc.vector(value=[1, 2, 3], unit='m')
+    vector = sc.vector(value=[0, 0, 1])
+    value = sc.scalar(6.5, unit='m')
+    translation = Transformation(TransformationType.TRANSLATION,
+                                 vector=vector.value,
+                                 value=value.value,
+                                 value_units=str(value.unit),
+                                 offset=offset.value,
+                                 offset_unit=str(offset.unit))
+    builder = builder_with_detector(depends_on=translation)
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        depends_on = detector['depends_on'][()].value
+        t = nxtransformations.Transformation(detector[depends_on])
+        assert t.depends_on is None
+        assert sc.identical(t.offset, offset)
+        assert sc.identical(t.vector, vector)
+        assert sc.identical(t[()], value)
+
+
+def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
+                                                                LoadFromNexus]):
+    resource, loader = nexus_group
+    offset = sc.vector(value=[1, 2, 3], unit='m')
+    vector = sc.vector(value=[0, 0, 1])
+    log = sc.DataArray(
+        sc.array(dims=['time'], values=[1.1, 2.2], unit='m'),
+        coords={'time': sc.array(dims=['time'], values=[11, 22], unit='s')})
+    translation = Transformation(TransformationType.TRANSLATION,
+                                 vector=vector.value,
+                                 value=log.values,
+                                 value_units=str(log.unit),
+                                 time=log.coords['time'].values,
+                                 time_units=str(log.coords['time'].unit),
+                                 offset=offset.value,
+                                 offset_unit=str(offset.unit))
+    log.coords['time'] = sc.epoch(unit='ns') + log.coords['time'].to(unit='ns')
+    builder = builder_with_detector(depends_on=translation)
+    with resource(builder)() as f:
+        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        depends_on = detector['depends_on'][()].value
+        t = nxtransformations.Transformation(detector[depends_on])
+        assert t.depends_on is None
+        assert sc.identical(t.offset, offset)
+        assert sc.identical(t.vector, vector)
+        assert sc.identical(t[()], log)

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -27,9 +27,9 @@ def builder_with_detector(*, depends_on):
 
 def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
-    offset = sc.spatial.translation(value=[1, 2, 3], unit='m')
+    offset = sc.spatial.translation(value=[1, 2, 3], unit='mm')
     vector = sc.vector(value=[0, 0, 1])
-    value = sc.scalar(6.5, unit='m')
+    value = sc.scalar(6.5, unit='mm')
     translation = Transformation(TransformationType.TRANSLATION,
                                  vector=vector.value,
                                  value=value.value,
@@ -37,9 +37,9 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
                                  offset=offset.values,
                                  offset_unit=str(offset.unit))
     builder = builder_with_detector(depends_on=translation)
-    t = value * vector
+    t = value.to(unit='m') * vector
     expected = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
-    expected = expected * offset
+    expected = expected * sc.spatial.translation(value=[0.001, 0.002, 0.003], unit='m')
     with resource(builder)() as f:
         root = nexus.NXroot(f, loader)
         detector = root['entry/detector_0']

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -44,7 +44,7 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
         assert t.depends_on is None
         assert sc.identical(t.offset, offset)
         assert sc.identical(t.vector, vector)
-        assert sc.identical(t[()], value)
+        assert sc.identical(t.value(()), value)
 
 
 def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
@@ -72,4 +72,4 @@ def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
         assert t.depends_on is None
         assert sc.identical(t.offset, offset)
         assert sc.identical(t.vector, vector)
-        assert sc.identical(t[()], log)
+        assert sc.identical(t.value(()), log)

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -27,14 +27,14 @@ def builder_with_detector(*, depends_on):
 
 def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
-    offset = sc.vector(value=[1, 2, 3], unit='m')
+    offset = sc.spatial.translation(value=[1, 2, 3], unit='m')
     vector = sc.vector(value=[0, 0, 1])
     value = sc.scalar(6.5, unit='m')
     translation = Transformation(TransformationType.TRANSLATION,
                                  vector=vector.value,
                                  value=value.value,
                                  value_units=str(value.unit),
-                                 offset=offset.value,
+                                 offset=offset.values,
                                  offset_unit=str(offset.unit))
     builder = builder_with_detector(depends_on=translation)
     with resource(builder)() as f:
@@ -50,7 +50,7 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
 def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
                                                                 LoadFromNexus]):
     resource, loader = nexus_group
-    offset = sc.vector(value=[1, 2, 3], unit='m')
+    offset = sc.spatial.translation(value=[1, 2, 3], unit='m')
     vector = sc.vector(value=[0, 0, 1])
     log = sc.DataArray(
         sc.array(dims=['time'], values=[1.1, 2.2], unit='m'),
@@ -61,7 +61,7 @@ def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
                                  value_units=str(log.unit),
                                  time=log.coords['time'].values,
                                  time_units=str(log.coords['time'].unit),
-                                 offset=offset.value,
+                                 offset=offset.values,
                                  offset_unit=str(offset.unit))
     log.coords['time'] = sc.epoch(unit='ns') + log.coords['time'].to(unit='ns')
     builder = builder_with_detector(depends_on=translation)

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -37,6 +37,9 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
                                  offset=offset.values,
                                  offset_unit=str(offset.unit))
     builder = builder_with_detector(depends_on=translation)
+    t = value * vector
+    expected = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
+    expected = expected * offset
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         depends_on = detector['depends_on'][()].value
@@ -44,7 +47,7 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
         assert t.depends_on is None
         assert sc.identical(t.offset, offset)
         assert sc.identical(t.vector, vector)
-        assert sc.identical(t.value(()), value)
+        assert sc.identical(t[()], expected)
 
 
 def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
@@ -65,6 +68,9 @@ def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
                                  offset_unit=str(offset.unit))
     log.coords['time'] = sc.epoch(unit='ns') + log.coords['time'].to(unit='ns')
     builder = builder_with_detector(depends_on=translation)
+    t = log * vector
+    t.data = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
+    expected = t * offset
     with resource(builder)() as f:
         detector = nexus.NXroot(f, loader)['entry/detector_0']
         depends_on = detector['depends_on'][()].value
@@ -72,4 +78,4 @@ def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
         assert t.depends_on is None
         assert sc.identical(t.offset, offset)
         assert sc.identical(t.vector, vector)
-        assert sc.identical(t.value(()), log)
+        assert sc.identical(t[()], expected)

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -41,9 +41,10 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
     expected = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
     expected = expected * offset
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        root = nexus.NXroot(f, loader)
+        detector = root['entry/detector_0']
         depends_on = detector['depends_on'][()].value
-        t = nxtransformations.Transformation(detector[depends_on])
+        t = nxtransformations.Transformation(root[depends_on])
         assert t.depends_on is None
         assert sc.identical(t.offset, offset)
         assert sc.identical(t.vector, vector)
@@ -72,9 +73,10 @@ def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
     t.data = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
     expected = t * offset
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        root = nexus.NXroot(f, loader)
+        detector = root['entry/detector_0']
         depends_on = detector['depends_on'][()].value
-        t = nxtransformations.Transformation(detector[depends_on])
+        t = nxtransformations.Transformation(root[depends_on])
         assert t.depends_on is None
         assert sc.identical(t.offset, offset)
         assert sc.identical(t.vector, vector)

--- a/tests/test_load_nexus.py
+++ b/tests/test_load_nexus.py
@@ -1026,7 +1026,8 @@ def test_skips_component_position_from_transformation_missing_unit(
         component_class: Union[Type[Source], Type[Sample]], component_name: str,
         transform_type: TransformationType, load_function: Callable):
     builder = NexusBuilder()
-    transformation = Transformation(transform_type, np.array([0, 0, -1]),
+    transformation = Transformation(transform_type,
+                                    np.array([0, 0, -1]),
                                     value=np.array(2.3))
     builder.add_component(component_class(component_name, depends_on=transformation))
     with pytest.warns(UserWarning):

--- a/tests/test_load_nexus.py
+++ b/tests/test_load_nexus.py
@@ -787,7 +787,7 @@ def test_loads_component_position_from_single_transformation(
     builder = NexusBuilder()
     transformation = Transformation(transform_type,
                                     vector=np.array([0, 0, 1]),
-                                    value=np.array([value]),
+                                    value=np.array(value),
                                     value_units=value_units)
     builder.add_component(component_class(component_name, depends_on=transformation))
     loaded_data = load_function(builder)
@@ -810,7 +810,7 @@ def test_loads_component_position_from_single_transformation_with_offset(
     builder = NexusBuilder()
     transformation = Transformation(transform_type,
                                     vector=np.array([0, 0, 1]),
-                                    value=np.array([value]),
+                                    value=np.array(value),
                                     value_units=value_units,
                                     offset=[1, 2, 3],
                                     offset_unit='m')
@@ -835,7 +835,7 @@ def test_raises_if_offset_but_not_offset_units_found(
     builder = NexusBuilder()
     transformation = Transformation(transform_type,
                                     vector=np.array([0, 0, 1]),
-                                    value=np.array([value]),
+                                    value=np.array(value),
                                     value_units=value_units,
                                     offset=[1, 2, 3],
                                     offset_unit=None)
@@ -858,7 +858,7 @@ def test_loads_component_position_from_log_transformation(
     # an NXlog
     transformation = Transformation(transform_type,
                                     vector=np.array([0, 0, 1]),
-                                    value=np.array([value]),
+                                    value=np.array(value),
                                     value_units=value_units)
     builder.add_component(component_class(component_name, depends_on=transformation))
     loaded_data = load_function(builder)
@@ -1002,8 +1002,8 @@ def test_load_component_position_prefers_transform_over_distance(
     # can define position and orientation in 3D.
     builder = NexusBuilder()
     transformation = Transformation(TransformationType.TRANSLATION,
-                                    np.array([0, 0, 1]),
-                                    np.array([2.3]),
+                                    vector=np.array([0, 0, 1]),
+                                    value=np.array(2.3),
                                     value_units="m")
     builder.add_component(
         component_class(component_name,
@@ -1012,7 +1012,7 @@ def test_load_component_position_prefers_transform_over_distance(
                         distance_units="m"))
     loaded_data = load_function(builder)
 
-    expected_position = np.array([0, 0, transformation.value[0]])
+    expected_position = np.array([0, 0, transformation.value])
     assert np.allclose(loaded_data[f"{component_name}_position"].values,
                        expected_position)
     assert loaded_data[f"{component_name}_position"].unit == sc.Unit("m")
@@ -1027,29 +1027,7 @@ def test_skips_component_position_from_transformation_missing_unit(
         transform_type: TransformationType, load_function: Callable):
     builder = NexusBuilder()
     transformation = Transformation(transform_type, np.array([0, 0, -1]),
-                                    np.array([2.3]))
-    builder.add_component(component_class(component_name, depends_on=transformation))
-    with pytest.warns(UserWarning):
-        load_function(builder)
-
-
-@pytest.mark.parametrize("component_class,component_name",
-                         ((Sample, "sample"), (Source, "source")))
-@pytest.mark.parametrize("transform_type,value_units",
-                         ((TransformationType.ROTATION, "deg"),
-                          (TransformationType.TRANSLATION, "m")))
-def test_skips_component_position_with_transformation_with_small_vector(
-        component_class: Union[Type[Source], Type[Sample]], component_name: str,
-        transform_type: TransformationType, value_units: str, load_function: Callable):
-    # The vector defines the direction of the translation or axis
-    # of the rotation so it is ill-defined if it is close to zero
-    # in magnitude
-    builder = NexusBuilder()
-    zero_vector = np.array([0, 0, 0])
-    transformation = Transformation(transform_type,
-                                    zero_vector,
-                                    np.array([2.3]),
-                                    value_units=value_units)
+                                    value=np.array(2.3))
     builder.add_component(component_class(component_name, depends_on=transformation))
     with pytest.warns(UserWarning):
         load_function(builder)
@@ -1063,11 +1041,11 @@ def test_loads_component_position_from_multiple_transformations(
     builder = NexusBuilder()
     transformation_1 = Transformation(TransformationType.ROTATION,
                                       np.array([0, 1, 0]),
-                                      np.array([90]),
+                                      value=np.array(90),
                                       value_units="deg")
     transformation_2 = Transformation(TransformationType.TRANSLATION,
                                       np.array([0, 0, 1]),
-                                      np.array([2.3]),
+                                      value=np.array(2.3),
                                       value_units="m",
                                       depends_on=transformation_1)
     builder.add_component(component_class(component_name, depends_on=transformation_2))
@@ -1112,18 +1090,18 @@ def test_loads_source_position_dependent_on_sample_position(load_function: Calla
     builder = NexusBuilder()
     transformation_0 = Transformation(TransformationType.ROTATION,
                                       np.array([0, 1, 0]),
-                                      np.array([90]),
+                                      value=np.array(90),
                                       value_units="deg")
     transformation_1 = Transformation(TransformationType.TRANSLATION,
                                       np.array([0, 0, 1]),
-                                      np.array([2.3]),
+                                      value=np.array(2.3),
                                       value_units="m",
                                       depends_on=transformation_0)
     builder.add_sample(Sample("sample", depends_on=transformation_1))
     transformation_2 = Transformation(
         TransformationType.TRANSLATION,
         np.array([0, 0, 1]),
-        np.array([1.0]),
+        value=np.array(1.0),
         value_units="m",
         depends_on="/entry/sample/transformations/transform_1")
     builder.add_source(Source("source", depends_on=transformation_2))
@@ -1154,7 +1132,7 @@ def test_loads_pixel_positions_with_transformations(load_function: Callable):
     distance = 57  # cm
     transformation = Transformation(TransformationType.TRANSLATION,
                                     vector=np.array([0, 0, 1]),
-                                    value=np.array([distance]),
+                                    value=np.array(distance),
                                     value_units="cm")
 
     builder = NexusBuilder()
@@ -1214,11 +1192,11 @@ def test_loads_pixel_positions_with_multiple_transformations(load_function: Call
 
     transformation1 = Transformation(TransformationType.TRANSLATION,
                                      vector=np.array([0, 0, 1]),
-                                     value=np.array([12]),
+                                     value=np.array(12),
                                      value_units="cm")
     transformation2 = Transformation(TransformationType.TRANSLATION,
                                      vector=np.array([0, 0, 1]),
-                                     value=np.array([34]),
+                                     value=np.array(34),
                                      value_units="cm")
 
     builder = NexusBuilder()
@@ -1300,7 +1278,7 @@ def test_links_in_transformation_paths_are_followed(load_function: Callable):
     distance = 13.6
     builder.add_component(Source("source"))
     builder.add_dataset_at_path(
-        "/entry/transform", np.array([distance]), {
+        "/entry/transform", np.array(distance), {
             "vector": np.array([0, 0, 1]),
             "units": "m",
             "transformation_type": "translation",
@@ -1321,14 +1299,14 @@ def test_relative_links_in_transformation_paths_are_followed(load_function: Call
     distance = 13.6
     builder.add_component(Source("source"))
     builder.add_dataset_at_path(
-        "/entry/transform1", np.array([distance]), {
+        "/entry/transform1", np.array(distance), {
             "vector": np.array([0, 0, 1]),
             "units": "m",
             "transformation_type": "translation",
             "depends_on": "."
         })
     builder.add_dataset_at_path(
-        "/entry/transform2", np.array([distance]), {
+        "/entry/transform2", np.array(distance), {
             "vector": np.array([0, 0, 1]),
             "units": "m",
             "transformation_type": "translation",
@@ -1813,7 +1791,7 @@ def test_load_monitor_with_transformation(load_function: Callable):
 
     transformation = Transformation(TransformationType.TRANSLATION,
                                     vector=np.array([0, 0, 1]),
-                                    value=np.array([6.5]),
+                                    value=np.array(6.5),
                                     value_units='m',
                                     offset=[1, 2, 3],
                                     offset_unit='m')


### PR DESCRIPTION
This is mostly a refactor without changes. Removing most uses of the old API in this part of the code.

Functional change:
- The `vector` attribute of a transform in https://manual.nexusformat.org/classes/base_classes/NXtransformations.html#nxtransformations is not normalized any more. If I read the standard correctly this should not be done: "t is given by the vector attribute multiplied by the field value". Corresponding test is removed.