### PR TITLE
Add "JSONGroup" and remove dependence on loader from new Nexus API

### DIFF
--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -76,12 +76,12 @@ def _ensure_str(str_or_bytes: Union[str, bytes], encoding: str) -> str:
 
 
 _map_to_supported_type = {
-    np.int8: np.int32,
-    np.int16: np.int32,
-    np.uint8: np.int32,
-    np.uint16: np.int32,
-    np.uint32: np.int32,
-    np.uint64: np.int64,
+    'int8': np.int32,
+    'int16': np.int32,
+    'uint8': np.int32,
+    'uint16': np.int32,
+    'uint32': np.int32,
+    'uint64': np.int64,
 }
 
 

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -287,6 +287,9 @@ class JSONAttributeManager:
     def __getitem__(self, name):
         return _get_attribute_value(self._node, name)
 
+    def get(self, name: str, default=None):
+        return self[name] if name in self else default
+
 
 class JSONNode:
     def __init__(self, node: dict, loader: LoadFromJson):
@@ -342,6 +345,13 @@ class _JSONGroup(JSONNode):
 
     def keys(self) -> List[str]:
         return self._loader.keys(self._node)
+
+    def visititems(self, callable):
+        for key in self.keys():
+            item = self[key]
+            callable(key, item)
+            if isinstance(item, _JSONGroup):
+                item.visititems(callable)
 
 
 @dataclass

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -363,7 +363,14 @@ class _JSONGroup(JSONNode):
         return self._loader.keys(self._node)
 
     def visititems(self, callable):
-        for key in self.keys():
+        def skip(node):
+            return node['type'] == _nexus_link or contains_stream(node)
+
+        children = [
+            child[_nexus_name] for child in self._node[_nexus_children]
+            if not skip(child)
+        ]
+        for key in children:
             item = self[key]
             callable(key, item)
             if isinstance(item, _JSONGroup):

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -288,7 +288,7 @@ class JSONAttributeManager:
         return _get_attribute_value(self._node, name)
 
 
-class JSONDataset:
+class JSONNode:
     def __init__(self, node: dict, loader: LoadFromJson):
         self._node = node
         self._loader = loader
@@ -296,13 +296,6 @@ class JSONDataset:
     @property
     def attrs(self) -> JSONAttributeManager:
         return JSONAttributeManager(self._node)
-
-    @property
-    def dtype(self) -> str:
-        try:
-            return self._node[_nexus_dataset]["type"]
-        except KeyError:
-            return self._node[_nexus_dataset]["dtype"]
 
     @property
     def name(self) -> str:
@@ -315,9 +308,22 @@ class JSONDataset:
     def file(self):
         return self._node.file
 
+
+class JSONDataset(JSONNode):
+    @property
+    def dtype(self) -> str:
+        try:
+            return self._node[_nexus_dataset]["type"]
+        except KeyError:
+            return self._node[_nexus_dataset]["dtype"]
+
     @property
     def shape(self):
         return np.asarray(self._node[_nexus_values]).shape
+
+
+class _JSONGroup(JSONNode):
+    pass
 
 
 @dataclass

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -297,7 +297,6 @@ class JSONNode:
         self._parent = self if parent is None else parent
         self._node = node
         self._loader = loader
-        print(self.name, parent is None, self._file.name, self._parent.name)
 
     @property
     def attrs(self) -> JSONAttributeManager:

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -331,8 +331,18 @@ class JSONDataset(JSONNode):
             return self._node[_nexus_dataset]["dtype"]
 
     @property
+    def ndim(self) -> int:
+        return len(self.shape)
+
+    @property
     def shape(self):
         return np.asarray(self._node[_nexus_values]).shape
+
+    def __getitem__(self, index):
+        return np.asarray(self._node[_nexus_values])[index]
+
+    def read_direct(self, buf, source_sel):
+        buf[...] = self[source_sel]
 
 
 class _JSONGroup(JSONNode):

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -310,12 +310,6 @@ class JSONNode:
         else:
             return self._node.get(_nexus_path, '/')
 
-    def _as_group_or_dataset(self, item, parent):
-        if self._loader.is_group(item):
-            return _JSONGroup(item, self._loader, parent=parent)
-        else:
-            return JSONDataset(item, self._loader, parent=parent)
-
     @property
     def file(self):
         return self._file
