### PR TITLE
Prototype writing in Nexus API

### DIFF
--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -209,8 +209,9 @@ class JSONAttributeManager:
         return _get_attribute_value(self._node, name)
 
     def __setitem__(self, name, value):
+        if name in self:
+            raise NotImplementedError("Replacing existing item not implemented yet.")
         attr = make_json_attr(name, value)
-        # TODO Replace if exists
         self._node['attributes'].append(attr)
         return self[name]
 
@@ -322,15 +323,17 @@ class JSONGroup(JSONNode):
                 item.visititems(callable)
 
     def create_dataset(self, name: str, data) -> JSONDataset:
+        if name in self:
+            raise NotImplementedError("Replacing existing item not implemented yet.")
         dataset = make_json_dataset(name, data)
-        # TODO Replace if exists
         self._node[_nexus_children].append(dataset)
         return self[name]
 
     def create_group(self, name: str) -> JSONGroup:
+        if name in self:
+            raise NotImplementedError("Replacing existing item not implemented yet.")
         group = {"type": "group", "name": name, "children": [], "attributes": []}
         self._node[_nexus_children].append(group)
-        # TODO Replace if exists
         return self[name]
 
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -77,6 +77,9 @@ class Attrs:
             return _ensure_str(attr, _cset_to_encoding(cset))
         return attr
 
+    def __setitem__(self, name: str, val: Any):
+        self._attrs[name] = val
+
     def get(self, name: str, default=None) -> Any:
         return self[name] if name in self else default
 
@@ -296,7 +299,7 @@ class NXobject:
     def __repr__(self) -> str:
         return f'<{type(self).__name__} "{self._group.name}">'
 
-    def create_field(self, name: str, data: DimensionedArray, **kwargs):
+    def create_field(self, name: str, data: DimensionedArray, **kwargs) -> Field:
         dataset = self._group.create_dataset(name, data=data.values, **kwargs)
         if data.unit is not None:
             dataset.attrs['units'] = str(data.unit)
@@ -306,6 +309,11 @@ class NXobject:
             indices = [self.dims.index(dim) for dim in data.dims]
             self._group.attrs[f'{name}_indices'] = indices
         return Field(dataset, data.dims)
+
+    def create_class(self, name: str, nx_class: NX_class) -> NXobject:
+        group = self._group.create_group(name)
+        group.attrs['NX_class'] = nx_class.name
+        return _make(group)
 
 
 class NXroot(NXobject):

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 from enum import Enum, auto
 import functools
-from typing import List, Union, NoReturn, Any, Dict, Tuple
+from typing import List, Union, NoReturn, Any, Dict, Tuple, Protocol
 import numpy as np
 import scipp as sc
 import h5py
@@ -17,6 +17,26 @@ from ._common import Group, Dataset, ScippIndex
 from ._common import to_plain_index
 
 NXobjectIndex = Union[str, ScippIndex]
+
+
+# TODO move into scipp
+class DimensionedArray(Protocol):
+    """
+    A multi-dimensional array with a unit and dimension labels.
+
+    Could be, e.g., a scipp.Variable or a dimple dataclass wrapping a numpy array.
+    """
+    @property
+    def values(self):
+        """Multi-dimensional array of values"""
+
+    @property
+    def unit(self):
+        """Physical unit of the values"""
+
+    @property
+    def dims(self) -> List[str]:
+        """Dimension labels for the values"""
 
 
 class NexusStructureError(Exception):
@@ -275,6 +295,17 @@ class NXobject:
 
     def __repr__(self) -> str:
         return f'<{type(self).__name__} "{self._group.name}">'
+
+    def create_field(self, name: str, data: DimensionedArray, **kwargs):
+        dataset = self._group.create_dataset(name, data=data.values, **kwargs)
+        if data.unit is not None:
+            dataset.attrs['units'] = str(data.unit)
+        if hasattr(self, 'dims'):
+            # Nexus provides no way of defining dim labels directly. Unless the
+            # group has dimensions this information will be lost.
+            indices = [self.dims.index(dim) for dim in data.dims]
+            self._group.attrs[f'{name}_indices'] = indices
+        return Field(dataset, data.dims)
 
 
 class NXroot(NXobject):

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -303,11 +303,6 @@ class NXobject:
         dataset = self._group.create_dataset(name, data=data.values, **kwargs)
         if data.unit is not None:
             dataset.attrs['units'] = str(data.unit)
-        if hasattr(self, 'dims'):
-            # Nexus provides no way of defining dim labels directly. Unless the
-            # group has dimensions this information will be lost.
-            indices = [self.dims.index(dim) for dim in data.dims]
-            self._group.attrs[f'{name}_indices'] = indices
         return Field(dataset, data.dims)
 
     def create_class(self, name: str, nx_class: NX_class) -> NXobject:

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -195,3 +195,21 @@ def test_uses_default_field_dims_if_inference_fails(nexus_group: Callable):
         data = nexus.NXroot(f)['entry/data1']
         assert 'yy2' not in data[()].coords
         assert sc.identical(data['yy2'][()], da.coords['yy2'].rename(yy='dim_0'))
