### PR TITLE
Add scippnexus and plopp to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
     allow:
       - dependency-name: "scipp"
         dependency-type: "direct"
+      - dependency-name: "scippnexus"
+        dependency-type: "direct"
+      - dependency-name: "plopp"
+        dependency-type: "direct"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+[![PyPI badge](http://img.shields.io/pypi/v/scippneutron.svg)](https://pypi.python.org/pypi/scippneutron)
 [![Anaconda-Server Badge](https://anaconda.org/scipp/scippneutron/badges/version.svg)](https://anaconda.org/scipp/scippneutron)
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
-[![Release build](https://github.com/scipp/scipp/actions/workflows/release.yml/badge.svg)](https://github.com/scipp/scippneutron/actions/workflows/release.yml)
+[![Release](https://github.com/scipp/scippneutron/actions/workflows/release.yml/badge.svg)](https://github.com/scipp/scippneutron/actions/workflows/release.yml)
 
 # scippneutron
 


### PR DESCRIPTION
Similarly to scipp updates, we want to be alerted early when a scippnexus or plopp update breaks scippneutron.