@@ -356,7 +350,14 @@ class _JSONGroup(JSONNode):
         return self._loader.dataset_in_group(self._node, name)
 
     def keys(self) -> List[str]:
-        return self._loader.keys(self._node)
+        children = self._node[_nexus_children]
+        return [child[_nexus_name] for child in children if not contains_stream(child)]
+
+    def _as_group_or_dataset(self, item, parent):
+        if self._loader.is_group(item):
+            return _JSONGroup(item, self._loader, parent=parent)
+        else:
+            return JSONDataset(item, self._loader, parent=parent)
 
     def get(self, name: str, default=None):
         if name.startswith('/') and name.count('/') == 1:

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -344,14 +344,18 @@ class JSONDataset(JSONNode):
     def read_direct(self, buf, source_sel):
         buf[...] = self[source_sel]
 
+    def asstr(self, **ignored):
+        return self
+
 
 class _JSONGroup(JSONNode):
     def __contains__(self, name: str) -> bool:
         return self._loader.dataset_in_group(self._node, name)
 
     def __getitem__(self, name: str) -> Union[JSONDataset, _JSONGroup]:
-        item = self._loader.get_child_from_group(self._node, name)
-        return self._as_group_or_dataset(item)
+        if (item := self._loader.get_child_from_group(self._node, name)) is not None:
+            return self._as_group_or_dataset(item)
+        raise KeyError(f"Unable to open object (object '{name}' doesn't exist)")
 
     def keys(self) -> List[str]:
         return self._loader.keys(self._node)

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -139,7 +139,7 @@ class LoadFromJson:
 
     def keys(self, group: Dict):
         children = group[_nexus_children]
-        return [child[_nexus_name] for child in children]
+        return [child[_nexus_name] for child in children if not contains_stream(child)]
 
     def values(self, group: Dict):
         return group[_nexus_children]

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -10,7 +10,7 @@ from ..nexus import NXroot, NX_class
 from ._common import BadSource, SkipSource
 from ._common import add_position_and_transforms_to_data
 from ._hdf5_nexus import LoadFromHdf5
-from ._json_nexus import LoadFromJson, get_streams_info, StreamInfo
+from ._json_nexus import LoadFromJson, get_streams_info, StreamInfo, _JSONGroup
 from ._nexus import LoadFromNexus, ScippData
 import h5py
 from timeit import default_timer as timer
@@ -136,7 +136,7 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
     Main implementation for loading data is extracted to this function so that
     in-memory data can be used for unit tests.
     """
-    root = NXroot(nexus_file if root is None else nexus_file[root], nexus)
+    root = NXroot(nexus_file if root is None else nexus_file[root])
     classes = root.by_nx_class()
 
     if len(classes[NX_class.NXentry]) > 1:
@@ -290,7 +290,9 @@ def _load_nexus_json(
     streams = None
     if get_start_info:
         streams = get_streams_info(loaded_json)
-    return _load_data(loaded_json, None, LoadFromJson(loaded_json), True), streams
+    loader = LoadFromJson(loaded_json)
+    group = _JSONGroup(loaded_json, loader)
+    return _load_data(group, None, loader, True), streams
 
 
 def load_nexus_json(json_filename: str) -> Optional[ScippData]:

--- a/src/scippneutron/file_loading/nxdata.py
+++ b/src/scippneutron/file_loading/nxdata.py
@@ -8,15 +8,12 @@ import scipp as sc
 import numpy as np
 from ._common import to_child_select, Group
 from .nxobject import Field, NXobject, ScippIndex, NexusStructureError
-from ._nexus import LoadFromNexus
-from ._hdf5_nexus import LoadFromHdf5
 
 
 class NXdata(NXobject):
     def __init__(
             self,
             group: Group,
-            loader: LoadFromNexus = LoadFromHdf5(),
             signal_name_default: str = None,
             signal_override: Union[Field, _EventField] = None,  # noqa: F821
             axes: List[str] = None,
@@ -30,7 +27,7 @@ class NXdata(NXobject):
         :param axes: Default axes used, if no `axes` attribute found in file.
         :param skip: Names of fields to skip when loading coords.
         """
-        super().__init__(group, loader)
+        super().__init__(group)
         self._signal_name_default = signal_name_default
         self._signal_override = signal_override
         self._axes_default = axes

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -191,4 +191,4 @@ class NXdetector(NXobject):
         return self._nxdata()._get_field_dims(name)
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
-        return self._nxdata()[select]
+        return self._nxdata()._getitem(select)