+
+
+def test_create_field_from_variable(nexus_group: Callable):
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
+    builder.add_data(Data(name='data1', data=da))
+    expected = da.copy()
+    xx2 = sc.array(dims=['xx'], unit='s', values=[3, 4])
+    xx3 = sc.array(dims=['xx'], unit=None, values=[3, 4])
+    expected.coords['xx2'] = xx2
+    expected.coords['xx3'] = xx3
+    with nexus_group(builder)() as f:
+        data = nexus.NXroot(f)['entry/data1']
+        data.create_field('xx2', xx2)
+        data.create_field('xx3', xx3)
+        loaded = data[...]
+        assert sc.identical(loaded, expected)

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -213,3 +213,22 @@ def test_create_field_from_variable(nexus_group: Callable):
         data.create_field('xx3', xx3)
         loaded = data[...]
         assert sc.identical(loaded, expected)
+
+
+def test_create_data(nexus_group: Callable):
+    builder = NexusBuilder()
+    da = sc.DataArray(
+        sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
+    da.coords['xx'] = sc.array(dims=['xx'], unit='s', values=[3, 4])
+    da.coords['yy'] = sc.array(dims=['yy'], unit='s', values=[5, 6])
+    builder.add_data(Data(name='data1', data=da))
+    with nexus_group(builder)() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data2', nexus.NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx', da.coords['xx'])
+        data.create_field('yy', da.coords['yy'])
+        loaded = data[...]
+        assert sc.identical(loaded, da)

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -1,5 +1,5 @@
 from .nexus_test import open_nexus, open_json
-from .nexus_helpers import NexusBuilder, Data
+from .nexus_helpers import NexusBuilder
 from typing import Callable
 import scipp as sc
 from scippneutron import nexus
@@ -13,9 +13,8 @@ def nexus_group(request):
 
 
 def test_without_coords(nexus_group: Callable):
-    builder = NexusBuilder()
     signal = sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]])
