### PR TITLE
Update for upcoming scippnexus changes

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -19,7 +19,7 @@ dependencies:
   - python-graphviz
   - pythreejs
   - scipp=23.01.1
-  - scippnexus>=0.4.1
+  - scippnexus>=23.01.1
   - scipy>=1.7.0
   - tox
 

--- a/.buildconfig/ci-macos.yml
+++ b/.buildconfig/ci-macos.yml
@@ -15,5 +15,5 @@ dependencies:
   - pytest-asyncio
   - pythreejs
   - scipp=23.01.1
-  - scippnexus>=0.4.1
+  - scippnexus>=23.01.1
   - scipy>=1.7.0

--- a/.buildconfig/ci-windows.yml
+++ b/.buildconfig/ci-windows.yml
@@ -15,5 +15,5 @@ dependencies:
   - pytest-asyncio
   - pythreejs
   - scipp=23.01.1
-  - scippnexus>=0.4.1
+  - scippnexus>=23.01.1
   - scipy>=1.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: [ --markdown-linebreak-ext=md ]
         exclude: '\.svg'
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - pooch
     - python
     - scipp>=23.01.1
-    - scippnexus>=0.4.1
+    - scippnexus>=23.01.1
     - scipy>=1.7.0
 
 test:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,5 +3,5 @@ numpy >= 1.20
 plopp >= 22.12.1
 pooch
 scipp[interactive] >= 23.01.1
-scippnexus >= 0.4.1
+scippnexus >= 23.01.1
 scipy >= 1.7.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -326,7 +326,7 @@ scipp[interactive]==23.1.1
     # via
     #   -r requirements/base.in
     #   scippnexus
-scippnexus==22.12.3
+scippnexus==23.1.1
     # via -r requirements/base.in
 scipy==1.10.0
     # via

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -128,8 +128,9 @@ def _origin(unit) -> sc.Variable:
 
 def _depends_on_to_position(obj) -> Union[None, sc.Variable]:
     if (transform := obj.get('depends_on')) is not None:
-        if isinstance(transform, sc.DataArray) or transform.dtype == sc.DType.DataArray:
-            return None  # cannot compute position if time-dependent
+        if isinstance(transform,
+                      (str, sc.DataArray)) or transform.dtype == sc.DType.DataArray:
+            return None  # cannot compute position if bad transform or time-dependent
         else:
             return transform * _origin(transform.unit)
 

--- a/src/scippneutron/file_loading/load_nexus.py
+++ b/src/scippneutron/file_loading/load_nexus.py
@@ -135,6 +135,8 @@ def _depends_on_to_position(obj) -> Union[None, sc.Variable]:
 
 
 def _monitor_to_canonical(monitor):
+    if isinstance(monitor, sc.DataGroup):
+        return monitor
     if monitor.bins is not None:
         monitor.bins.coords['tof'] = monitor.bins.coords.pop('event_time_offset')
         monitor.bins.coords['detector_id'] = monitor.bins.coords.pop('event_id')
@@ -216,6 +218,8 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
     for group in detectors.values():
         try:
             det = group[()]
+            if isinstance(det, sc.DataGroup):
+                raise NexusStructureError(f"Failed to load NXdetector {group.name}")
             det = _zip_pixel_offset(det)
             det = det.flatten(to='detector_id')
             det.bins.coords['tof'] = det.bins.coords.pop('event_time_offset')
@@ -257,6 +261,8 @@ def _load_data(nexus_file: Union[h5py.File, Dict], root: Optional[str],
         for group in classes.get('NXevent_data', {}).values():
             try:
                 events = group[()]
+                if isinstance(events, sc.DataGroup):
+                    raise NexusStructureError(f"Failed to load NXdetector {group.name}")
                 events.coords['pulse_time'] = events.coords.pop('event_time_zero')
                 events.bins.coords['tof'] = events.bins.coords.pop('event_time_offset')
                 events.bins.coords['detector_id'] = events.bins.coords.pop('event_id')

--- a/tests/load_nexus_test.py
+++ b/tests/load_nexus_test.py
@@ -850,10 +850,10 @@ def test_raises_if_offset_but_not_offset_units_found(
     builder.add_component(component_class(component_name, depends_on=transformation))
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore",
-                                message='Skipped loading',
+                                message='Failed to load',
                                 category=UserWarning)
         loaded_data = load_function(builder)
-    assert loaded_data is None
+    assert isinstance(loaded_data[component_name].value['depends_on'], str)
 
 
 @pytest.mark.parametrize("component_class,component_name",

--- a/tests/load_nexus_test.py
+++ b/tests/load_nexus_test.py
@@ -119,8 +119,7 @@ def test_loads_data_from_single_event_data_group(load_function: Callable):
         sc.array(dims=['detector_id', 'tof'],
                  unit='counts',
                  dtype='float32',
-                 values=expected_counts,
-                 variances=expected_counts))
+                 values=expected_counts))
     expected_detector_ids = np.array([1, 2, 3])
     assert np.array_equal(loaded_data.coords['detector_id'].values,
                           expected_detector_ids)


### PR DESCRIPTION
Make tests pass with https://github.com/scipp/scippnexus/pull/95.

I verified that this works with the AMOR and Loki-detector-test files we have.

Todo:
- [x] Update requirements when scippnexus is release.