--- a/src/scippneutron/file_loading/nxdetector.py
+++ b/src/scippneutron/file_loading/nxdetector.py
@@ -142,7 +142,6 @@ class NXdetector(NXobject):
         # NXdetector uses a "hard-coded" signal name 'data', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
         return NXdata(self._group,
-                      self._loader,
                       signal_name_default='data' if 'data' in self else None,
                       signal_override=signal,
                       skip=self._nxevent_data_fields)
@@ -162,7 +161,7 @@ class NXdetector(NXobject):
             # (except for possibly using it to deduce shape and dims).
             return next(iter(event_entries.values()))
         if 'event_time_offset' in self:
-            return NXevent_data(self._group, self._loader)
+            return NXevent_data(self._group)
         return None
 
     @property

--- a/src/scippneutron/file_loading/nxevent_data.py
+++ b/src/scippneutron/file_loading/nxevent_data.py
@@ -5,9 +5,10 @@ from typing import List, Union
 import numpy as np
 import scipp as sc
 
-from ._common import BadSource
+from ._common import BadSource, SkipSource
 from ._common import to_plain_index, convert_time_to_datetime64
 from .nxobject import NXobject, ScippIndex, NexusStructureError
+from ._json_nexus import _JSONGroup, contains_stream
 
 _event_dimension = "event"
 _pulse_dimension = "pulse"
@@ -131,11 +132,11 @@ class NXevent_data(NXobject):
         return sc.DataArray(data=binned, coords={'event_time_zero': event_time_zero})
 
     def _check_for_missing_fields(self):
-        # if self._loader.contains_stream(self._group):
-        #     # Do not warn about missing datasets if the group contains
-        #     # a stream, as this will provide the missing data
-        #     raise SkipSource("Data source is missing datasets"
-        #                      "but contains a stream source for the data")
+        if isinstance(self._group, _JSONGroup) and contains_stream(self._group._node):
+            # Do not warn about missing datasets if the group contains
+            # a stream, as this will provide the missing data
+            raise SkipSource("Data source is missing datasets"
+                             "but contains a stream source for the data")
 
         for field in ("event_time_zero", "event_index", "event_time_offset"):
             if field not in self:

--- a/src/scippneutron/file_loading/nxevent_data.py
+++ b/src/scippneutron/file_loading/nxevent_data.py
@@ -5,7 +5,7 @@ from typing import List, Union
 import numpy as np
 import scipp as sc
 
-from ._common import BadSource, SkipSource
+from ._common import BadSource
 from ._common import to_plain_index, convert_time_to_datetime64
 from .nxobject import NXobject, ScippIndex, NexusStructureError
 
@@ -131,11 +131,11 @@ class NXevent_data(NXobject):
         return sc.DataArray(data=binned, coords={'event_time_zero': event_time_zero})
 
     def _check_for_missing_fields(self):
-        if self._loader.contains_stream(self._group):
-            # Do not warn about missing datasets if the group contains
-            # a stream, as this will provide the missing data
-            raise SkipSource("Data source is missing datasets"
-                             "but contains a stream source for the data")
+        # if self._loader.contains_stream(self._group):
+        #     # Do not warn about missing datasets if the group contains
+        #     # a stream, as this will provide the missing data
+        #     raise SkipSource("Data source is missing datasets"
+        #                      "but contains a stream source for the data")
 
         for field in ("event_time_zero", "event_index", "event_time_offset"):
             if field not in self:

--- a/src/scippneutron/file_loading/nxlog.py
+++ b/src/scippneutron/file_loading/nxlog.py
@@ -32,7 +32,7 @@ class NXlog(NXobject):
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXlog uses a "hard-coded" signal name 'value', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
-        return NXdata(self._group, self._loader, signal_name_default='value', axes=axes)
+        return NXdata(self._group, signal_name_default='value', axes=axes)
 
     def _getitem(self, select: ScippIndex) -> sc.DataArray:
         data = self._nxbase[select]

--- a/src/scippneutron/file_loading/nxmonitor.py
+++ b/src/scippneutron/file_loading/nxmonitor.py
@@ -30,11 +30,11 @@ class NXmonitor(NXobject):
     def _nxbase(self) -> Union[NXdata, NXevent_data]:
         """Branch between event-mode and histogram-mode monitor."""
         if self._is_events:
