### PR TITLE
Refactor new JSON wrappers and remove old code

### DIFF
--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
-# @author Matthew Jones
-
-from typing import Union, Tuple, Dict, List
-import h5py
+# @author Simon Heybrock
+from typing import Union, Tuple, Dict, List, Protocol, Callable
 import scipp as sc
 import numpy as np
 
@@ -32,16 +30,17 @@ class MissingAttribute(Exception):
     pass
 
 
-class JSONGroup(dict):
-    def __init__(self, parent: dict, name: str, file: dict, group: dict):
-        super().__init__(**group)
-        self.parent = parent
-        self.name = name
-        self.file = file
+# TODO Define more required methods
+class Dataset(Protocol):
+    """h5py.Dataset-like"""
+    def shape(self) -> List[int]:
+        """Shape of a dataset"""
 
 
-Dataset = Union[h5py.Dataset, Dict]
-Group = Union[h5py.Group, JSONGroup]
+class Group(Protocol):
+    """h5py.Group-like"""
+    def visititems(self, func: Callable) -> None:
+        """"""
 
 
 def convert_time_to_datetime64(

--- a/src/scippneutron/file_loading/_hdf5_nexus.py
+++ b/src/scippneutron/file_loading/_hdf5_nexus.py
@@ -31,16 +31,6 @@ def _cset_to_encoding(cset: int) -> str:
                          f"{h5py.h5t.CSET_UTF8=} but got '{cset}'. ")
 
 
