### PR TITLE
Refactor more Nexus tests

### DIFF
--- a/src/scippneutron/file_loading/_common.py
+++ b/src/scippneutron/file_loading/_common.py
@@ -55,7 +55,7 @@ def convert_time_to_datetime64(
 
     The times are also relative to a given log start time, which might be
     different for each log. If this log start time is not available, the start of the
-    unix epoch (1970-01-01T00:00:00Z) is used instead.
+    unix epoch (1970-01-01T00:00:00) is used instead.
 
     See https://manual.nexusformat.org/classes/base_classes/NXlog.html
 
@@ -65,7 +65,7 @@ def convert_time_to_datetime64(
             Used to generate warnings if loading the log fails.
         start: Optional, the start time of the log in an ISO8601
             string. If not provided, defaults to the beginning of the
-            unix epoch (1970-01-01T00:00:00Z).
+            unix epoch (1970-01-01T00:00:00).
         scaling_factor: Optional, the scaling factor between the provided
             time series data and the unit of the raw_times Variable. If
             not provided, defaults to 1 (a no-op scaling factor).
@@ -79,7 +79,7 @@ def convert_time_to_datetime64(
                         f"loading group at '{group_path}'.")
 
     try:
-        _start_ts = sc.scalar(value=np.datetime64(start or "1970-01-01T00:00:00Z"),
+        _start_ts = sc.scalar(value=np.datetime64(start or "1970-01-01T00:00:00"),
                               unit=sc.units.ns,
                               dtype=sc.DType.datetime64)
     except ValueError:

--- a/src/scippneutron/file_loading/_json_nexus.py
+++ b/src/scippneutron/file_loading/_json_nexus.py
@@ -45,7 +45,8 @@ numpy_to_filewriter_type = {
     np.uint16: "uint16",
     np.uint32: "uint32",
     np.uint64: "uint64",
-    np.str_: "string"
+    np.str_: "string",
+    np.object_: "string"
 }
 
 

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -57,6 +57,7 @@ class NX_class(Enum):
     NXroot = auto()
     NXsample = auto()
     NXsource = auto()
+    NXtransformations = auto()
 
 
 class Attrs:
@@ -310,6 +311,15 @@ class NXobject:
         group.attrs['NX_class'] = nx_class.name
         return _make(group)
 
+    def __setitem__(self, name: str, value: Union[Field, NXobject, DimensionedArray]):
+        """Create a link or a new field."""
+        if isinstance(value, Field):
+            self._group[name] = value._dataset
+        elif isinstance(value, NXobject):
+            self._group[name] = value._group
+        else:
+            self.create_field(name, value)
+
 
 class NXroot(NXobject):
     @property
@@ -326,6 +336,10 @@ class NXentry(NXobject):
 
 
 class NXinstrument(NXobject):
+    pass
+
+
+class NXtransformations(NXobject):
     pass
 
 
@@ -349,6 +363,6 @@ def _nx_class_registry():
         cls.__name__: cls
         for cls in [
             NXroot, NXentry, NXevent_data, NXlog, NXmonitor, NXdata, NXdetector,
-            NXsample, NXsource, NXdisk_chopper, NXinstrument
+            NXsample, NXsource, NXdisk_chopper, NXinstrument, NXtransformations
         ]
     }

--- a/src/scippneutron/file_loading/nxobject.py
+++ b/src/scippneutron/file_loading/nxobject.py
@@ -301,7 +301,10 @@ class NXobject:
         return f'<{type(self).__name__} "{self._group.name}">'
 
     def create_field(self, name: str, data: DimensionedArray, **kwargs) -> Field:
-        dataset = self._group.create_dataset(name, data=data.values, **kwargs)
+        values = data.values
+        if data.dtype == sc.DType.string:
+            values = np.array(data.values, dtype=object)
+        dataset = self._group.create_dataset(name, data=values, **kwargs)
         if data.unit is not None:
             dataset.attrs['units'] = str(data.unit)
         return Field(dataset, data.dims)

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -1,15 +1,11 @@
-from .nexus_helpers import (
-    NexusBuilder,
-    EventData,
-    Log,
-    Monitor,
-)
+from .nexus_helpers import NexusBuilder
 from .test_load_nexus import UTF8_TEST_STRINGS
+import h5py
 import numpy as np
 import pytest
-from typing import Callable
 import scipp as sc
 from scippneutron import nexus
+from scippneutron.nexus import NX_class
 
 
 def open_nexus(builder: NexusBuilder):
@@ -21,295 +17,239 @@ def open_json(builder: NexusBuilder):
 
 
 @pytest.fixture(params=[open_nexus, open_json])
-def nexus_group(request):
-    """
-    Each test with this fixture is executed with load_nexus_json
-    loading JSON output from the NexusBuilder, and with load_nexus
-    loading in-memory NeXus output from the NexusBuilder
-    """
-    return request.param
+def nxroot(request):
+    """Yield NXroot containing a single NXentry named 'entry'"""
+    with request.param(NexusBuilder())() as f:
+        yield nexus.NXroot(f)
 
 
-def builder_with_events_monitor_and_log():
-    event_time_offsets = np.array([456, 743, 347, 345, 632, 23], dtype='int64')
-    event_data = EventData(
-        event_id=np.array([1, 2, 3, 1, 3, 2]),
-        event_time_offset=event_time_offsets,
-        event_time_zero=np.array([
-            1600766730000000000, 1600766731000000000, 1600766732000000000,
-            1600766733000000000
-        ]),
-        event_index=np.array([0, 3, 3, 5]),
-    )
-
-    builder = NexusBuilder()
-    builder.add_event_data(event_data)
-    builder.add_event_data(event_data)
-    builder.add_monitor(
-        Monitor("monitor",
-                data=np.array([1.]),
-                axes=[("time_of_flight", np.array([1.]))]))
-    builder.add_log(
-        Log("log", np.array([1.1, 2.2, 3.3]), np.array([4.4, 5.5, 6.6]),
-            value_units=''))
-    return builder
+def test_nxobject_root(nxroot):
+    assert nxroot.nx_class == nexus.NX_class.NXroot
+    assert set(nxroot.keys()) == {'entry'}
 
 
-def test_nxobject_root(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        assert root.nx_class == nexus.NX_class.NXroot
-        assert set(root.keys()) == {'entry', 'monitor'}
+def test_nxobject_create_class_creates_keys(nxroot):
+    nxroot.create_class('log', NX_class.NXlog)
+    assert set(nxroot.keys()) == {'entry', 'log'}
 
 
-def test_nxobject_items(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        items = root.items()
-        assert len(items) == 2
-        for k, v in items:
-            if k == 'entry':
-                assert v.nx_class == nexus.NX_class.NXentry
-            else:
-                assert k == 'monitor'
-                assert v.nx_class == nexus.NX_class.NXmonitor
+def test_nxobject_items(nxroot):
+    items = nxroot.items()
+    assert len(items) == 1
+    name, entry = items[0]
+    assert name == 'entry'
+    entry.create_class('monitor', NX_class.NXmonitor)
+    entry.create_class('log', NX_class.NXlog)
+    for k, v in entry.items():
+        if k == 'log':
+            assert v.nx_class == nexus.NX_class.NXlog
+        else:
+            assert k == 'monitor'
+            assert v.nx_class == nexus.NX_class.NXmonitor
 
 
-def test_nxobject_entry(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        entry = nexus.NXroot(f)['entry']
-        assert entry.nx_class == nexus.NX_class.NXentry
-        assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
+def test_nxobject_entry(nxroot):
+    entry = nxroot['entry']
+    assert entry.nx_class == nexus.NX_class.NXentry
+    entry.create_class('events_0', NX_class.NXevent_data)
+    entry.create_class('events_1', NX_class.NXevent_data)
+    entry.create_class('log', NX_class.NXlog)
+    assert set(entry.keys()) == {'events_0', 'events_1', 'log'}
 
 
-def test_nxobject_monitor(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        monitor = nexus.NXroot(f)['monitor']
-        assert monitor.nx_class == nexus.NX_class.NXmonitor
-        assert sc.identical(
-            monitor[...],
-            sc.DataArray(sc.array(dims=['time_of_flight'], values=[1.0]),
-                         coords={
-                             'time_of_flight':
-                             sc.array(dims=['time_of_flight'], values=[1.0])
-                         }))
+def test_nxobject_monitor(nxroot):
+    monitor = nxroot['entry'].create_class('monitor', NX_class.NXmonitor)
+    assert monitor.nx_class == nexus.NX_class.NXmonitor
+    da = sc.DataArray(
+        sc.array(dims=['time_of_flight'], values=[1.0]),
+        coords={'time_of_flight': sc.array(dims=['time_of_flight'], values=[1.0])})
+    monitor['data'] = da.data
+    monitor['data'].attrs['axes'] = 'time_of_flight'
+    monitor['time_of_flight'] = da.coords['time_of_flight']
+    assert sc.identical(monitor[...], da)
 
 
-def test_nxobject_log(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        log = nexus.NXroot(f)['entry']['log']
-        assert log.nx_class == nexus.NX_class.NXlog
-        assert sc.identical(
-            log[...],
-            sc.DataArray(
-                sc.array(dims=['time'], values=[1.1, 2.2, 3.3]),
-                coords={
-                    'time':
-                    sc.epoch(unit='ns') +
-                    sc.array(dims=['time'], unit='s', values=[4.4, 5.5, 6.6]).to(
-                        unit='ns', dtype='int64')
-                }))
+def test_nxobject_log(nxroot):
+    da = sc.DataArray(sc.array(dims=['time'], values=[1.1, 2.2, 3.3]),
+                      coords={
+                          'time':
+                          sc.epoch(unit='ns') +
+                          sc.array(dims=['time'], unit='s', values=[4.4, 5.5, 6.6]).to(
+                              unit='ns', dtype='int64')
+                      })
+    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log['value'] = da.data
+    log['time'] = da.coords['time'] - sc.epoch(unit='ns')
+    assert log.nx_class == nexus.NX_class.NXlog
+    assert sc.identical(log[...], da)
 
 
-def test_nxobject_event_data(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        event_data = nexus.NXroot(f)['entry']['events_0']
-        assert set(event_data.keys()) == set(
-            ['event_id', 'event_index', 'event_time_offset', 'event_time_zero'])
-        assert event_data.nx_class == nexus.NX_class.NXevent_data
+def test_nxobject_event_data(nxroot):
+    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    assert event_data.nx_class == nexus.NX_class.NXevent_data
 
 
-def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(
-        nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        with pytest.raises(KeyError):
-            root['abcde']
+def test_nxobject_getting_item_that_does_not_exists_raises_KeyError(nxroot):
+    with pytest.raises(KeyError):
+        nxroot['abcde']
 
 
-def test_nxobject_name_property_is_full_path(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        assert root.name == '/'
-        assert root['monitor'].name == '/monitor'
-        assert root['entry'].name == '/entry'
-        assert root['entry']['log'].name == '/entry/log'
-        assert root['entry']['events_0'].name == '/entry/events_0'
+def test_nxobject_name_property_is_full_path(nxroot):
+    nxroot.create_class('monitor', NX_class.NXmonitor)
+    nxroot['entry'].create_class('log', NX_class.NXlog)
+    nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    assert nxroot.name == '/'
+    assert nxroot['monitor'].name == '/monitor'
+    assert nxroot['entry'].name == '/entry'
+    assert nxroot['entry']['log'].name == '/entry/log'
+    assert nxroot['entry']['events_0'].name == '/entry/events_0'
 
 
-def test_nxobject_grandchild_can_be_accessed_using_path(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        assert root['entry/log'].name == '/entry/log'
-        assert root['/entry/log'].name == '/entry/log'
+def test_nxobject_grandchild_can_be_accessed_using_path(nxroot):
+    nxroot['entry'].create_class('log', NX_class.NXlog)
+    assert nxroot['entry/log'].name == '/entry/log'
+    assert nxroot['/entry/log'].name == '/entry/log'
 
 
-def test_nxobject_by_nx_class_of_root_contains_everything(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        classes = root.by_nx_class()
-        assert list(classes[nexus.NX_class.NXentry]) == ['entry']
-        assert list(classes[nexus.NX_class.NXmonitor]) == ['monitor']
-        assert list(classes[nexus.NX_class.NXlog]) == ['log']
-        assert set(classes[nexus.NX_class.NXevent_data]) == {'events_0', 'events_1'}
+def test_nxobject_by_nx_class_of_root_contains_everything(nxroot):
+    nxroot.create_class('monitor', NX_class.NXmonitor)
+    nxroot['entry'].create_class('log', NX_class.NXlog)
+    nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    nxroot['entry'].create_class('events_1', NX_class.NXevent_data)
+    classes = nxroot.by_nx_class()
+    assert list(classes[nexus.NX_class.NXentry]) == ['entry']
+    assert list(classes[nexus.NX_class.NXmonitor]) == ['monitor']
+    assert list(classes[nexus.NX_class.NXlog]) == ['log']
+    assert set(classes[nexus.NX_class.NXevent_data]) == {'events_0', 'events_1'}
 
 
-def test_nxobject_by_nx_class_contains_only_children(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        root = nexus.NXroot(f)
-        classes = root['entry'].by_nx_class()
-        assert list(classes[nexus.NX_class.NXentry]) == []
-        assert list(classes[nexus.NX_class.NXmonitor]) == []
-        assert list(classes[nexus.NX_class.NXlog]) == ['log']
-        assert set(classes[nexus.NX_class.NXevent_data]) == set(
-            ['events_0', 'events_1'])
+def test_nxobject_by_nx_class_contains_only_children(nxroot):
+    nxroot.create_class('monitor', NX_class.NXmonitor)
+    nxroot['entry'].create_class('log', NX_class.NXlog)
+    nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    nxroot['entry'].create_class('events_1', NX_class.NXevent_data)
+    classes = nxroot['entry'].by_nx_class()
+    assert list(classes[nexus.NX_class.NXentry]) == []
+    assert list(classes[nexus.NX_class.NXmonitor]) == []
+    assert list(classes[nexus.NX_class.NXlog]) == ['log']
+    assert set(classes[nexus.NX_class.NXevent_data]) == set(['events_0', 'events_1'])
 
 
-def test_nxobject_dataset_items_are_returned_as_Field(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        field = nexus.NXroot(f)['entry/events_0/event_time_offset']
-        assert isinstance(field, nexus.Field)
+def test_nxobject_dataset_items_are_returned_as_Field(nxroot):
+    events = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    events['event_time_offset'] = sc.arange('event', 5)
+    field = nxroot['entry/events_0/event_time_offset']
+    assert isinstance(field, nexus.Field)
 
 
-def test_field_properties(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        field = nexus.NXroot(f)['entry/events_0/event_time_offset']
-        assert field.dtype == 'int64'
-        assert field.name == '/entry/events_0/event_time_offset'
-        assert field.shape == (6, )
-        assert field.unit == sc.Unit('ns')
+def test_field_properties(nxroot):
+    events = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    events['event_time_offset'] = sc.arange('event', 6, dtype='int64', unit='ns')
+    field = nxroot['entry/events_0/event_time_offset']
+    assert field.dtype == 'int64'
+    assert field.name == '/entry/events_0/event_time_offset'
+    assert field.shape == (6, )
+    assert field.unit == sc.Unit('ns')
 
 
-def test_field_dim_labels(nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        event_data = nexus.NXroot(f)['entry/events_0']
-        assert event_data['event_time_offset'].dims == ['event']
-        assert event_data['event_time_zero'].dims == ['pulse']
-        assert event_data['event_index'].dims == ['pulse']
-        assert event_data['event_id'].dims == ['event']
-        log = nexus.NXroot(f)['entry/log']
-        assert log['time'].dims == ['time']
-        assert log['value'].dims == ['time']
-        monitor = nexus.NXroot(f)['monitor']
-        assert monitor['time_of_flight'].dims == ['time_of_flight']
-        assert monitor['data'].dims == ['time_of_flight']
+def test_field_dim_labels(nxroot):
+    events = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    events['event_time_offset'] = sc.arange('ignored', 2)
+    events['event_time_zero'] = sc.arange('ignored', 2)
+    events['event_index'] = sc.arange('ignored', 2)
+    events['event_id'] = sc.arange('ignored', 2)
+    event_data = nxroot['entry/events_0']
+    assert event_data['event_time_offset'].dims == ['event']
+    assert event_data['event_time_zero'].dims == ['pulse']
+    assert event_data['event_index'].dims == ['pulse']
+    assert event_data['event_id'].dims == ['event']
+    log = nxroot['entry'].create_class('log', NX_class.NXlog)
+    log['value'] = sc.arange('ignored', 2)
+    log['time'] = sc.arange('ignored', 2)
+    assert log['time'].dims == ['time']
+    assert log['value'].dims == ['time']
 
 
-def test_field_unit_is_none_if_no_units_attribute(nexus_group: Callable):
-    builder = builder_with_events_monitor_and_log()
-    builder.add_log(
-        Log("mylog",
-            np.array([1.1, 2.2, 3.3]),
-            np.array([4.4, 5.5, 6.6]),
-            value_units=None))
-    with nexus_group(builder)() as f:
-        field = nexus.NXroot(f)['entry/mylog']
-        assert field.unit is None
+def test_field_unit_is_none_if_no_units_attribute(nxroot):
+    log = nxroot.create_class('log', NX_class.NXlog)
+    log['value'] = sc.arange('ignored', 2, unit=None)
+    log['time'] = sc.arange('ignored', 2)
+    assert log.unit is None
+    field = log['value']
+    assert field.unit is None
 
 
-def test_field_getitem_returns_variable_with_correct_size_and_values(
-        nexus_group: Callable):
-    with nexus_group(builder_with_events_monitor_and_log())() as f:
-        field = nexus.NXroot(f)['entry/events_0/event_time_offset']
-        assert sc.identical(
-            field[...],
-            sc.array(dims=['dim_0'],
-                     unit='ns',
-                     values=[456, 743, 347, 345, 632, 23],
-                     dtype='int64'))
-        assert sc.identical(
-            field[1:],
-            sc.array(dims=['dim_0'],
-                     unit='ns',
-                     values=[743, 347, 345, 632, 23],
-                     dtype='int64'))
-        assert sc.identical(
-            field[:-1],
-            sc.array(dims=['dim_0'],
-                     unit='ns',
-                     values=[456, 743, 347, 345, 632],
-                     dtype='int64'))
+def test_field_getitem_returns_variable_with_correct_size_and_values(nxroot):
+    nxroot['field'] = sc.arange('ignored', 6, dtype='int64', unit='ns')
+    field = nxroot['field']
+    assert sc.identical(
+        field[...],
+        sc.array(dims=['dim_0'], unit='ns', values=[0, 1, 2, 3, 4, 5], dtype='int64'))
+    assert sc.identical(
+        field[1:],
+        sc.array(dims=['dim_0'], unit='ns', values=[1, 2, 3, 4, 5], dtype='int64'))
+    assert sc.identical(
+        field[:-1],
+        sc.array(dims=['dim_0'], unit='ns', values=[0, 1, 2, 3, 4], dtype='int64'))
 
 
 @pytest.mark.parametrize("string", UTF8_TEST_STRINGS)
-def test_field_of_utf8_encoded_dataset_is_loaded_correctly(nexus_group: Callable,
-                                                           string):
-    builder = NexusBuilder()
-    if nexus_group == open_nexus:
-        builder.add_title(np.array([string, string + string], dtype=object))
-    else:  # json encodes itself
-        builder.add_title(np.array([string, string + string]))
-    with nexus_group(builder)() as f:
-        title = nexus.NXroot(f)['entry/title']
-        assert sc.identical(title[...],
-                            sc.array(dims=['dim_0'], values=[string, string + string]))
+def test_field_of_utf8_encoded_dataset_is_loaded_correctly(nxroot, string):
+    nxroot['entry']['title'] = sc.array(dims=['ignored'],
+                                        values=[string, string + string])
+    title = nxroot['entry/title']
+    assert sc.identical(title[...],
+                        sc.array(dims=['dim_0'], values=[string, string + string]))
 
 
 def test_field_of_extended_ascii_in_ascii_encoded_dataset_is_loaded_correctly():
-    nexus_group = open_nexus
-    builder = NexusBuilder()
     # When writing, if we use bytes h5py will write as ascii encoding
     # 0xb0 = degrees symbol in latin-1 encoding.
     string = b"run at rot=90" + bytes([0xb0])
-    builder.add_title(np.array([string, string + b'x']))
-    with nexus_group(builder)() as f:
-        title = nexus.NXroot(f)['entry/title']
+    with h5py.File('dummy.nxs', mode='w', driver="core", backing_store=False) as f:
+        f['title'] = np.array([string, string + b'x'])
+        title = nexus.NXroot(f)['title']
         assert sc.identical(
             title[...],
             sc.array(dims=['dim_0'], values=["run at rot=90°", "run at rot=90°x"]))
 
 
-def test_negative_event_index_converted_to_num_event(nexus_group: Callable):
-    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
-    event_data = EventData(
-        event_id=np.array([1, 2, 3, 1, 3, 2]),
-        event_time_offset=event_time_offsets,
-        event_time_zero=np.array([
-            1600766730000000000, 1600766731000000000, 1600766732000000000,
-            1600766733000000000
-        ]),
-        event_index=np.array([0, 3, 3, -1000]),
-    )
-
-    builder = NexusBuilder()
-    builder.add_event_data(event_data)
-    with nexus_group(builder)() as f:
-        root = nexus.NXroot(f)
-        events = root['entry/events_0'][...]
-        assert events.bins.size().values[2] == 3
-        assert events.bins.size().values[3] == 0
+def create_event_data_ids_1234(group):
+    group['event_id'] = sc.array(dims=[''], unit=None, values=[1, 2, 4, 1, 2, 2])
+    group['event_time_offset'] = sc.array(dims=[''],
+                                          unit='s',
+                                          values=[456, 7, 3, 345, 632, 23])
+    group['event_time_zero'] = sc.array(dims=[''], unit='s', values=[1, 2, 3, 4])
+    group['event_index'] = sc.array(dims=[''], unit='None', values=[0, 3, 3, -1000])
 
 
-def builder_with_events_and_events_monitor_without_event_id():
-    event_time_offsets = np.array([456, 743, 347, 345, 632, 23])
-    event_data = EventData(
-        event_id=None,
-        event_time_offset=event_time_offsets,
-        event_time_zero=np.array([
-            1600766730000000000, 1600766731000000000, 1600766732000000000,
-            1600766733000000000
-        ]),
-        event_index=np.array([0, 3, 3, 5]),
-    )
-
-    builder = NexusBuilder()
-    builder.add_event_data(event_data)
-    builder.add_monitor(
-        Monitor("monitor", data=np.array([1.]), axes=[], events=event_data))
-    return builder
+def test_negative_event_index_converted_to_num_event(nxroot):
+    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    create_event_data_ids_1234(event_data)
+    events = nxroot['entry/events_0'][...]
+    assert events.bins.size().values[2] == 3
+    assert events.bins.size().values[3] == 0
 
 
-def test_event_data_without_event_id_can_be_loaded(nexus_group: Callable):
-    with nexus_group(builder_with_events_and_events_monitor_without_event_id())() as f:
-        event_data = nexus.NXroot(f)['entry/events_0']
-        da = event_data[...]
-        assert len(da.bins.coords) == 1
-        assert 'event_time_offset' in da.bins.coords
+def create_event_data_without_event_id(group):
+    group['event_time_offset'] = sc.array(dims=[''],
+                                          unit='s',
+                                          values=[456, 7, 3, 345, 632, 23])
+    group['event_time_zero'] = sc.array(dims=[''], unit='s', values=[1, 2, 3, 4])
+    group['event_index'] = sc.array(dims=[''], unit='None', values=[0, 3, 3, 5])
 
 
-def test_event_mode_monitor_without_event_id_can_be_loaded(nexus_group: Callable):
-    with nexus_group(builder_with_events_and_events_monitor_without_event_id())() as f:
-        monitor = nexus.NXroot(f)['monitor']
-        da = monitor[...]
-        assert len(da.bins.coords) == 1
-        assert 'event_time_offset' in da.bins.coords
+def test_event_data_without_event_id_can_be_loaded(nxroot):
+    event_data = nxroot['entry'].create_class('events_0', NX_class.NXevent_data)
+    create_event_data_without_event_id(event_data)
+    da = event_data[...]
+    assert len(da.bins.coords) == 1
+    assert 'event_time_offset' in da.bins.coords
+
+
+def test_event_mode_monitor_without_event_id_can_be_loaded(nxroot):
+    monitor = nxroot['entry'].create_class('monitor', NX_class.NXmonitor)
+    create_event_data_without_event_id(monitor)
+    da = monitor[...]
+    assert len(da.bins.coords) == 1
+    assert 'event_time_offset' in da.bins.coords

--- a/tests/nxtransformations_test.py
+++ b/tests/nxtransformations_test.py
@@ -1,77 +1,82 @@
 from .nexus_test import open_nexus, open_json
-from .nexus_helpers import NexusBuilder, Detector, Transformation, TransformationType
+from .nexus_helpers import NexusBuilder
 import numpy as np
 import pytest
-from typing import Callable
 import scipp as sc
 from scippneutron import nexus
+from scippneutron.nexus import NX_class
 from scippneutron.file_loading import nxtransformations
 
 
 @pytest.fixture(params=[open_nexus, open_json])
-def nexus_group(request):
-    return request.param
+def nxroot(request):
+    with request.param(NexusBuilder())() as f:
+        yield nexus.NXroot(f)
 
 
-def builder_with_detector(*, depends_on):
-    builder = NexusBuilder()
-    da = sc.DataArray(sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]]))
-    detector_numbers = np.array([[1, 2], [3, 4]])
-    builder.add_detector(
-        Detector(detector_numbers=detector_numbers, data=da, depends_on=depends_on))
-    return builder
+def create_detector(group):
+    data = sc.array(dims=['xx', 'yy'], values=[[1.1, 2.2], [3.3, 4.4]])
+    detector_numbers = sc.array(dims=['xx', 'yy'],
+                                unit=None,
+                                values=np.array([[1, 2], [3, 4]]))
+    detector = group.create_class('detector_0', NX_class.NXdetector)
+    detector.create_field('detector_number', detector_numbers)
+    detector.create_field('data', data)
+    return detector
 
 
-def test_Transformation_with_single_value(nexus_group: Callable):
+def test_Transformation_with_single_value(nxroot):
+    detector = create_detector(nxroot)
+    detector.create_field('depends_on', sc.scalar('/detector_0/transformations/t1'))
+    transformations = detector.create_class('transformations',
+                                            NX_class.NXtransformations)
+    value = sc.scalar(6.5, unit='mm')
     offset = sc.spatial.translation(value=[1, 2, 3], unit='mm')
     vector = sc.vector(value=[0, 0, 1])
-    value = sc.scalar(6.5, unit='mm')
-    translation = Transformation(TransformationType.TRANSLATION,
-                                 vector=vector.value,
-                                 value=value.value,
-                                 value_units=str(value.unit),
-                                 offset=offset.values,
-                                 offset_unit=str(offset.unit))
-    builder = builder_with_detector(depends_on=translation)
     t = value.to(unit='m') * vector
     expected = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
     expected = expected * sc.spatial.translation(value=[0.001, 0.002, 0.003], unit='m')
-    with nexus_group(builder)() as f:
-        root = nexus.NXroot(f)
-        detector = root['entry/detector_0']
-        depends_on = detector['depends_on'][()].value
-        t = nxtransformations.Transformation(root[depends_on])
-        assert t.depends_on is None
-        assert sc.identical(t.offset, offset)
-        assert sc.identical(t.vector, vector)
-        assert sc.identical(t[()], expected)
+    value = transformations.create_field('t1', value)
+    value.attrs['depends_on'] = '.'
+    value.attrs['transformation_type'] = 'translation'
+    value.attrs['offset'] = offset.values
+    value.attrs['offset_units'] = str(offset.unit)
+    value.attrs['vector'] = vector.value
+
+    depends_on = detector['depends_on'][()].value
+    t = nxtransformations.Transformation(nxroot[depends_on])
+    assert t.depends_on is None
+    assert sc.identical(t.offset, offset)
+    assert sc.identical(t.vector, vector)
+    assert sc.identical(t[()], expected)
 
 
-def test_Transformation_with_multiple_values(nexus_group: Callable):
-    offset = sc.spatial.translation(value=[1, 2, 3], unit='m')
-    vector = sc.vector(value=[0, 0, 1])
+def test_Transformation_with_multiple_values(nxroot):
+    detector = create_detector(nxroot)
+    detector.create_field('depends_on', sc.scalar('/detector_0/transformations/t1'))
+    transformations = detector.create_class('transformations',
+                                            NX_class.NXtransformations)
     log = sc.DataArray(
         sc.array(dims=['time'], values=[1.1, 2.2], unit='m'),
         coords={'time': sc.array(dims=['time'], values=[11, 22], unit='s')})
-    translation = Transformation(TransformationType.TRANSLATION,
-                                 vector=vector.value,
-                                 value=log.values,
-                                 value_units=str(log.unit),
-                                 time=log.coords['time'].values,
-                                 time_units=str(log.coords['time'].unit),
-                                 offset=offset.values,
-                                 offset_unit=str(offset.unit))
     log.coords['time'] = sc.epoch(unit='ns') + log.coords['time'].to(unit='ns')
-    builder = builder_with_detector(depends_on=translation)
+    offset = sc.spatial.translation(value=[1, 2, 3], unit='m')
+    vector = sc.vector(value=[0, 0, 1])
     t = log * vector
     t.data = sc.spatial.translations(dims=t.dims, values=t.values, unit=t.unit)
     expected = t * offset
-    with nexus_group(builder)() as f:
-        root = nexus.NXroot(f)
-        detector = root['entry/detector_0']
-        depends_on = detector['depends_on'][()].value
-        t = nxtransformations.Transformation(root[depends_on])
-        assert t.depends_on is None
-        assert sc.identical(t.offset, offset)
-        assert sc.identical(t.vector, vector)
-        assert sc.identical(t[()], expected)
+    value = transformations.create_class('t1', NX_class.NXlog)
+    value['time'] = log.coords['time'] - sc.epoch(unit='ns')
+    value['value'] = log.data
+    value.attrs['depends_on'] = '.'
+    value.attrs['transformation_type'] = 'translation'
+    value.attrs['offset'] = offset.values
+    value.attrs['offset_units'] = str(offset.unit)
+    value.attrs['vector'] = vector.value
+
+    depends_on = detector['depends_on'][()].value
+    t = nxtransformations.Transformation(nxroot[depends_on])
+    assert t.depends_on is None
+    assert sc.identical(t.offset, offset)
+    assert sc.identical(t.vector, vector)
+    assert sc.identical(t[()], expected)


### PR DESCRIPTION
- Refactor (I think all) remaining tests of new Nexus API.
- Support writing scipp.DType.string
- Avoid timezone warning
- Support `NXobject.__setitem__`, equivalent to `h5py` behavior.
  - I was wondering if this might enable a convenient syntax for creating classes? I am not 100% happy with `group.create_class('mylog', NX_class.NXlog)`, but I cannot see how, right now?

Next step will be to remove remaining dependencies, and move new API into a submodule/subfolder, so it can be extracted into a package later.