### PR TITLE
Remove pytest-xdist

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -20,7 +20,6 @@ dependencies:
   - pooch
   - pytest
   - pytest-asyncio
-  - pytest-xdist
   - python-graphviz
   - pythreejs
   - scipp=0.14.*

--- a/.buildconfig/ci-macos.yml
+++ b/.buildconfig/ci-macos.yml
@@ -13,7 +13,6 @@ dependencies:
   - pooch
   - pytest
   - pytest-asyncio
-  - pytest-xdist
   - pythreejs
   - scipp=0.14.*
   - scippnexus

--- a/.buildconfig/ci-windows.yml
+++ b/.buildconfig/ci-windows.yml
@@ -13,7 +13,6 @@ dependencies:
   - pooch
   - pytest
   - pytest-asyncio
-  - pytest-xdist
   - pythreejs
   - scipp=0.14.*
   - scippnexus

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -82,7 +82,7 @@ jobs:
       - run: cmake --build --preset build
       - run: ctest --preset test
 
-      - run: python -m pytest -n auto -v tests
+      - run: python -m pytest -v tests
 
       - run: |
           python -m sphinx -j2 -v -b html -d doctrees docs html


### PR DESCRIPTION
We have had some failing tests since #340 was merged.
- Failure to load a file with mantid possibly because it ran out of memory. The test is guarded by a check of the total system memory, so it could be that using multiple threads, used more memory and it hit the limit.
- Failure when importing `mantid.simpleapi` with a message `'File exists'`. Possibly caused by multiple processes trying to create mantid config files at the same time.

This PR disables multi-threaded builds to hopefully fix those problems. Tests don't currently take very long so we should be fine.