### PR TITLE
Cleanup and minor changes and fixed in Nexus code

### DIFF
--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -151,6 +151,10 @@ class LoadFromHdf5:
             dtype = sc.DType.string
 
         shape = list(dataset.shape)
+        if dimensions == [] and shape == [1]:
+            # NeXus treats [] and [1] interchangeably, in general this is ill-defined,
+            # but this is the best we can do.
+            shape = []
         if index is Ellipsis:
             index = tuple()
         if isinstance(index, slice):

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -125,12 +125,8 @@ class LoadFromHdf5:
         return found_groups
 
     @staticmethod
-    def dataset_in_group(group: h5py.Group, dataset_name: str) -> Tuple[bool, str]:
-        if dataset_name not in group:
-            return False, (f"Unable to load data from NXevent_data "
-                           f"at '{group.name}' due to missing '{dataset_name}'"
-                           f" field\n")
-        return True, ""
+    def dataset_in_group(group: h5py.Group, dataset_name: str) -> bool:
+        return dataset_name in group
 
     def load_dataset_direct(self,
                             dataset: h5py.Dataset,
@@ -229,13 +225,6 @@ class LoadFromHdf5:
             return group[child_name]
         except KeyError:
             return None
-
-    def get_dataset_from_group(self, group: h5py.Group,
-                               dataset_name: str) -> Optional[h5py.Dataset]:
-        dataset = self.get_child_from_group(group, dataset_name)
-        if not self.is_group(dataset):
-            return dataset
-        return None
 
     @staticmethod
     def get_attr_encoding(group: h5py.Group, dataset_name: str) -> str:

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -29,8 +29,8 @@ def _cset_to_encoding(cset: int) -> str:
         return "utf-8"
     else:
         raise ValueError(f"Unknown character set in HDF5 data file. Expected data "
-                         f"types are {h5py.h5t.CSET_ASCII} (H5T_CSET_ASCII) or "
-                         f"{h5py.h5t.CSET_UTF8} (H5T_CSET_UTF8) but got '{cset}'. ")
+                         f"types are {h5py.h5t.CSET_ASCII=} or "
+                         f"{h5py.h5t.CSET_UTF8=} but got '{cset}'. ")
 
 
 def _get_attr_as_str(h5_object, attribute_name: str) -> str:

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -238,12 +238,6 @@ class LoadFromHdf5:
         return None
 
     @staticmethod
-    def get_dataset_encoding(group: h5py.Group, dataset_name: str) -> str:
-        cset = h5py.h5d.open(group.id,
-                             dataset_name.encode("utf-8")).get_type().get_cset()
-        return _cset_to_encoding(cset)
-
-    @staticmethod
     def get_attr_encoding(group: h5py.Group, dataset_name: str) -> str:
         cset = h5py.h5a.open(group.id,
                              dataset_name.encode("utf-8")).get_type().get_cset()

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -210,17 +210,9 @@ class LoadFromJson:
                          name=f'{name}/{child_name}',
                          file=self._root)
 
-    def get_dataset_from_group(self, group: Dict, dataset_name: str) -> Optional[Dict]:
-        """
-        Returns dictionary for dataset or None if not found
-        """
-        return self._get_child_from_group(group, dataset_name, (_nexus_dataset, ))
-
-    def dataset_in_group(self, group: Dict, dataset_name: str) -> Tuple[bool, str]:
-        if self.get_dataset_from_group(group, dataset_name) is not None:
-            return True, ""
-        return False, (f"Unable to load data from NXevent_data "
-                       f" due to missing '{dataset_name}' field\n")
+    def dataset_in_group(self, group: Dict, dataset_name: str) -> bool:
+        return self._get_child_from_group(group, dataset_name,
+                                          (_nexus_dataset, )) is not None
 
     @staticmethod
     def supported_int_type(dataset):

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -291,12 +291,6 @@ class LoadFromJson:
             unit = None
         return unit
 
