### PR TITLE
Begin wrapping JSON Nexus

### DIFF
--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -198,13 +198,6 @@ class LoadFromHdf5:
         return dataset.dtype
 
     @staticmethod
-    def get_shape(dataset: h5py.Dataset) -> List:
-        """
-        The shape of the dataset
-        """
-        return dataset.shape
-
-    @staticmethod
     def get_child_from_group(group: Dict,
                              child_name: str) -> Union[h5py.Dataset, h5py.Group, None]:
         try:

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -130,6 +130,7 @@ class LoadFromHdf5:
 
     def load_dataset_direct(self,
                             dataset: h5py.Dataset,
+                            unit: Optional[sc.Unit] = None,
                             dimensions: Optional[List[str]] = [],
                             dtype: Optional[Any] = None,
                             index=tuple()) -> sc.Variable:
@@ -161,7 +162,7 @@ class LoadFromHdf5:
         variable = sc.empty(dims=dimensions,
                             shape=shape,
                             dtype=dtype,
-                            unit=self.get_unit(dataset))
+                            unit=unit)
         if dtype == sc.DType.string:
             try:
                 strings = dataset.asstr()[index]
@@ -202,21 +203,6 @@ class LoadFromHdf5:
         The shape of the dataset
         """
         return dataset.shape
-
-    @staticmethod
-    def get_unit(node: Union[h5py.Dataset, h5py.Group]) -> str:
-        try:
-            units = node.attrs["units"]
-        except (AttributeError, KeyError):
-            return None
-        units = _ensure_str(units, LoadFromHdf5.get_attr_encoding(node, "units"))
-        try:
-            sc.Unit(units)
-        except sc.UnitError:
-            warnings.warn(f"Unrecognized unit '{units}' for value dataset "
-                          f"in '{node.name}'; setting unit as 'dimensionless'")
-            return "dimensionless"
-        return units
 
     @staticmethod
     def get_child_from_group(group: Dict,

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -159,10 +159,7 @@ class LoadFromHdf5:
         for i, ind in enumerate(index):
             shape[i] = len(range(*ind.indices(shape[i])))
 
-        variable = sc.empty(dims=dimensions,
-                            shape=shape,
-                            dtype=dtype,
-                            unit=unit)
+        variable = sc.empty(dims=dimensions, shape=shape, dtype=dtype, unit=unit)
         if dtype == sc.DType.string:
             try:
                 strings = dataset.asstr()[index]

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -8,7 +8,7 @@ from typing import Union, Any, List, Optional, Tuple, Dict
 import h5py
 import numpy as np
 import scipp as sc
-from ._common import Group, MissingDataset, MissingAttribute
+from ._common import Group, MissingDataset
 
 
 def _cset_to_encoding(cset: int) -> str:
@@ -239,24 +239,6 @@ class LoadFromHdf5:
             return group[path]
         except KeyError:
             raise MissingDataset
-
-    @staticmethod
-    def get_attribute(node: Union[h5py.Group, h5py.Dataset],
-                      attribute_name: str) -> Any:
-        try:
-            return node.attrs[attribute_name]
-        except KeyError:
-            raise MissingAttribute
-
-    @staticmethod
-    def get_string_attribute(node: Union[h5py.Group, h5py.Dataset],
-                             attribute_name: str) -> str:
-        try:
-            val = node.attrs[attribute_name]
-        except KeyError:
-            raise MissingAttribute(f"Missing attribute named {attribute_name}")
-
-        return _ensure_str(val, LoadFromHdf5.get_attr_encoding(node, attribute_name))
 
     @staticmethod
     def is_group(node: Any):

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -191,13 +191,6 @@ class LoadFromHdf5:
         return group.name
 
     @staticmethod
-    def get_dtype(dataset: h5py.Dataset) -> str:
-        """
-        The dtype of the dataset
-        """
-        return dataset.dtype
-
-    @staticmethod
     def get_child_from_group(group: Dict,
                              child_name: str) -> Union[h5py.Dataset, h5py.Group, None]:
         try:

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -254,13 +254,6 @@ class LoadFromJson:
         except KeyError:
             return dataset[_nexus_dataset]["dtype"]
 
-    @staticmethod
-    def get_shape(dataset: Dict) -> List:
-        """
-        The shape of the dataset
-        """
-        return np.asarray(dataset[_nexus_values]).shape
-
     def get_object_by_path(self, group: Dict, path_str: str) -> Dict:
         for node in filter(None, path_str.split("/")):
             group = self._get_child_from_group(group, node)
@@ -293,6 +286,34 @@ class JSONAttributeManager:
 
     def __getitem__(self, name):
         return _get_attribute_value(self._node, name)
+
+
+class JSONDataset:
+    def __init__(self, node: dict, loader: LoadFromJson):
+        self._node = node
+        self._loader = loader
+
+    @property
+    def dtype(self) -> str:
+        try:
+            return self._node[_nexus_dataset]["type"]
+        except KeyError:
+            return self._node[_nexus_dataset]["dtype"]
+
+    @property
+    def name(self) -> str:
+        if isinstance(self._node, JSONGroup):
+            return self._node.name
+        else:
+            return self._node.get(_nexus_path, '/')
+
+    @property
+    def file(self):
+        return self._node.file
+
+    @property
+    def shape(self):
+        return np.asarray(self._node[_nexus_values]).shape
 
 
 @dataclass

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -310,6 +310,22 @@ class LoadFromJson:
         return contains_stream(group)
 
 
+class JSONAttributeManager:
+    def __init__(self, node: dict, loader: LoadFromJson):
+        self._node = node
+        self._loader = loader
+
+    def __contains__(self, name):
+        try:
+            self[name]
+        except MissingAttribute:
+            return False
+        return True
+
+    def __getitem__(self, name):
+        return self._loader.get_attribute(self._node, name)
+
+
 @dataclass
 class StreamInfo:
     topic: str

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -213,10 +213,6 @@ class LoadFromJson:
         return self._get_child_from_group(group, dataset_name,
                                           (_nexus_dataset, )) is not None
 
-    @staticmethod
-    def supported_int_type(dataset):
-        return _filewriter_to_supported_numpy_dtype[LoadFromJson.get_dtype(dataset)]
-
     def load_dataset_direct(self,
                             dataset: Dict,
                             unit: Optional[sc.Unit] = None,
@@ -232,7 +228,8 @@ class LoadFromJson:
           otherwise retain dataset dtype
         """
         if dtype is None:
-            dtype = self.supported_int_type(dataset)
+            dtype = _filewriter_to_supported_numpy_dtype[LoadFromJson.get_dtype(
+                dataset)]
 
         return sc.array(dims=dimensions,
                         values=np.asarray(dataset[_nexus_values])[index],

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -291,14 +291,6 @@ class LoadFromJson:
         return group
 
     @staticmethod
-    def get_attribute(node: Dict, attribute_name: str) -> Any:
-        return _get_attribute_value(node, attribute_name)
-
-    @staticmethod
-    def get_string_attribute(node: Dict, attribute_name: str) -> str:
-        return _get_attribute_value(node, attribute_name)
-
-    @staticmethod
     def is_group(node: Any):
         try:
             return node["type"] == _nexus_group
@@ -311,9 +303,8 @@ class LoadFromJson:
 
 
 class JSONAttributeManager:
-    def __init__(self, node: dict, loader: LoadFromJson):
+    def __init__(self, node: dict):
         self._node = node
-        self._loader = loader
 
     def __contains__(self, name):
         try:
@@ -323,7 +314,7 @@ class JSONAttributeManager:
         return True
 
     def __getitem__(self, name):
-        return self._loader.get_attribute(self._node, name)
+        return _get_attribute_value(self._node, name)
 
 
 @dataclass

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -294,6 +294,10 @@ class JSONDataset:
         self._loader = loader
 
     @property
+    def attrs(self) -> JSONAttributeManager:
+        return JSONAttributeManager(self._node)
+
+    @property
     def dtype(self) -> str:
         try:
             return self._node[_nexus_dataset]["type"]


### PR DESCRIPTION
This is the first actual step towards removal of `LoadFromHdf5` and `LoadFromJson`. We introduce wrappers for attributes and datasets. This is not fully complete, and the next main step will be a wrapper for groups. This PR illustrates the approach.