-            return NXevent_data(self._group, self._loader)
+            return NXevent_data(self._group)
         # NXdata uses the 'signal' attribute to define the field name of the signal.
         # NXmonitor uses a "hard-coded" signal name 'data', without specifying the
         # attribute in the file, so we pass this explicitly to NXdata.
-        return NXdata(self._group, self._loader, signal_name_default='data')
+        return NXdata(self._group, signal_name_default='data')
 
     def _get_field_dims(self, name: str) -> Union[None, List[str]]:
         if self._is_events:

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -69,9 +69,7 @@ class Field:
 
     In HDF5 fields are represented as dataset.
     """
-    def __init__(self,
-                 dataset: Dataset,
-                 dims=None):
+    def __init__(self, dataset: Dataset, dims=None):
         self._dataset = dataset
         if dims is not None:
             self._dims = dims
@@ -116,8 +114,8 @@ class Field:
     @property
     def dtype(self) -> str:
         dtype = self._dataset.dtype
-        if dtype == 'str' or (not isinstance(self._dataset, JSONDataset)
-                              and h5py.check_string_dtype(dtype)):
+        if str(dtype).startswith('str') or (not isinstance(self._dataset, JSONDataset)
+                                            and h5py.check_string_dtype(dtype)):
             dtype = sc.DType.string
         else:
             dtype = sc.DType(_ensure_supported_int_type(str(dtype)))
@@ -179,8 +177,6 @@ class NXobject:
             raise KeyError("None is not a valid index")
         if isinstance(name, str):
             item = self._group[name]
-            if item is None:
-                raise KeyError(f"Unable to open object (object '{name}' doesn't exist)")
             if hasattr(item, 'shape'):
                 dims = self._get_field_dims(name) if use_field_dims else None
                 return Field(item, dims=dims)
@@ -256,10 +252,7 @@ class NXobject:
             names = [group.name.split('/')[-1] for group in groups]
             if len(names) != len(set(names)):  # fall back to full path if duplicate
                 names = [group.name for group in groups]
-            out[NX_class[nx_class]] = {
-                n: _make(g)
-                for n, g in zip(names, groups)
-            }
+            out[NX_class[nx_class]] = {n: _make(g) for n, g in zip(names, groups)}
         return out
 
     @property

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -131,6 +131,7 @@ def _transformation_is_nx_log_stream(t):
     if (not isinstance(t, (Field, NXobject))):
         return True
     transform = t._group if isinstance(t, NXobject) else t._dataset
+    return False
     nexus = t._loader
     # Stream objects are only in the dict loaded from json
     if isinstance(transform, dict):

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -8,7 +8,7 @@ from typing import Union
 import scipp as sc
 import scipp.spatial
 import scipp.interpolate
-from ._json_nexus import contains_stream
+from ._json_nexus import contains_stream, _JSONGroup
 from .nxobject import Field, NXobject, ScippIndex
 
 
@@ -128,22 +128,12 @@ def get_full_transformation(depends_on: Field) -> Union[None, sc.DataArray]:
 
 def _transformation_is_nx_log_stream(t):
     t = t._obj
-    if (not isinstance(t, (Field, NXobject))):
-        return True
-    transform = t._group if isinstance(t, NXobject) else t._dataset
-    return False
-    nexus = t._loader
     # Stream objects are only in the dict loaded from json
-    if isinstance(transform, dict):
-        # If transform is a group and contains a stream but not a value dataset
-        # then assume it is a streamed NXlog transformation
-        try:
-            if nexus.is_group(transform):
-                found_value_dataset = nexus.dataset_in_group(transform, "value")
-                if not found_value_dataset and contains_stream(transform):
-                    return True
-        except KeyError:
-            pass
+    # If transform is a group and contains a stream but not a value dataset
+    # then assume it is a streamed NXlog transformation
+    if isinstance(t, _JSONGroup):
+        if 'value' not in t and contains_stream(t._node):
+            return True
     return False
 
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -28,6 +28,7 @@ def open_json(builder: NexusBuilder):
                 yield _JSONGroup(f, LoadFromJson(''))
         finally:
             pass
+
     return func
 
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -69,7 +69,7 @@ def builder_with_events_monitor_and_log():
 def test_nxobject_root(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         assert root.nx_class == nexus.NX_class.NXroot
         assert set(root.keys()) == {'entry', 'monitor'}
 
@@ -77,7 +77,7 @@ def test_nxobject_root(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_nxobject_items(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         items = root.items()
         assert len(items) == 2
         for k, v in items:
@@ -91,7 +91,7 @@ def test_nxobject_items(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_nxobject_entry(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        entry = nexus.NXroot(f, loader)['entry']
+        entry = nexus.NXroot(f)['entry']
         assert entry.nx_class == nexus.NX_class.NXentry
         assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
@@ -99,7 +99,7 @@ def test_nxobject_entry(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_nxobject_monitor(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        monitor = nexus.NXroot(f, loader)['monitor']
+        monitor = nexus.NXroot(f)['monitor']
         assert monitor.nx_class == nexus.NX_class.NXmonitor
         assert sc.identical(
             monitor[...],
@@ -113,7 +113,7 @@ def test_nxobject_monitor(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_nxobject_log(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        log = nexus.NXroot(f, loader)['entry']['log']
+        log = nexus.NXroot(f)['entry']['log']
         assert log.nx_class == nexus.NX_class.NXlog
         assert sc.identical(
             log[...],
@@ -130,7 +130,7 @@ def test_nxobject_log(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_nxobject_event_data(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        event_data = nexus.NXroot(f, loader)['entry']['events_0']
+        event_data = nexus.NXroot(f)['entry']['events_0']
         assert set(event_data.keys()) == set(
             ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
         assert event_data.nx_class == nexus.NX_class.NXevent_data
@@ -140,7 +140,7 @@ def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         with pytest.raises(KeyError):
             root['abcde']
 
@@ -149,7 +149,7 @@ def test_nxobject_name_property_is_full_path(nexus_group: Tuple[Callable,
                                                                 LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         assert root.name == '/'
         assert root['monitor'].name == '/monitor'
         assert root['entry'].name == '/entry'
@@ -161,7 +161,7 @@ def test_nxobject_grandchild_can_be_accessed_using_path(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         assert root['entry/log'].name == '/entry/log'
         assert root['/entry/log'].name == '/entry/log'
 
@@ -170,7 +170,7 @@ def test_nxobject_by_nx_class_of_root_contains_everything(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         classes = root.by_nx_class()
         assert list(classes[nexus.NX_class.NXentry]) == ['entry']
         assert list(classes[nexus.NX_class.NXmonitor]) == ['monitor']
@@ -182,7 +182,7 @@ def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable
                                                                         LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         classes = root['entry'].by_nx_class()
         assert list(classes[nexus.NX_class.NXentry]) == []
         assert list(classes[nexus.NX_class.NXmonitor]) == []
@@ -195,14 +195,14 @@ def test_nxobject_dataset_items_are_returned_as_Field(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
+        field = nexus.NXroot(f)['entry/events_0/event_time_offset']
         assert isinstance(field, nexus.Field)
 
 
 def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
+        field = nexus.NXroot(f)['entry/events_0/event_time_offset']
         assert field.dtype == 'int64'
         assert field.name == '/entry/events_0/event_time_offset'
         assert field.shape == (6, )
@@ -212,15 +212,15 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
 def test_field_dim_labels(nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        event_data = nexus.NXroot(f, loader)['entry/events_0']
+        event_data = nexus.NXroot(f)['entry/events_0']
         assert event_data['event_time_offset'].dims == ['event']
         assert event_data['event_time_zero'].dims == ['pulse']
         assert event_data['event_index'].dims == ['pulse']
         assert event_data['event_id'].dims == ['event']
-        log = nexus.NXroot(f, loader)['entry/log']
+        log = nexus.NXroot(f)['entry/log']
         assert log['time'].dims == ['time']
         assert log['value'].dims == ['time']
-        monitor = nexus.NXroot(f, loader)['monitor']
+        monitor = nexus.NXroot(f)['monitor']
         assert monitor['time_of_flight'].dims == ['time_of_flight']
         assert monitor['data'].dims == ['time_of_flight']
 
@@ -235,7 +235,7 @@ def test_field_unit_is_none_if_no_units_attribute(nexus_group: Tuple[Callable,
             np.array([4.4, 5.5, 6.6]),
             value_units=None))
     with resource(builder)() as f:
-        field = nexus.NXroot(f, loader)['entry/mylog']
+        field = nexus.NXroot(f)['entry/mylog']
         assert field.unit is None
 
 
@@ -243,7 +243,7 @@ def test_field_getitem_returns_variable_with_correct_size_and_values(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_monitor_and_log())() as f:
-        field = nexus.NXroot(f, loader)['entry/events_0/event_time_offset']
+        field = nexus.NXroot(f)['entry/events_0/event_time_offset']
         assert sc.identical(
             field[...],
             sc.array(dims=['dim_0'],
@@ -274,20 +274,20 @@ def test_field_of_utf8_encoded_dataset_is_loaded_correctly(
     else:  # json encodes itself
         builder.add_title(np.array([string, string + string]))
     with resource(builder)() as f:
-        title = nexus.NXroot(f, loader)['entry/title']
+        title = nexus.NXroot(f)['entry/title']
         assert sc.identical(title[...],
                             sc.array(dims=['dim_0'], values=[string, string + string]))
 
 
 def test_field_of_extended_ascii_in_ascii_encoded_dataset_is_loaded_correctly():
-    resource, loader = open_nexus, LoadFromHdf5()
+    resource = open_nexus
     builder = NexusBuilder()
     # When writing, if we use bytes h5py will write as ascii encoding
     # 0xb0 = degrees symbol in latin-1 encoding.
     string = b"run at rot=90" + bytes([0xb0])
     builder.add_title(np.array([string, string + b'x']))
     with resource(builder)() as f:
-        title = nexus.NXroot(f, loader)['entry/title']
+        title = nexus.NXroot(f)['entry/title']
         assert sc.identical(
             title[...],
             sc.array(dims=['dim_0'], values=["run at rot=90°", "run at rot=90°x"]))
@@ -310,7 +310,7 @@ def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable
     builder.add_event_data(event_data)
     resource, loader = nexus_group
     with resource(builder)() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         events = root['entry/events_0'][...]
         assert events.bins.size().values[2] == 3
         assert events.bins.size().values[3] == 0
@@ -339,7 +339,7 @@ def test_event_data_without_event_id_can_be_loaded(nexus_group: Tuple[Callable,
                                                                       LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_and_events_monitor_without_event_id())() as f:
-        event_data = nexus.NXroot(f, loader)['entry/events_0']
+        event_data = nexus.NXroot(f)['entry/events_0']
         da = event_data[...]
         assert len(da.bins.coords) == 1
         assert 'event_time_offset' in da.bins.coords
@@ -349,7 +349,7 @@ def test_event_mode_monitor_without_event_id_can_be_loaded(
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_and_events_monitor_without_event_id())() as f:
-        monitor = nexus.NXroot(f, loader)['monitor']
+        monitor = nexus.NXroot(f)['monitor']
         da = monitor[...]
         assert len(da.bins.coords) == 1
         assert 'event_time_offset' in da.bins.coords

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from .nexus_helpers import (
     NexusBuilder,
     EventData,
@@ -11,7 +12,7 @@ from typing import Callable, Tuple
 import scipp as sc
 from scippneutron.file_loading._nexus import LoadFromNexus
 from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
-from scippneutron.file_loading._json_nexus import LoadFromJson
+from scippneutron.file_loading._json_nexus import LoadFromJson, _JSONGroup
 from scippneutron import nexus
 
 
@@ -20,7 +21,14 @@ def open_nexus(builder: NexusBuilder):
 
 
 def open_json(builder: NexusBuilder):
-    return builder.json
+    @contextmanager
+    def func():
+        try:
+            with builder.json() as f:
+                yield _JSONGroup(f, LoadFromJson(''))
+        finally:
+            pass
+    return func
 
 
 @pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -21,7 +21,7 @@ def test_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -34,7 +34,7 @@ def test_with_coords_matching_axis_names(nexus_group: Tuple[Callable, LoadFromNe
     da.coords['xx'] = da.data['yy', 0]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -48,7 +48,7 @@ def test_guessed_dim_for_coord_not_matching_axis_name(
     da.coords['xx2'] = da.data['yy', 1]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -63,7 +63,7 @@ def test_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -77,7 +77,7 @@ def test_slice_of_1d(nexus_group: Tuple[Callable, LoadFromNexus]):
     da.coords['scalar'] = sc.scalar(1.2)
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         assert sc.identical(data['xx', :2], da['xx', :2])
         assert sc.identical(data[:2], da['xx', :2])
 
@@ -92,7 +92,7 @@ def test_slice_of_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         assert sc.identical(data['xx', :2], da['xx', :2])
 
 
@@ -105,7 +105,7 @@ def test_guessed_dim_for_2d_coord_not_matching_axis_name(
     da.coords['xx2'] = da.data
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -119,7 +119,7 @@ def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         da = data[...]
         assert 'yy2' not in da.coords
 
@@ -133,7 +133,7 @@ def test_guesses_transposed_dims_for_2d_coord(nexus_group: Tuple[Callable,
     da.coords['xx2'] = sc.transpose(da.data)
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -146,7 +146,7 @@ def test_integer_indices_attribute_for_coord(nexus_group: Tuple[Callable,
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': 1}))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -158,7 +158,7 @@ def test_list_indices_attribute_for_coord(nexus_group: Tuple[Callable, LoadFromN
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': [1]}))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -171,7 +171,7 @@ def test_transpose_indices_attribute_for_coord(nexus_group: Tuple[Callable,
     da.coords['xx2'] = sc.transpose(da.data)
     builder.add_data(Data(name='data1', data=da, attrs={'xx2_indices': [1, 0]}))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
@@ -186,7 +186,7 @@ def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Tuple[Callable,
     # We flag 'xx' as auxiliary_signal. It should thus not be loaded as a coord.
     builder.add_data(Data(name='data1', data=da, attrs={'auxiliary_signals': ['xx']}))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         del da.coords['xx']
         assert sc.identical(loaded, da)
@@ -202,7 +202,7 @@ def test_field_dims_match_NXdata_dims(nexus_group: Tuple[Callable, LoadFromNexus
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         assert sc.identical(data['xx', :2].data, data['signal1']['xx', :2])
         assert sc.identical(data['xx', :2].coords['xx'], data['xx']['xx', :2])
         assert sc.identical(data['xx', :2].coords['xx2'], data['xx2']['xx', :2])
@@ -218,6 +218,6 @@ def test_uses_default_field_dims_if_inference_fails(nexus_group: Tuple[Callable,
     da.coords['yy2'] = sc.arange('yy', 4)
     builder.add_data(Data(name='data1', data=da))
     with resource(builder)() as f:
-        data = nexus.NXroot(f, loader)['entry/data1']
+        data = nexus.NXroot(f)['entry/data1']
         assert 'yy2' not in data[()].coords
         assert sc.identical(data['yy2'][()], da.coords['yy2'].rename(yy='dim_0'))

--- a/tests/nxdetector_test.py
+++ b/tests/nxdetector_test.py
@@ -21,7 +21,7 @@ def test_raises_if_no_data_found(nexus_group: Tuple[Callable, LoadFromNexus]):
     builder = NexusBuilder()
     builder.add_detector(Detector(detector_numbers=np.array([1, 2, 3, 4])))
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         with pytest.raises(KeyError):
             detector[...]
 
@@ -42,7 +42,7 @@ def test_loads_events_when_data_and_events_found(nexus_group: Tuple[Callable,
                  data=da,
                  event_data=event_data))
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector[...].bins is not None
 
 
@@ -57,7 +57,7 @@ def test_loads_data_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
                                                   unit=None,
                                                   values=detector_numbers)
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         loaded = detector[...]
         assert sc.identical(loaded, expected)
 
@@ -74,7 +74,7 @@ def test_select_events_raises_if_detector_contains_data(
                                                   unit=None,
                                                   values=detector_numbers)
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         with pytest.raises(nexus.NexusStructureError):
             detector.select_events
 
@@ -92,7 +92,7 @@ def test_loads_data_with_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
                                                   unit=None,
                                                   values=detector_numbers)
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         loaded = detector[...]
         assert sc.identical(loaded, expected)
 
@@ -111,7 +111,7 @@ def test_loads_event_data_mapped_to_detector_numbers_based_on_their_event_id(
         Detector(detector_numbers=np.array([1, 2, 3, 4]), event_data=event_data))
     resource, loader = nexus_group
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector.dims == ['dim_0']
         assert detector.shape == (4, )
         loaded = detector[...]
@@ -136,7 +136,7 @@ def test_loads_event_data_with_2d_detector_numbers(nexus_group: Tuple[Callable,
         Detector(detector_numbers=np.array([[1, 2], [3, 4]]), event_data=event_data))
     resource, loader = nexus_group
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector.dims == ['dim_0', 'dim_1']
         assert detector.shape == (2, 2)
         loaded = detector[...]
@@ -162,7 +162,7 @@ def test_select_events_slices_underlying_event_data(nexus_group: Tuple[Callable,
         Detector(detector_numbers=np.array([[1, 2], [3, 4]]), event_data=event_data))
     resource, loader = nexus_group
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert sc.identical(
             detector.select_events['pulse', :2][...].bins.size().data,
             sc.array(dims=['dim_0', 'dim_1'],
@@ -203,7 +203,7 @@ def test_select_events_slice_does_not_affect_original_detector(
         Detector(detector_numbers=np.array([[1, 2], [3, 4]]), event_data=event_data))
     resource, loader = nexus_group
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         detector.select_events['pulse', 0][...]
         assert sc.identical(
             detector[...].bins.size().data,
@@ -230,7 +230,7 @@ def test_loading_event_data_creates_automatic_detector_numbers_if_not_present_in
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_and_no_detector_number())() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector.dims == ['detector_number']
         with pytest.raises(nexus.NexusStructureError):
             detector.shape
@@ -247,7 +247,7 @@ def test_loading_event_data_with_selection_and_automatic_detector_numbers_raises
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_and_no_detector_number())() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector.dims == ['detector_number']
         with pytest.raises(nexus.NexusStructureError):
             detector['detector_number', 0]
@@ -257,7 +257,7 @@ def test_loading_event_data_with_full_selection_and_automatic_detector_numbers_w
         nexus_group: Tuple[Callable, LoadFromNexus]):
     resource, loader = nexus_group
     with resource(builder_with_events_and_no_detector_number())() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector.dims == ['detector_number']
         assert detector[...].shape == [4]
         assert detector[()].shape == [4]
@@ -302,7 +302,7 @@ def test_event_data_field_dims_labels(nexus_group: Tuple[Callable, LoadFromNexus
         Detector(detector_numbers=np.array([1, 2, 3, 4]), event_data=event_data))
     resource, loader = nexus_group
     with resource(builder)() as f:
-        detector = nexus.NXroot(f, loader)['entry/detector_0']
+        detector = nexus.NXroot(f)['entry/detector_0']
         assert detector['detector_number'].dims == ['dim_0']
 
 
@@ -324,7 +324,7 @@ def test_nxevent_data_selection_yields_correct_pulses(
     resource, loader = nexus_group
 
     with resource(builder)() as f:
-        events = nexus.NXroot(f, loader)['entry/events_0']
+        events = nexus.NXroot(f)['entry/events_0']
 
         class Load:
             def __getitem__(self, select=...):

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -41,7 +41,7 @@ def test_Transformation_with_single_value(nexus_group: Tuple[Callable, LoadFromN
     expected = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
     expected = expected * sc.spatial.translation(value=[0.001, 0.002, 0.003], unit='m')
     with resource(builder)() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         detector = root['entry/detector_0']
         depends_on = detector['depends_on'][()].value
         t = nxtransformations.Transformation(root[depends_on])
@@ -73,7 +73,7 @@ def test_Transformation_with_multiple_values(nexus_group: Tuple[Callable,
     t.data = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
     expected = t * offset
     with resource(builder)() as f:
-        root = nexus.NXroot(f, loader)
+        root = nexus.NXroot(f)
         detector = root['entry/detector_0']
         depends_on = detector['depends_on'][()].value
         t = nxtransformations.Transformation(root[depends_on])


### PR DESCRIPTION
- Add JSONGroup (named _JSONGroup until the small legacy of the same name is removed).
- Remove need to track the "loader" in NXobject, Field, and friends.

This is the last but one big step in removing the older LoadFromHdf5 and LoadFromJson classes. There should now be a fair amount of code that can be moved and removed. Next, _JSONGroup and JSONDataset will be refactored to avoid the cumbersome reliance on LoadFromJson. I chose to not include this refactoring step (which will result in code removal) here, since I felt that the diff would be much harder to decipher. This implies that a number of details in this PR are temporary.