-def _get_attr_encoding(group: h5py.Group, dataset_name: str) -> str:
-    cset = h5py.h5a.open(group.id, dataset_name.encode("utf-8")).get_type().get_cset()
-    return _cset_to_encoding(cset)
-
-
-def _get_attr_as_str(h5_object, attribute_name: str) -> str:
-    return _ensure_str(h5_object.attrs[attribute_name],
-                       _get_attr_encoding(h5_object, attribute_name))
-
-
 def _warn_latin1_decode(obj, decoded, error):
     warnings.warn(f"Encoding for bytes '{obj}' declared as ascii, "
                   f"but contains characters in extended ascii range. Assuming "

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -91,8 +91,10 @@ def contains_stream(group: Dict) -> bool:
     """
     Return True if the group contains a stream object
     """
+    if not isinstance(group, _JSONGroup):
+        return False
     try:
-        for child in group[_nexus_children]:
+        for child in group._node[_nexus_children]:
             try:
                 if child["type"] == _nexus_stream:
                     return True
@@ -382,7 +384,7 @@ class _JSONGroup(JSONNode):
 
     def visititems(self, callable):
         def skip(node):
-            return node['type'] == _nexus_link or contains_stream(node)
+            return node['type'] == _nexus_link or contains_stream(self)
 
         children = [
             child[_nexus_name] for child in self._node[_nexus_children]

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -96,7 +96,7 @@ def contains_stream(group: Dict) -> bool:
     """
     Return True if the group contains a stream object
     """
-    if not isinstance(group, _JSONGroup):
+    if not isinstance(group, JSONGroup):
         return False
     try:
         for child in group._node[_nexus_children]:
@@ -211,7 +211,7 @@ class JSONDataset(JSONNode):
         return self
 
 
-class _JSONGroup(JSONNode):
+class JSONGroup(JSONNode):
     def __contains__(self, name: str) -> bool:
         try:
             self[name]
@@ -225,11 +225,11 @@ class _JSONGroup(JSONNode):
 
     def _as_group_or_dataset(self, item, parent):
         if item['type'] == _nexus_group:
-            return _JSONGroup(item, parent=parent)
+            return JSONGroup(item, parent=parent)
         else:
             return JSONDataset(item, parent=parent)
 
-    def __getitem__(self, name: str) -> Union[JSONDataset, _JSONGroup]:
+    def __getitem__(self, name: str) -> Union[JSONDataset, JSONGroup]:
         if name.startswith('/') and name.count('/') == 1:
             parent = self.file
         elif '/' in name:
@@ -258,7 +258,7 @@ class _JSONGroup(JSONNode):
         for key in children:
             item = self[key]
             callable(key, item)
-            if isinstance(item, _JSONGroup):
+            if isinstance(item, JSONGroup):
                 item.visititems(callable)
 
 

--- a/src/scippneutron/file_loading/_nexus.py
+++ b/src/scippneutron/file_loading/_nexus.py
@@ -1,7 +1,4 @@
-from ._json_nexus import LoadFromJson
-from ._hdf5_nexus import LoadFromHdf5
 from typing import Union
 import scipp as sc
 
-LoadFromNexus = Union[LoadFromJson, LoadFromHdf5]
 ScippData = Union[sc.Dataset, sc.DataArray, None]

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -291,7 +291,7 @@ def _load_nexus_json(
     if get_start_info:
         streams = get_streams_info(loaded_json)
     loader = LoadFromJson(loaded_json)
-    group = _JSONGroup(loaded_json, loader)
+    group = _JSONGroup(loaded_json)
     return _load_data(group, None, loader, True), streams
 
 

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -9,7 +9,7 @@ from ..nexus import NXroot, NX_class
 
 from ._common import BadSource, SkipSource
 from ._common import add_position_and_transforms_to_data
-from ._json_nexus import get_streams_info, StreamInfo, _JSONGroup
+from ._json_nexus import get_streams_info, StreamInfo, JSONGroup
 from ._json_nexus import contains_stream
 from ._nexus import ScippData
 import h5py
@@ -290,7 +290,7 @@ def _load_nexus_json(
     streams = None
     if get_start_info:
         streams = get_streams_info(loaded_json)
-    group = _JSONGroup(loaded_json)
+    group = JSONGroup(loaded_json)
     return _load_data(group, None, True), streams
 
 

--- a/src/scippneutron/file_loading/nxevent_data.py
+++ b/src/scippneutron/file_loading/nxevent_data.py
@@ -8,7 +8,7 @@ import scipp as sc
 from ._common import BadSource, SkipSource
 from ._common import to_plain_index, convert_time_to_datetime64
 from .nxobject import NXobject, ScippIndex, NexusStructureError
-from ._json_nexus import _JSONGroup, contains_stream
+from ._json_nexus import contains_stream
 
 _event_dimension = "event"
 _pulse_dimension = "pulse"
@@ -132,7 +132,7 @@ class NXevent_data(NXobject):
         return sc.DataArray(data=binned, coords={'event_time_zero': event_time_zero})
 
     def _check_for_missing_fields(self):
-        if isinstance(self._group, _JSONGroup) and contains_stream(self._group._node):
+        if contains_stream(self._group):
             # Do not warn about missing datasets if the group contains
             # a stream, as this will provide the missing data
             raise SkipSource("Data source is missing datasets"

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -132,7 +132,7 @@ def _transformation_is_nx_log_stream(t):
     # If transform is a group and contains a stream but not a value dataset
     # then assume it is a streamed NXlog transformation
     if isinstance(t, _JSONGroup):
-        if 'value' not in t and contains_stream(t._node):
+        if 'value' not in t and contains_stream(t):
             return True
     return False
 

--- a/src/scippneutron/file_loading/nxtransformations.py
+++ b/src/scippneutron/file_loading/nxtransformations.py
@@ -8,7 +8,7 @@ from typing import Union
 import scipp as sc
 import scipp.spatial
 import scipp.interpolate
-from ._json_nexus import contains_stream, _JSONGroup
+from ._json_nexus import contains_stream, JSONGroup
 from .nxobject import Field, NXobject, ScippIndex
 
 
@@ -131,7 +131,7 @@ def _transformation_is_nx_log_stream(t):
     # Stream objects are only in the dict loaded from json
     # If transform is a group and contains a stream but not a value dataset
     # then assume it is a streamed NXlog transformation
-    if isinstance(t, _JSONGroup):
+    if isinstance(t, JSONGroup):
         if 'value' not in t and contains_stream(t):
             return True
     return False

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -9,7 +9,7 @@ import numpy as np
 from enum import Enum
 from contextlib import contextmanager
 import json
-from scippneutron.file_loading._json_nexus import _JSONGroup
+from scippneutron.file_loading._json_nexus import JSONGroup
 
 h5root = Union[h5py.File, h5py.Group]
 
@@ -481,7 +481,7 @@ class NexusBuilder:
     @contextmanager
     def json(self):
         try:
-            yield _JSONGroup(json.loads(self.json_string))
+            yield JSONGroup(json.loads(self.json_string))
         finally:
             pass
 

--- a/tests/nexus_helpers.py
+++ b/tests/nexus_helpers.py
@@ -10,6 +10,7 @@ from enum import Enum
 from contextlib import contextmanager
 import json
 from scippneutron.file_loading._json_nexus import LoadFromJson, MissingDataset
+from scippneutron.file_loading._json_nexus import _JSONGroup
 
 h5root = Union[h5py.File, h5py.Group]
 
@@ -469,7 +470,7 @@ class NexusBuilder:
     @contextmanager
     def json(self):
         try:
-            yield json.loads(self.json_string)
+            yield _JSONGroup(json.loads(self.json_string))
         finally:
             pass
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -25,7 +25,7 @@ def open_json(builder: NexusBuilder):
     def func():
         try:
             with builder.json() as f:
-                yield _JSONGroup(f, LoadFromJson(''))
+                yield _JSONGroup(f)
         finally:
             pass
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from .nexus_helpers import (
     NexusBuilder,
     EventData,
@@ -8,11 +7,8 @@ from .nexus_helpers import (
 from .test_load_nexus import UTF8_TEST_STRINGS
 import numpy as np
 import pytest
-from typing import Callable, Tuple
+from typing import Callable
 import scipp as sc
-from scippneutron.file_loading._nexus import LoadFromNexus
-from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
-from scippneutron.file_loading._json_nexus import LoadFromJson, _JSONGroup
 from scippneutron import nexus
 
 
@@ -21,18 +17,10 @@ def open_nexus(builder: NexusBuilder):
 
 
 def open_json(builder: NexusBuilder):
-    @contextmanager
-    def func():
-        try:
-            with builder.json() as f:
-                yield _JSONGroup(f)
-        finally:
-            pass
-
-    return func
+    return builder.json
 
 
-@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+@pytest.fixture(params=[open_nexus, open_json])
 def nexus_group(request):
     """
     Each test with this fixture is executed with load_nexus_json
@@ -67,17 +55,15 @@ def builder_with_events_monitor_and_log():
     return builder
 
 
-def test_nxobject_root(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_root(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         assert root.nx_class == nexus.NX_class.NXroot
         assert set(root.keys()) == {'entry', 'monitor'}
 
 
-def test_nxobject_items(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_items(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         items = root.items()
         assert len(items) == 2
@@ -89,17 +75,15 @@ def test_nxobject_items(nexus_group: Tuple[Callable, LoadFromNexus]):
                 assert v.nx_class == nexus.NX_class.NXmonitor
 
 
-def test_nxobject_entry(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_entry(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         entry = nexus.NXroot(f)['entry']
         assert entry.nx_class == nexus.NX_class.NXentry
         assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
 
-def test_nxobject_monitor(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_monitor(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         monitor = nexus.NXroot(f)['monitor']
         assert monitor.nx_class == nexus.NX_class.NXmonitor
         assert sc.identical(
@@ -111,9 +95,8 @@ def test_nxobject_monitor(nexus_group: Tuple[Callable, LoadFromNexus]):
                          }))
 
 
-def test_nxobject_log(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_log(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         log = nexus.NXroot(f)['entry']['log']
         assert log.nx_class == nexus.NX_class.NXlog
         assert sc.identical(
@@ -128,9 +111,8 @@ def test_nxobject_log(nexus_group: Tuple[Callable, LoadFromNexus]):
                 }))
 
 
-def test_nxobject_event_data(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_event_data(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         event_data = nexus.NXroot(f)['entry']['events_0']
         assert set(event_data.keys()) == set(
             ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
@@ -138,18 +120,15 @@ def test_nxobject_event_data(nexus_group: Tuple[Callable, LoadFromNexus]):
 
 
 def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+        nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         with pytest.raises(KeyError):
             root['abcde']
 
 
-def test_nxobject_name_property_is_full_path(nexus_group: Tuple[Callable,
-                                                                LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_name_property_is_full_path(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         assert root.name == '/'
         assert root['monitor'].name == '/monitor'
@@ -158,19 +137,15 @@ def test_nxobject_name_property_is_full_path(nexus_group: Tuple[Callable,
         assert root['entry']['events_0'].name == '/entry/events_0'
 
 
-def test_nxobject_grandchild_can_be_accessed_using_path(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_grandchild_can_be_accessed_using_path(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         assert root['entry/log'].name == '/entry/log'
         assert root['/entry/log'].name == '/entry/log'
 
 
-def test_nxobject_by_nx_class_of_root_contains_everything(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_by_nx_class_of_root_contains_everything(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         classes = root.by_nx_class()
         assert list(classes[nexus.NX_class.NXentry]) == ['entry']
@@ -179,10 +154,8 @@ def test_nxobject_by_nx_class_of_root_contains_everything(
         assert set(classes[nexus.NX_class.NXevent_data]) == {'events_0', 'events_1'}
 
 
-def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable,
-                                                                        LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_by_nx_class_contains_only_children(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         root = nexus.NXroot(f)
         classes = root['entry'].by_nx_class()
         assert list(classes[nexus.NX_class.NXentry]) == []
@@ -192,17 +165,14 @@ def test_nxobject_by_nx_class_contains_only_children(nexus_group: Tuple[Callable
             ['events_0', 'events_1'])
 
 
-def test_nxobject_dataset_items_are_returned_as_Field(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_nxobject_dataset_items_are_returned_as_Field(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f)['entry/events_0/event_time_offset']
         assert isinstance(field, nexus.Field)
 
 
-def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_field_properties(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f)['entry/events_0/event_time_offset']
         assert field.dtype == 'int64'
         assert field.name == '/entry/events_0/event_time_offset'
@@ -210,9 +180,8 @@ def test_field_properties(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert field.unit == sc.Unit('ns')
 
 
-def test_field_dim_labels(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+def test_field_dim_labels(nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         event_data = nexus.NXroot(f)['entry/events_0']
         assert event_data['event_time_offset'].dims == ['event']
         assert event_data['event_time_zero'].dims == ['pulse']
@@ -226,24 +195,21 @@ def test_field_dim_labels(nexus_group: Tuple[Callable, LoadFromNexus]):
         assert monitor['data'].dims == ['time_of_flight']
 
 
-def test_field_unit_is_none_if_no_units_attribute(nexus_group: Tuple[Callable,
-                                                                     LoadFromNexus]):
-    resource, loader = nexus_group
+def test_field_unit_is_none_if_no_units_attribute(nexus_group: Callable):
     builder = builder_with_events_monitor_and_log()
     builder.add_log(
         Log("mylog",
             np.array([1.1, 2.2, 3.3]),
             np.array([4.4, 5.5, 6.6]),
             value_units=None))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         field = nexus.NXroot(f)['entry/mylog']
         assert field.unit is None
 
 
 def test_field_getitem_returns_variable_with_correct_size_and_values(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_monitor_and_log())() as f:
+        nexus_group: Callable):
+    with nexus_group(builder_with_events_monitor_and_log())() as f:
         field = nexus.NXroot(f)['entry/events_0/event_time_offset']
         assert sc.identical(
             field[...],
@@ -266,36 +232,34 @@ def test_field_getitem_returns_variable_with_correct_size_and_values(
 
 
 @pytest.mark.parametrize("string", UTF8_TEST_STRINGS)
-def test_field_of_utf8_encoded_dataset_is_loaded_correctly(
-        nexus_group: Tuple[Callable, LoadFromNexus], string):
-    resource, loader = nexus_group
+def test_field_of_utf8_encoded_dataset_is_loaded_correctly(nexus_group: Callable,
+                                                           string):
     builder = NexusBuilder()
-    if isinstance(loader, LoadFromHdf5):
+    if nexus_group == open_nexus:
         builder.add_title(np.array([string, string + string], dtype=object))
     else:  # json encodes itself
         builder.add_title(np.array([string, string + string]))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         title = nexus.NXroot(f)['entry/title']
         assert sc.identical(title[...],
                             sc.array(dims=['dim_0'], values=[string, string + string]))
 
 
 def test_field_of_extended_ascii_in_ascii_encoded_dataset_is_loaded_correctly():
-    resource = open_nexus
+    nexus_group = open_nexus
     builder = NexusBuilder()
     # When writing, if we use bytes h5py will write as ascii encoding
     # 0xb0 = degrees symbol in latin-1 encoding.
     string = b"run at rot=90" + bytes([0xb0])
     builder.add_title(np.array([string, string + b'x']))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         title = nexus.NXroot(f)['entry/title']
         assert sc.identical(
             title[...],
             sc.array(dims=['dim_0'], values=["run at rot=90°", "run at rot=90°x"]))
 
 
-def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable,
-                                                                        LoadFromNexus]):
+def test_negative_event_index_converted_to_num_event(nexus_group: Callable):
     event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
     event_data = EventData(
         event_id=np.array([1, 2, 3, 1, 3, 2]),
@@ -309,8 +273,7 @@ def test_negative_event_index_converted_to_num_event(nexus_group: Tuple[Callable
 
     builder = NexusBuilder()
     builder.add_event_data(event_data)
-    resource, loader = nexus_group
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         root = nexus.NXroot(f)
         events = root['entry/events_0'][...]
         assert events.bins.size().values[2] == 3
@@ -336,20 +299,16 @@ def builder_with_events_and_events_monitor_without_event_id():
     return builder
 
 
-def test_event_data_without_event_id_can_be_loaded(nexus_group: Tuple[Callable,
-                                                                      LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_and_events_monitor_without_event_id())() as f:
+def test_event_data_without_event_id_can_be_loaded(nexus_group: Callable):
+    with nexus_group(builder_with_events_and_events_monitor_without_event_id())() as f:
         event_data = nexus.NXroot(f)['entry/events_0']
         da = event_data[...]
         assert len(da.bins.coords) == 1
         assert 'event_time_offset' in da.bins.coords
 
 
-def test_event_mode_monitor_without_event_id_can_be_loaded(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
-    with resource(builder_with_events_and_events_monitor_without_event_id())() as f:
+def test_event_mode_monitor_without_event_id_can_be_loaded(nexus_group: Callable):
+    with nexus_group(builder_with_events_and_events_monitor_without_event_id())() as f:
         monitor = nexus.NXroot(f)['monitor']
         da = monitor[...]
         assert len(da.bins.coords) == 1

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -1,60 +1,52 @@
 from .nexus_test import open_nexus, open_json
 from .nexus_helpers import NexusBuilder, Data
-from typing import Callable, Tuple
+from typing import Callable
 import scipp as sc
-from scippneutron.file_loading._nexus import LoadFromNexus
-from scippneutron.file_loading._hdf5_nexus import LoadFromHdf5
-from scippneutron.file_loading._json_nexus import LoadFromJson
 from scippneutron import nexus
 import pytest
 
 
-@pytest.fixture(params=[(open_nexus, LoadFromHdf5()), (open_json, LoadFromJson(''))])
+@pytest.fixture(params=[open_nexus, open_json])
 def nexus_group(request):
     return request.param
 
 
-def test_without_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_without_coords(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_with_coords_matching_axis_names(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_with_coords_matching_axis_names(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_guessed_dim_for_coord_not_matching_axis_name(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_guessed_dim_for_coord_not_matching_axis_name(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = da.data['yy', 1]
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_multiple_coords(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
@@ -62,28 +54,26 @@ def test_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_slice_of_1d(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_slice_of_1d(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(sc.array(dims=['xx'], unit='m', values=[1, 2, 3]))
     da.coords['xx'] = da.data
     da.coords['xx2'] = da.data
     da.coords['scalar'] = sc.scalar(1.2)
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         assert sc.identical(data['xx', :2], da['xx', :2])
         assert sc.identical(data[:2], da['xx', :2])
 
 
-def test_slice_of_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_slice_of_multiple_coords(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
@@ -91,109 +81,95 @@ def test_slice_of_multiple_coords(nexus_group: Tuple[Callable, LoadFromNexus]):
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         assert sc.identical(data['xx', :2], da['xx', :2])
 
 
-def test_guessed_dim_for_2d_coord_not_matching_axis_name(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_guessed_dim_for_2d_coord_not_matching_axis_name(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = da.data
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(
-        nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         da = data[...]
         assert 'yy2' not in da.coords
 
 
-def test_guesses_transposed_dims_for_2d_coord(nexus_group: Tuple[Callable,
-                                                                 LoadFromNexus]):
-    resource, loader = nexus_group
+def test_guesses_transposed_dims_for_2d_coord(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = sc.transpose(da.data)
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_integer_indices_attribute_for_coord(nexus_group: Tuple[Callable,
-                                                                LoadFromNexus]):
-    resource, loader = nexus_group
+def test_integer_indices_attribute_for_coord(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': 1}))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_list_indices_attribute_for_coord(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_list_indices_attribute_for_coord(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['yy2'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': [1]}))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_transpose_indices_attribute_for_coord(nexus_group: Tuple[Callable,
-                                                                  LoadFromNexus]):
-    resource, loader = nexus_group
+def test_transpose_indices_attribute_for_coord(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['xx2'] = sc.transpose(da.data)
     builder.add_data(Data(name='data1', data=da, attrs={'xx2_indices': [1, 0]}))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         assert sc.identical(loaded, da)
 
 
-def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Tuple[Callable,
-                                                                    LoadFromNexus]):
-    resource, loader = nexus_group
+def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['xx', 0]
     # We flag 'xx' as auxiliary_signal. It should thus not be loaded as a coord.
     builder.add_data(Data(name='data1', data=da, attrs={'auxiliary_signals': ['xx']}))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         loaded = data[...]
         del da.coords['xx']
         assert sc.identical(loaded, da)
 
 
-def test_field_dims_match_NXdata_dims(nexus_group: Tuple[Callable, LoadFromNexus]):
-    resource, loader = nexus_group
+def test_field_dims_match_NXdata_dims(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
@@ -201,7 +177,7 @@ def test_field_dims_match_NXdata_dims(nexus_group: Tuple[Callable, LoadFromNexus
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         assert sc.identical(data['xx', :2].data, data['signal1']['xx', :2])
         assert sc.identical(data['xx', :2].coords['xx'], data['xx']['xx', :2])
@@ -209,15 +185,13 @@ def test_field_dims_match_NXdata_dims(nexus_group: Tuple[Callable, LoadFromNexus
         assert sc.identical(data['xx', :2].coords['yy'], data['yy'][:])
 
 
-def test_uses_default_field_dims_if_inference_fails(nexus_group: Tuple[Callable,
-                                                                       LoadFromNexus]):
-    resource, loader = nexus_group
+def test_uses_default_field_dims_if_inference_fails(nexus_group: Callable):
     builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['yy2'] = sc.arange('yy', 4)
     builder.add_data(Data(name='data1', data=da))
-    with resource(builder)() as f:
+    with nexus_group(builder)() as f:
         data = nexus.NXroot(f)['entry/data1']
         assert 'yy2' not in data[()].coords
         assert sc.identical(data['yy2'][()], da.coords['yy2'].rename(yy='dim_0'))


### PR DESCRIPTION
There is more cleanup to do, moving more code around, but this is the major step removing the old `LoadFromJson` and `LoadFromHdf5`.