### PR TITLE
Remove hard run dependency on Mantid

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -95,6 +95,8 @@ test:
     - python cmake-package-test/build.py
 
 build:
+  ignore_run_exports:
+    - mantid [py==38]
   # Build number is number of Git commits since last tag, if that fails use 0
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   script_env:

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -3,6 +3,36 @@
 Release Notes
 =============
 
+v0.6.0 (unreleased)
+-------------------
+
+Features
+~~~~~~~~
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* Remove accidental dependency on Mantid. Users now have to install Mantid themselves if they need it `332 <https://github.com/scipp/scipp/pull/332>`_.
+
+Bugfixes
+~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Deprecations
+~~~~~~~~~~~~
+
+Stability, Maintainability, and Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.5.2 (March 2022)
 -------------------
 


### PR DESCRIPTION
Mantid defines itself as a 'run_export' which means that depending on it in the `host` section (or `build` if there is no `host`) automatically turns it into a `run` dependency.

This is an artefact of requiring mantid in `build` for our docs. So the change in this PR should become redundant once we update the conda setup to match that of scipp. But in the meantime, this PR fixes the issue.