-    with nexus_group(builder)() as f:
+    with nexus_group(NexusBuilder())() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.create_field('signal', signal)
@@ -25,162 +24,192 @@ def test_without_coords(nexus_group: Callable):
 
 
 def test_with_coords_matching_axis_names(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx', da.coords['xx'])
+        assert sc.identical(data[...], da)
 
 
 def test_guessed_dim_for_coord_not_matching_axis_name(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = da.data['yy', 1]
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx2', da.coords['xx2'])
+        assert sc.identical(data[...], da)
 
 
 def test_multiple_coords(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx', da.coords['xx'])
+        data.create_field('xx2', da.coords['xx2'])
+        data.create_field('yy', da.coords['yy'])
+        assert sc.identical(data[...], da)
 
 
 def test_slice_of_1d(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(sc.array(dims=['xx'], unit='m', values=[1, 2, 3]))
     da.coords['xx'] = da.data
     da.coords['xx2'] = da.data
     da.coords['scalar'] = sc.scalar(1.2)
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx', da.coords['xx'])
+        data.create_field('xx2', da.coords['xx2'])
+        data.create_field('scalar', da.coords['scalar'])
         assert sc.identical(data['xx', :2], da['xx', :2])
         assert sc.identical(data[:2], da['xx', :2])
 
 
 def test_slice_of_multiple_coords(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx', da.coords['xx'])
+        data.create_field('xx2', da.coords['xx2'])
+        data.create_field('yy', da.coords['yy'])
         assert sc.identical(data['xx', :2], da['xx', :2])
 
 
 def test_guessed_dim_for_2d_coord_not_matching_axis_name(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = da.data
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx2', da.coords['xx2'])
+        assert sc.identical(data[...], da)
 
 
 def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
     da.coords['yy2'] = da.data['xx', 0]
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('yy2', da.coords['yy2'])
         da = data[...]
         assert 'yy2' not in da.coords
 
 
 def test_guesses_transposed_dims_for_2d_coord(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = sc.transpose(da.data)
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('xx2', da.coords['xx2'])
+        assert sc.identical(data[...], da)
 
 
-def test_integer_indices_attribute_for_coord(nexus_group: Callable):
-    builder = NexusBuilder()
+@pytest.mark.parametrize("indices", [1, [1]], ids=['int', 'list-of-int'])
+def test_indices_attribute_for_coord(nexus_group: Callable, indices):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['yy2'] = da.data['xx', 0]
-    builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': 1}))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
-
-
-def test_list_indices_attribute_for_coord(nexus_group: Callable):
-    builder = NexusBuilder()
-    da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
-    da.coords['yy2'] = da.data['xx', 0]
-    builder.add_data(Data(name='data1', data=da, attrs={'yy2_indices': [1]}))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.attrs['yy2_indices'] = indices
+        data.create_field('signal', da.data)
+        data.create_field('yy2', da.coords['yy2'])
+        assert sc.identical(data[...], da)
 
 
 def test_transpose_indices_attribute_for_coord(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['xx2'] = sc.transpose(da.data)
-    builder.add_data(Data(name='data1', data=da, attrs={'xx2_indices': [1, 0]}))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.attrs['xx2_indices'] = [1, 0]
+        data.create_field('signal', da.data)
+        data.create_field('xx2', da.coords['xx2'])
+        assert sc.identical(data[...], da)
 
 
 def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['xx', 0]
-    # We flag 'xx' as auxiliary_signal. It should thus not be loaded as a coord.
-    builder.add_data(Data(name='data1', data=da, attrs={'auxiliary_signals': ['xx']}))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        loaded = data[...]
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        # We flag 'xx' as auxiliary_signal. It should thus not be loaded as a coord,
+        # even though we create the field.
+        data.attrs['auxiliary_signals'] = ['xx']
+        data.create_field('signal', da.data)
+        data.create_field('xx', da.coords['xx'])
         del da.coords['xx']
-        assert sc.identical(loaded, da)
+        assert sc.identical(data[...], da)
 
 
 def test_field_dims_match_NXdata_dims(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal1'
+        data.create_field('signal1', da.data)
+        data.create_field('xx', da.coords['xx'])
+        data.create_field('xx2', da.coords['xx2'])
+        data.create_field('yy', da.coords['yy'])
         assert sc.identical(data['xx', :2].data, data['signal1']['xx', :2])
         assert sc.identical(data['xx', :2].coords['xx'], data['xx']['xx', :2])
         assert sc.identical(data['xx', :2].coords['xx2'], data['xx2']['xx', :2])
@@ -188,51 +217,34 @@ def test_field_dims_match_NXdata_dims(nexus_group: Callable):
 
 
 def test_uses_default_field_dims_if_inference_fails(nexus_group: Callable):
-    builder = NexusBuilder()
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['yy2'] = sc.arange('yy', 4)
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        data = entry.create_class('data1', NX_class.NXdata)
+        data.attrs['axes'] = da.dims
+        data.attrs['signal'] = 'signal'
+        data.create_field('signal', da.data)
+        data.create_field('yy2', da.coords['yy2'])
         assert 'yy2' not in data[()].coords
         assert sc.identical(data['yy2'][()], da.coords['yy2'].rename(yy='dim_0'))
 
 
-def test_create_field_from_variable(nexus_group: Callable):
-    builder = NexusBuilder()
-    da = sc.DataArray(
-        sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
-    builder.add_data(Data(name='data1', data=da))
-    expected = da.copy()
-    xx2 = sc.array(dims=['xx'], unit='s', values=[3, 4])
-    xx3 = sc.array(dims=['xx'], unit=None, values=[3, 4])
-    expected.coords['xx2'] = xx2
-    expected.coords['xx3'] = xx3
-    with nexus_group(builder)() as f:
-        data = nexus.NXroot(f)['entry/data1']
-        data.create_field('xx2', xx2)
-        data.create_field('xx3', xx3)
-        data.attrs['xx2_indices'] = [0]
-        data.attrs['xx3_indices'] = [0]
-        loaded = data[...]
-        assert sc.identical(loaded, expected)
-
-
-def test_create_data(nexus_group: Callable):
-    builder = NexusBuilder()
-    da = sc.DataArray(
-        sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]]))
-    da.coords['xx'] = sc.array(dims=['xx'], unit='s', values=[3, 4])
-    da.coords['yy'] = sc.array(dims=['yy'], unit='s', values=[5, 6])
-    builder.add_data(Data(name='data1', data=da))
-    with nexus_group(builder)() as f:
+@pytest.mark.parametrize("unit", ['m', 's', None])
+def test_create_field_from_variable(nexus_group: Callable, unit):
+    var = sc.array(dims=['xx'], unit=unit, values=[3, 4])
+    with nexus_group(NexusBuilder())() as f:
         entry = nexus.NXroot(f)['entry']
-        data = entry.create_class('data2', nexus.NX_class.NXdata)
-        data.attrs['axes'] = da.dims
-        data.attrs['signal'] = 'signal'
-        data.create_field('signal', da.data)
-        data.create_field('xx', da.coords['xx'])
-        data.create_field('yy', da.coords['yy'])
-        loaded = data[...]
-        assert sc.identical(loaded, da)
+        entry.create_field('field', var)
+        loaded = entry['field'][...]
+        # Nexus does not support storing dim labels
+        assert sc.identical(loaded, var.rename(xx=loaded.dim))
+
+
+@pytest.mark.parametrize("nx_class", [NX_class.NXdata, NX_class.NXlog])
+def test_create_class(nexus_group: Callable, nx_class):
+    with nexus_group(NexusBuilder())() as f:
+        entry = nexus.NXroot(f)['entry']
+        group = entry.create_class('group', nx_class)
+        assert group.nx_class == nx_class

--- a/tests/nxdata_test.py
+++ b/tests/nxdata_test.py
@@ -9,12 +9,12 @@ import pytest
 
 @pytest.fixture(params=[open_nexus, open_json])
 def nexus_group(request):
-    return request.param
+    return request.param(NexusBuilder())
 
 
 def test_without_coords(nexus_group: Callable):
     signal = sc.array(dims=['xx', 'yy'], unit='m', values=[[1.1, 2.2], [3.3, 4.4]])
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.create_field('signal', signal)
@@ -27,7 +27,7 @@ def test_with_coords_matching_axis_names(nexus_group: Callable):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['yy', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -41,7 +41,7 @@ def test_guessed_dim_for_coord_not_matching_axis_name(nexus_group: Callable):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = da.data['yy', 1]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -57,7 +57,7 @@ def test_multiple_coords(nexus_group: Callable):
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -74,7 +74,7 @@ def test_slice_of_1d(nexus_group: Callable):
     da.coords['xx'] = da.data
     da.coords['xx2'] = da.data
     da.coords['scalar'] = sc.scalar(1.2)
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -93,7 +93,7 @@ def test_slice_of_multiple_coords(nexus_group: Callable):
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -109,7 +109,7 @@ def test_guessed_dim_for_2d_coord_not_matching_axis_name(nexus_group: Callable):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = da.data
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -123,7 +123,7 @@ def test_skips_axis_if_dim_guessing_finds_ambiguous_shape(nexus_group: Callable)
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
     da.coords['yy2'] = da.data['xx', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -138,7 +138,7 @@ def test_guesses_transposed_dims_for_2d_coord(nexus_group: Callable):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx2'] = sc.transpose(da.data)
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -152,7 +152,7 @@ def test_guesses_transposed_dims_for_2d_coord(nexus_group: Callable):
 def test_indices_attribute_for_coord(nexus_group: Callable, indices):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['yy2'] = da.data['xx', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -166,7 +166,7 @@ def test_indices_attribute_for_coord(nexus_group: Callable, indices):
 def test_transpose_indices_attribute_for_coord(nexus_group: Callable):
     da = sc.DataArray(sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2], [4, 5]]))
     da.coords['xx2'] = sc.transpose(da.data)
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -181,7 +181,7 @@ def test_auxiliary_signal_is_not_loaded_as_coord(nexus_group: Callable):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['xx'] = da.data['xx', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -201,7 +201,7 @@ def test_field_dims_match_NXdata_dims(nexus_group: Callable):
     da.coords['xx'] = da.data['yy', 0]
     da.coords['xx2'] = da.data['yy', 1]
     da.coords['yy'] = da.data['xx', 0]
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -220,7 +220,7 @@ def test_uses_default_field_dims_if_inference_fails(nexus_group: Callable):
     da = sc.DataArray(
         sc.array(dims=['xx', 'yy'], unit='m', values=[[1, 2, 3], [4, 5, 6]]))
     da.coords['yy2'] = sc.arange('yy', 4)
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         data = entry.create_class('data1', NX_class.NXdata)
         data.attrs['axes'] = da.dims
@@ -234,7 +234,7 @@ def test_uses_default_field_dims_if_inference_fails(nexus_group: Callable):
 @pytest.mark.parametrize("unit", ['m', 's', None])
 def test_create_field_from_variable(nexus_group: Callable, unit):
     var = sc.array(dims=['xx'], unit=unit, values=[3, 4])
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         entry.create_field('field', var)
         loaded = entry['field'][...]
@@ -244,7 +244,7 @@ def test_create_field_from_variable(nexus_group: Callable, unit):
 
 @pytest.mark.parametrize("nx_class", [NX_class.NXdata, NX_class.NXlog])
 def test_create_class(nexus_group: Callable, nx_class):
-    with nexus_group(NexusBuilder())() as f:
+    with nexus_group() as f:
         entry = nexus.NXroot(f)['entry']
         group = entry.create_class('group', nx_class)
         assert group.nx_class == nx_class


### PR DESCRIPTION
Add support for creating groups and datasets with the Nexus API. The current main purpose for this is to write unit test without reliance and the highly bespoke NexusBuilder (note that we are still relying on it for creation of the initial file/dict, but this can now be changed easily).