-    def load_scalar_string(self, group: Dict, dataset_name: str) -> sc.Variable:
-        dataset = self.get_dataset_from_group(group, dataset_name)
-        if dataset is None:
-            raise MissingDataset()
-        return dataset[_nexus_values]
-
     def get_object_by_path(self, group: Dict, path_str: str) -> Dict:
         for node in filter(None, path_str.split("/")):
             group = self._get_child_from_group(group, node)

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -136,15 +136,7 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
     Main implementation for loading data is extracted to this function so that
     in-memory data can be used for unit tests.
     """
-    if root is not None:
-        root_node = nexus_file[root]
-    else:
-        root_node = nexus_file
-
-    no_event_data = True
-    loaded_data = sc.Dataset()
-
-    root = NXroot(root_node, nexus)
+    root = NXroot(nexus_file if root is None else nexus_file[root], nexus)
     classes = root.by_nx_class()
 
     if len(classes[NX_class.NXentry]) > 1:
@@ -185,6 +177,9 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
                 ValueError) as e:
             if not nexus.contains_stream(group._group):
                 warn(f"Skipped loading {group.name} due to:\n{e}")
+
+    no_event_data = True
+    loaded_data = sc.Dataset()
 
     # If no event data are found, make a Dataset and add the metadata as
     # Dataset entries. Otherwise, make a DataArray.

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -147,7 +147,12 @@ class NXdata(NXobject):
                 continue
             try:
                 sel = to_child_select(self.dims, field.dims, select)
-                da.coords[name] = self[name][sel]
+                coord = self[name][sel]
+                # NeXus treats [] and [1] interchangeably, in general this is
+                # ill-defined, but this is the best we can do.
+                if coord.shape == [1] and da.sizes.get(coord.dim) != 1:
+                    coord = coord.squeeze()
+                da.coords[name] = coord
             except sc.DimensionError as e:
                 warn(f"Skipped load of axis {field.name} due to:\n{e}")
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -27,6 +27,7 @@ class NX_class(Enum):
     NXdisk_chopper = auto()
     NXentry = auto()
     NXevent_data = auto()
+    NXinstrument = auto()
     NXlog = auto()
     NXmonitor = auto()
     NXroot = auto()
@@ -201,7 +202,7 @@ class NXobject:
         return list(zip(self.keys(), self.values()))
 
     @functools.lru_cache()
-    def by_nx_class(self) -> Dict[NX_class, List['__class__']]:
+    def by_nx_class(self) -> Dict[NX_class, Dict[str, '__class__']]:
         classes = self._loader.find_by_nx_class(tuple(_nx_class_registry()),
                                                 self._group)
         out = {}
@@ -251,6 +252,10 @@ class NXentry(NXobject):
     pass
 
 
+class NXinstrument(NXobject):
+    pass
+
+
 def _make(group, loader) -> NXobject:
     try:
         nx_class = loader.get_string_attribute(group, 'NX_class')
@@ -273,6 +278,6 @@ def _nx_class_registry():
         cls.__name__: cls
         for cls in [
             NXroot, NXentry, NXevent_data, NXlog, NXmonitor, NXdata, NXdetector,
-            NXsample, NXsource, NXdisk_chopper
+            NXsample, NXsource, NXdisk_chopper, NXinstrument
         ]
     }

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -168,7 +168,7 @@ class NXobject:
         return None
 
     def __contains__(self, name: str) -> bool:
-        return self._loader.dataset_in_group(self._group, name)[0]
+        return self._loader.dataset_in_group(self._group, name)
 
     def get(self, name: str, default=None) -> Union['__class__', Field, sc.DataArray]:
         return self[name] if name in self else default

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -138,7 +138,7 @@ def _transformation_is_nx_log_stream(t):
         # then assume it is a streamed NXlog transformation
         try:
             if nexus.is_group(transform):
-                found_value_dataset, _ = nexus.dataset_in_group(transform, "value")
+                found_value_dataset = nexus.dataset_in_group(transform, "value")
                 if not found_value_dataset and contains_stream(transform):
                     return True
         except KeyError:

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -271,6 +271,20 @@ def test_field_of_utf8_encoded_dataset_is_loaded_correctly(
                             sc.array(dims=['dim_0'], values=[string, string + string]))
 
 
+def test_field_of_extended_ascii_in_ascii_encoded_dataset_is_loaded_correctly():
+    resource, loader = open_nexus, LoadFromHdf5()
+    builder = NexusBuilder()
+    # When writing, if we use bytes h5py will write as ascii encoding
+    # 0xb0 = degrees symbol in latin-1 encoding.
+    string = b"run at rot=90" + bytes([0xb0])
+    builder.add_title(np.array([string, string + b'x']))
+    with resource(builder)() as f:
+        title = nexus.NXroot(f, loader)['entry/title']
+        assert sc.identical(
+            title[...],
+            sc.array(dims=['dim_0'], values=["run at rot=90°", "run at rot=90°x"]))
+
+
 def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable,
                                                                         LoadFromNexus]):
     event_time_offsets = np.array([456, 743, 347, 345, 632, 23])

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -262,9 +262,7 @@ def test_field_of_utf8_encoded_dataset_is_loaded_correctly(
     resource, loader = nexus_group
     builder = NexusBuilder()
     if isinstance(loader, LoadFromHdf5):
-        encoded1 = np.char.encode(string, 'utf-8')
-        encoded2 = np.char.encode(string + string, 'utf-8')
-        builder.add_title(np.array([encoded1, encoded2]))
+        builder.add_title(np.array([string, string + string], dtype=object))
     else:  # json encodes itself
         builder.add_title(np.array([string, string + string]))
     with resource(builder)() as f:

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -281,6 +281,11 @@ def test_can_load_nxdetector_from_PG3():
         assert da.coords['azimuthal_angle'].sizes == da.sizes
         assert da.coords['x_pixel_offset'].sizes == {'x_pixel_offset': 154}
         assert da.coords['y_pixel_offset'].sizes == {'y_pixel_offset': 7}
+        # local_name is an example of a dataset with shape=[1] that is treated as scalar
+        assert da.coords['local_name'].sizes == {}
+        # Extra scalar fields not in underlying NXevent_data
+        del da.coords['local_name']
+        del da.coords['total_counts']
         assert sc.identical(da.sum(), det.events[()].sum())  # no event lost in binning
 
 


### PR DESCRIPTION
- Remove unused code.
- Handle string encoding also for multi-valued datasets, not just in attributes and scalar datasets.
- Better handling of datasets with shape=[1], which NeXus uses interchangeably with single-valued (scalar, 0-D) datasets.