### PR TITLE
Frame unwrapping with pulse-skipping

### DIFF
--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -248,9 +248,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wrapped = da.transform_coords(event_time_offset=lambda time: time % pulse_period)\n",
-    "wrapped = wrapped.transform_coords(\n",
-    "    event_time_zero=lambda time: pulse_period * (time // pulse_period)\n",
+    "wrapped = da.transform_coords(\n",
+    "    event_time_offset=lambda time: time % pulse_period,\n",
+    "    event_time_zero=lambda time: pulse_period * (time // pulse_period),\n",
     ")\n",
     "wrapped.hist(Ltotal=100, event_time_offset=100).plot()"
    ]
@@ -458,7 +458,7 @@
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=2,\n",
-    "    lambda_min=0.8*wavmin,\n",
+    "    lambda_min=0.8 * wavmin,\n",
     "    frame_offset=0.0 * sc.Unit('ms'),\n",
     "    first_pulse_time=0 * pulse_period,\n",
     ").hist(Ltotal=100, tof=200).plot()"

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "from frameunwrapping import default_frame_diagram\n",
+    "\n",
     "default_frame_diagram().show()"
    ]
   },
@@ -87,6 +88,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e9e31362-3464-4ccb-8499-7e7e2796ee0b",
+   "metadata": {},
+   "source": [
+    "`scippneutron.tof.frames` provides utilities for performing such computations.\n",
+    "The transformation graph looks as follows:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "66353e3c-ef2c-409f-a965-3478b035fdb3",
@@ -94,8 +104,18 @@
    "outputs": [],
    "source": [
     "from scippneutron.tof import frames\n",
+    "\n",
     "import scipp as sc\n",
+    "\n",
     "sc.show_graph(frames.to_tof(), simplified=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "994575cf-a896-43f9-947f-ba16cd007841",
+   "metadata": {},
+   "source": [
+    "Note how `time_offset` and `frame_period` are aliases for `event_time_offset` and `pulse_period`, respectively."
    ]
   },
   {
@@ -103,7 +123,10 @@
    "id": "4b532f66-9119-4e65-8827-1ed2f4dcfbd0",
    "metadata": {},
    "source": [
-    "## Pulse-skipping"
+    "## Pulse-skipping\n",
+    "\n",
+    "Choppers may be used to skip pulses, for the purpose of a simultaneous study of a wider wavelength range.\n",
+    "Conceptually this looks as follows:"
    ]
   },
   {
@@ -114,20 +137,17 @@
    "outputs": [],
    "source": [
     "from frameunwrapping import frame_skipping_diagram\n",
+    "\n",
     "frame_skipping_diagram().show()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65f6f6ae-8025-4d53-b59f-34ef4f20dafe",
+   "cell_type": "markdown",
+   "id": "578444ae-edfa-4070-a00f-40afa2cdd92e",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import scipp as sc\n",
-    "from scippneutron.tof import frames\n",
-    "graph = frames.to_tof()\n",
-    "sc.show_graph(graph)"
+    "The transformation graph that was given above for the non-pulse-skipping mode is then extended as shown below.\n",
+    "The difference is that `frame_period` and `time_offset` are now computed from additional input parameters:"
    ]
   },
   {
@@ -137,7 +157,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.show_graph(frames.to_tof(pulse_skipping=True), simplified=False)"
+    "sc.show_graph(frames.to_tof(pulse_skipping=True), simplified=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02baefcd-75d6-4833-bd30-31b37cd1cfef",
+   "metadata": {},
+   "source": [
+    "For illustration, we create same fake event data:"
    ]
   },
   {
@@ -147,32 +175,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import scipp as sc\n",
     "import numpy as np\n",
     "from scippneutron.conversion import graph\n",
-    "N = 1000000\n",
+    "\n",
+    "import scipp as sc\n",
+    "\n",
+    "N = 1_000_000\n",
     "Lmax = 160 * sc.Unit('m')\n",
     "tmax = 700 * sc.Unit('ms')\n",
     "pulse_period = 71.0 * sc.Unit('ms')\n",
     "frame_period = 2 * pulse_period\n",
     "wavmin = 5.0 * sc.Unit('angstrom')\n",
     "wavmax = 8.0 * sc.Unit('angstrom')\n",
+    "# This fake data is for a frame_offset of 0.\n",
     "\n",
     "rng = np.random.default_rng(12345)\n",
+    "\n",
     "\n",
     "def fake_frame(frame_number):\n",
     "    dims = ['event']\n",
     "    L = sc.array(dims=dims, values=rng.random(N)) * Lmax\n",
     "    t = sc.array(dims=dims, values=rng.random(N)) * tmax\n",
-    "    table = sc.DataArray(sc.ones(dims=dims, shape=[N]), coords={'Ltotal':L, 'tof':t})\n",
+    "    table = sc.DataArray(sc.ones(dims=dims, shape=[N]), coords={'Ltotal': L, 'tof': t})\n",
     "    table = table.transform_coords('wavelength', graph=graph.tof.elastic(\"tof\"))\n",
     "    da = table.bin(wavelength=1).bins['wavelength', wavmin:wavmax]\n",
     "    return da.transform_coords(time=lambda tof: tof + frame_number * frame_period)\n",
     "\n",
+    "\n",
     "da = sc.concat([fake_frame(i) for i in range(-2, 8)], 'dummy').bins.concat('dummy')\n",
-    "    \n",
-    "da = da.bins['time', 0.0*sc.Unit('ms'):8*frame_period]\n",
-    "del da.attrs['time'] # problem with non-monotenous coord transform"
+    "\n",
+    "da = da.bins['time', 0.0 * sc.Unit('ms') : 8 * frame_period]\n",
+    "del da.attrs['time']  # avoid problems below with non-monotonous coord transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee2e08b2-6e25-49c7-a2d4-07cf90b04496",
+   "metadata": {},
+   "source": [
+    "Our fake data illustrates what we might observe when placing many neutron monitors every along our beamline.\n",
+    "Note that intensities are not modelled correctly, since this is irrelevant here:"
    ]
   },
   {
@@ -186,15 +228,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fc5892a1-fc0f-4108-8c7d-e995d345bc35",
+   "metadata": {},
+   "source": [
+    "We refer to each of the emitted bundles of neutrons as *frame*.\n",
+    "\n",
+    "In practice, NeXus files record event data using `NXevent_data`, and in particular the `event_time_zero` and `event_time_offset` fields.\n",
+    "`event_time_zero` gives the time of the source pulse.\n",
+    "When pulse-skipping is used, the neutrons from each *frame* may nevertheless assigned to *pulses* in the NeXus files.\n",
+    "That is, while we have a frame-period of $2 \\cdot 71~\\text{ms}$ (in this example), `event_time_zero` is in steps of $71~\\text{ms}$.\n",
+    "The `event_time_offset` that we would obtain from a NeXus files thus records the modulus of the `time`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cab93a0a-88ea-41a1-8bf8-87e732395c8b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "wrapped = da.transform_coords(event_time_offset=lambda time: time % pulse_period) \n",
-    "wrapped = wrapped.transform_coords(event_time_zero=lambda time: pulse_period * (time // pulse_period))\n",
+    "wrapped = da.transform_coords(event_time_offset=lambda time: time % pulse_period)\n",
+    "wrapped = wrapped.transform_coords(\n",
+    "    event_time_zero=lambda time: pulse_period * (time // pulse_period)\n",
+    ")\n",
     "wrapped.hist(Ltotal=100, event_time_offset=100).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6835b51c-e4e4-4f65-ac5f-14d8df600fa3",
+   "metadata": {},
+   "source": [
+    "If we consider only neutrons that arrive the sample or detectors, and split them by their `event_time_zero`, we obtain:"
    ]
   },
   {
@@ -204,7 +270,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wrapped.group('event_time_zero').bins['Ltotal', 159.0 * sc.Unit('m'):].hist(event_time_offset=100).plot()"
+    "wrapped.group('event_time_zero').bins['Ltotal', 159.0 * sc.Unit('m') :].hist(\n",
+    "    event_time_offset=100\n",
+    ").plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa4971b8-3676-445d-b59b-f60c533a84ce",
+   "metadata": {},
+   "source": [
+    "This shows a gap in every other *pulse*, corresponding to the gap between *frames*.\n",
+    "Every other pulse shows no gap, since those pulses are completely within a frame.\n",
+    "Note that all this depends on the detection point and, e.g., different sample-detector distances will lead to gaps at different locations or even pulses.\n",
+    "\n",
+    "We can now use [make_frames](../generated/modules/scippneutron.tof.frames.make_frames.html) to \"unwrap\" our fake raw data (or actual data from a NeXus file):"
    ]
   },
   {
@@ -214,11 +294,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scippneutron.tof import frames\n",
-    "\n",
-    "# TODO explain how to set Ltotal or L1 to use chopper as virtual source\n",
     "raw = wrapped.copy()\n",
-    "del raw.bins.attrs['tof']\n",
+    "del raw.bins.attrs['tof']  # Pretend we do not know 'tof' yet\n",
+    "\n",
     "unwrapped = frames.make_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
@@ -227,7 +305,163 @@
     "    frame_offset=0.0 * sc.Unit('ms'),\n",
     "    first_pulse_time=0 * pulse_period,\n",
     ")\n",
-    "unwrapped.hist(Ltotal=100, tof=100).plot()"
+    "unwrapped = unwrapped.hist(Ltotal=100, tof=200)\n",
+    "unwrapped.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "973b8629-fcd5-440b-9587-9cdce789737a",
+   "metadata": {},
+   "source": [
+    "At the sample or a detector we would only see this for a particular `Ltotal`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2b79068-d76b-4d91-af40-49962e1f4703",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unwrapped['Ltotal', -1].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c492b24b-1c66-4f8b-a8d5-f8c9fa2563ac",
+   "metadata": {},
+   "source": [
+    "### Failure cases \n",
+    "\n",
+    "At this point it is worth studying some failure cases that we may observe when incorrect parameters are given to `make_frames`.\n",
+    "Note that in all cases below we show a result for the entire `Ltotal` range from 0 to the maximum.\n",
+    "In practice, values will only be available at a few distances (monitors and detectors), so it will be much harder to distinguish the failure cases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e35b7e5a-cb53-469a-b0e1-56135968ee82",
+   "metadata": {},
+   "source": [
+    "#### Pulse stride 1 instead of 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea6cba38-8154-4f75-9f62-5ede8d971858",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.make_frames(\n",
+    "    raw,\n",
+    "    pulse_period=pulse_period,\n",
+    "    pulse_stride=1,\n",
+    "    lambda_min=wavmin,\n",
+    "    frame_offset=0.0 * sc.Unit('ms'),\n",
+    "    first_pulse_time=0 * pulse_period,\n",
+    ").hist(Ltotal=100, tof=200).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68b057a9-619d-48c7-8e3a-0b9833378b79",
+   "metadata": {},
+   "source": [
+    "#### Pulse stride 3 instead of 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcd7ae4d-7328-483f-9a03-7e8f165ae66e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.make_frames(\n",
+    "    raw,\n",
+    "    pulse_period=pulse_period,\n",
+    "    pulse_stride=3,\n",
+    "    lambda_min=wavmin,\n",
+    "    frame_offset=0.0 * sc.Unit('ms'),\n",
+    "    first_pulse_time=0 * pulse_period,\n",
+    ").hist(Ltotal=100, tof=200).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7793be6f-12bd-464c-b858-cccd795a6a50",
+   "metadata": {},
+   "source": [
+    "#### First pulse off by 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52fba858-8fa9-495d-b1a9-bdadc516fddf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.make_frames(\n",
+    "    raw,\n",
+    "    pulse_period=pulse_period,\n",
+    "    pulse_stride=2,\n",
+    "    lambda_min=wavmin,\n",
+    "    frame_offset=0.0 * sc.Unit('ms'),\n",
+    "    first_pulse_time=1 * pulse_period,\n",
+    ").hist(Ltotal=100, tof=200).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b9e854-9a1f-4dd7-aa8a-8ef70c427e36",
+   "metadata": {},
+   "source": [
+    "#### Wrong frame offset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a574dee5-55ab-4d06-a615-ba7ded64d6f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.make_frames(\n",
+    "    raw,\n",
+    "    pulse_period=pulse_period,\n",
+    "    pulse_stride=2,\n",
+    "    lambda_min=wavmin,\n",
+    "    frame_offset=10.0 * sc.Unit('ms'),\n",
+    "    first_pulse_time=0 * pulse_period,\n",
+    ").hist(Ltotal=100, tof=200).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18be068d-8835-4dda-8bea-f852ebe351b4",
+   "metadata": {},
+   "source": [
+    "#### Bad minimum wavelength"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dff75d90-b83d-4044-9a38-7a3a012aecb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frames.make_frames(\n",
+    "    raw,\n",
+    "    pulse_period=pulse_period,\n",
+    "    pulse_stride=2,\n",
+    "    lambda_min=0.8*wavmin,\n",
+    "    frame_offset=0.0 * sc.Unit('ms'),\n",
+    "    first_pulse_time=0 * pulse_period,\n",
+    ").hist(Ltotal=100, tof=200).plot()"
    ]
   },
   {
@@ -237,7 +471,9 @@
     "tags": []
    },
    "source": [
-    "## Wavelength-frame multiplication"
+    "## Wavelength-frame multiplication\n",
+    "\n",
+    "This is not implemented yet."
    ]
   }
  ],

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -165,7 +165,7 @@
    "id": "02baefcd-75d6-4833-bd30-31b37cd1cfef",
    "metadata": {},
    "source": [
-    "For illustration, we create same fake event data:"
+    "For illustration, we create some fake event data:"
    ]
   },
   {
@@ -205,7 +205,7 @@
     "da = sc.concat([fake_frame(i) for i in range(-2, 8)], 'dummy').bins.concat('dummy')\n",
     "\n",
     "da = da.bins['time', 0.0 * sc.Unit('ms') : 8 * frame_period]\n",
-    "del da.attrs['time']  # avoid problems below with non-monotonous coord transform"
+    "del da.attrs['time']  # avoid problems below with non-monotonic coord transform"
    ]
   },
   {
@@ -213,7 +213,7 @@
    "id": "ee2e08b2-6e25-49c7-a2d4-07cf90b04496",
    "metadata": {},
    "source": [
-    "Our fake data illustrates what we might observe when placing many neutron monitors every along our beamline.\n",
+    "Our fake data illustrates what we might observe when placing many neutron monitors along our beamline.\n",
     "Note that intensities are not modelled correctly, since this is irrelevant here:"
    ]
   },
@@ -236,9 +236,9 @@
     "\n",
     "In practice, NeXus files record event data using `NXevent_data`, and in particular the `event_time_zero` and `event_time_offset` fields.\n",
     "`event_time_zero` gives the time of the source pulse.\n",
-    "When pulse-skipping is used, the neutrons from each *frame* may nevertheless assigned to *pulses* in the NeXus files.\n",
+    "When pulse-skipping is used, the neutrons from each *frame* may nevertheless be assigned to *pulses* in the NeXus files.\n",
     "That is, while we have a frame-period of $2 \\cdot 71~\\text{ms}$ (in this example), `event_time_zero` is in steps of $71~\\text{ms}$.\n",
-    "The `event_time_offset` that we would obtain from a NeXus files thus records the modulus of the `time`:"
+    "The `event_time_offset` that we would obtain from a NeXus file thus records the modulus of the `time`:"
    ]
   },
   {
@@ -260,7 +260,7 @@
    "id": "6835b51c-e4e4-4f65-ac5f-14d8df600fa3",
    "metadata": {},
    "source": [
-    "If we consider only neutrons that arrive the sample or detectors, and split them by their `event_time_zero`, we obtain:"
+    "If we consider only neutrons that arrive at the sample or detectors, and split them by their `event_time_zero`, we obtain:"
    ]
   },
   {

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -118,6 +118,92 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65f6f6ae-8025-4d53-b59f-34ef4f20dafe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipp as sc\n",
+    "from scippneutron.tof import frames\n",
+    "graph = frames.to_tof()\n",
+    "#graph['detection_frame'] = frames.time_zero_to_detection_frame_index\n",
+    "#\n",
+    "#def correct_time_offset(raw_event_time_offset, frame_length, detection_frame):\n",
+    "#    return event_time_offset + detection_frame * frame_length\n",
+    "#\n",
+    "#graph['event_time_offset'] = correct_time_offset\n",
+    "sc.show_graph(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "848e31ed-f0fb-4c6c-8cc9-9de943ffc707",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.show_graph(frames.to_tof(pulse_skipping=True), simplified=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7fc8e1c-a51b-4c8b-a73b-6e7dd590aa1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipp as sc\n",
+    "import numpy as np\n",
+    "from scippneutron.conversion import graph\n",
+    "N = 1000000\n",
+    "Lmax = 160 * sc.Unit('m')\n",
+    "tmax = 700 * sc.Unit('ms')\n",
+    "pulse_period = 71.0 * sc.Unit('ms')\n",
+    "frame_period = 2 * pulse_period\n",
+    "\n",
+    "rng = np.random.default_rng(12345)\n",
+    "dims = ['event']\n",
+    "L = sc.array(dims=dims, values=rng.random(N)) * Lmax\n",
+    "t = sc.array(dims=dims, values=rng.random(N)) * tmax\n",
+    "#event_time_zero = sc.zeros(dims=dims, shape=[N], unit='ms')\n",
+    "table = sc.DataArray(sc.ones(dims=dims, shape=[N]), coords={'Ltotal':L, 'tof':t})\n",
+    "table = table.transform_coords('wavelength', graph=graph.tof.elastic(\"tof\"))\n",
+    "wavmin = 5.0 * sc.Unit('angstrom')\n",
+    "wavmax = 8.0 * sc.Unit('angstrom')\n",
+    "da = table.bin(wavelength=1).bins['wavelength', wavmin:wavmax]\n",
+    "size = len(da.bins.constituents['data'].meta['tof'])\n",
+    "\n",
+    "tmp = da.copy()\n",
+    "for i in range(10):\n",
+    "    tmp.bins.constituents['data'].meta['tof'] += frame_period\n",
+    "    #tmp.bins.constituents['data'].meta['event_time_zero'] += frame_period\n",
+    "    da = da.bins.concatenate(tmp)\n",
+    "da.bins.constituents['data'].meta['tof'] -= 2*frame_period\n",
+    "#da.bins.constituents['data'].meta['event_time_zero'] += frame_period\n",
+    "da = da.bins['tof', 0.0*sc.Unit('ms'):8*frame_period]\n",
+    "del da.attrs['tof'] # problem with non-monotenous coord transform\n",
+    "#da.bins.constituents['data'].meta['tof'][size:] += frame_period\n",
+    "#da = da.bins.concatenate(da)\n",
+    "#da.bins.constituents['data'].meta['tof'][2*size:] += 2*frame_period\n",
+    "wrapped = da.transform_coords(event_time_offset=lambda tof: tof % pulse_period) \n",
+    "wrapped = wrapped.transform_coords(event_time_zero=lambda tof: pulse_period * (tof // pulse_period))\n",
+    "\n",
+    "wrapped.hist(Ltotal=100, event_time_offset=500).plot()\n",
+    "da.hist(Ltotal=100, tof=500).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd8c09bd-de49-46b5-8f34-e217815fb22b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrapped.group('event_time_zero').bins['Ltotal', 159.0 * sc.Unit('m'):].hist(event_time_offset=100).plot()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "b1d30352-5836-435c-8fe2-3cd57a888d8f",
    "metadata": {

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -15,7 +15,7 @@
     "The sum of the two would typically yield the absolute detection time of the neutron.\n",
     "For computation of wavelengths or energies during data-reduction, a time-of-flight is required.\n",
     "In principle the time-of-flight could be equivalent to `event_time_offset`, and the emission time of the neutron to `event_time_zero`.\n",
-    "Since an actual computation of time-of-flight would require knowledge about chopper settings, detector positions, and whether the scattering off the sample is elastic or inelastic, this may however not be the case in practice.\n",
+    "Since an actual computation of time-of-flight would require knowledge about chopper settings, detector positions, and whether the scattering of the sample is elastic or inelastic, this may however not be the case in practice.\n",
     "Instead, the data acquisition system may, e.g., record the time at which the proton pulse hits the target as `event_time_zero`, with `event_time_offset` representing the offset since then.\n",
     "\n",
     "We refer to the process of \"unwrapping\" these time stamps into an actual time-of-flight as *frame unwrapping*, since `event_time_offset` \"wraps around\" with the period of the proton pulse and neutrons created by different proton pulses may be recorded with the *same* `event_time_zero`.\n",

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -344,13 +344,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c492b24b-1c66-4f8b-a8d5-f8c9fa2563ac",
    "metadata": {},
    "source": [
     "### Failure cases \n",
     "\n",
-    "At this point it is worth studying some failure cases that we may observe when incorrect parameters are given to `make_frames`.\n",
+    "At this point it is worth studying some failure cases that we may observe when incorrect parameters are given to `unwrap_frames`.\n",
     "Note that in all cases below we show a result for the entire `Ltotal` range from 0 to the maximum.\n",
     "In practice, values will only be available at a few distances (monitors and detectors), so it will be much harder to distinguish the failure cases."
    ]

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -59,7 +59,7 @@
     "For, e.g., detector 1 when then observe:\n",
     "\n",
     "- First (small `event_time_offset` $\\Delta t$, to the left of the dashed black line) we see the slowest neutrons from N (in this case N=2) source pulses earlier.\n",
-    "- Then (larger `event_time_offset` $\\Delta t$, to the right of the dashed black line) we see the slowest neutrons from N-1 (in this case N-1=1) source pulses earlier.\n",
+    "- Then (larger `event_time_offset` $\\Delta t$, to the right of the dashed black line) we see the fastest neutrons from N-1 (in this case N-1=1) source pulses earlier.\n",
     "- Typically there is is an intermediate region where no neutrons should be able to traverse the chopper cascade.\n",
     "  Neutrons detected in this time interval must thus be background from other sources.\n",
     "\n",

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -298,7 +298,7 @@
     "Every other pulse shows no gap, since those pulses are completely within a frame.\n",
     "Note that all this depends on the detection point and, e.g., different sample-detector distances will lead to gaps at different locations or even pulses.\n",
     "\n",
-    "We can now use [make_frames](../generated/modules/scippneutron.tof.frames.make_frames.html) to \"unwrap\" our fake raw data (or actual data from a NeXus file):"
+    "We can now use [unwrap_frames](../generated/modules/scippneutron.tof.frames.unwrap_frames.html) to \"unwrap\" our fake raw data (or actual data from a NeXus file):"
    ]
   },
   {
@@ -308,10 +308,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from scippneutron.tof import unwrap_frames\n",
+    "\n",
     "raw = wrapped.copy()\n",
     "del raw.bins.attrs['tof']  # Pretend we do not know 'tof' yet\n",
     "\n",
-    "unwrapped = frames.make_frames(\n",
+    "unwrapped = unwrap_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=2,\n",

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -18,7 +18,7 @@
     "Since an actual computation of time-of-flight would require knowledge about chopper settings, detector positions, and whether the scattering off the sample is elastic or inelastic, this may however not be the case in practice.\n",
     "Instead, the data acquisition system may, e.g., record the time at which the proton pulse hits the target as `event_time_zero`, with `event_time_offset` representing the offset since then.\n",
     "\n",
-    "We refer to the process of \"unwrapping\" these time stamps into an actual time-of-flight as *frame unwrapping*, since `event_time_offset` \"wraps around\" with the period of the proton pulse and neutron created by different proton pulse may be recorded with the *same* `event_time_zero`.\n",
+    "We refer to the process of \"unwrapping\" these time stamps into an actual time-of-flight as *frame unwrapping*, since `event_time_offset` \"wraps around\" with the period of the proton pulse and neutrons created by different proton pulses may be recorded with the *same* `event_time_zero`.\n",
     "The figures in the remainder of this document will clarify this."
    ]
   },

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -1,11 +1,25 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "dcc5c0db-6295-4fe7-a951-881a22070be5",
    "metadata": {},
    "source": [
-    "# Frame Unwrapping"
+    "# Frame Unwrapping\n",
+    "\n",
+    "## Context\n",
+    "\n",
+    "At time-of-flight neutron sources recording event-mode, time-stamps of detected neutrons are written to files in an `NXevent_data` group.\n",
+    "This contains two main time components, `event_time_zero` and `event_time_offset`.\n",
+    "The sum of the two would typically yield the absolute detection time of the neutron.\n",
+    "For computation of wavelengths or energies during data-reduction, a time-of-flight is required.\n",
+    "In principle the time-of-flight could be equivalent to `event_time_offset`, and the emission time of the neutron to `event_time_zero`.\n",
+    "Since an actual computation of time-of-flight would require knowledge about chopper settings, detector positions, and whether the scattering off the sample is elastic or inelastic, this may however not be the case in practice.\n",
+    "Instead, the data acquisition system may, e.g., record the time at which the proton pulse hits the target as `event_time_zero`, with `event_time_offset` representing the offset since then.\n",
+    "\n",
+    "We refer to the process of \"unwrapping\" these time stamps into an actual time-of-flight as *frame unwrapping*, since `event_time_offset` \"wraps around\" with the period of the proton pulse and neutron created by different proton pulse may be recorded with the *same* `event_time_zero`.\n",
+    "The figures in the remainder of this document will clarify this."
    ]
   },
   {

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -370,7 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frames.make_frames(\n",
+    "unwrap_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=1,\n",
@@ -395,7 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frames.make_frames(\n",
+    "unwrap_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=3,\n",
@@ -420,7 +420,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frames.make_frames(\n",
+    "unwrap_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=2,\n",
@@ -445,7 +445,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frames.make_frames(\n",
+    "unwrap_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=2,\n",
@@ -470,7 +470,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frames.make_frames(\n",
+    "unwrap_frames(\n",
     "    raw,\n",
     "    pulse_period=pulse_period,\n",
     "    pulse_stride=2,\n",

--- a/docs/reference/frame-unwrapping.ipynb
+++ b/docs/reference/frame-unwrapping.ipynb
@@ -127,12 +127,6 @@
     "import scipp as sc\n",
     "from scippneutron.tof import frames\n",
     "graph = frames.to_tof()\n",
-    "#graph['detection_frame'] = frames.time_zero_to_detection_frame_index\n",
-    "#\n",
-    "#def correct_time_offset(raw_event_time_offset, frame_length, detection_frame):\n",
-    "#    return event_time_offset + detection_frame * frame_length\n",
-    "#\n",
-    "#graph['event_time_offset'] = correct_time_offset\n",
     "sc.show_graph(graph)"
    ]
   },
@@ -149,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7fc8e1c-a51b-4c8b-a73b-6e7dd590aa1a",
+   "id": "71dd5ef2-4fd7-4ff9-bbe1-2b898984f423",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,36 +155,46 @@
     "tmax = 700 * sc.Unit('ms')\n",
     "pulse_period = 71.0 * sc.Unit('ms')\n",
     "frame_period = 2 * pulse_period\n",
-    "\n",
-    "rng = np.random.default_rng(12345)\n",
-    "dims = ['event']\n",
-    "L = sc.array(dims=dims, values=rng.random(N)) * Lmax\n",
-    "t = sc.array(dims=dims, values=rng.random(N)) * tmax\n",
-    "#event_time_zero = sc.zeros(dims=dims, shape=[N], unit='ms')\n",
-    "table = sc.DataArray(sc.ones(dims=dims, shape=[N]), coords={'Ltotal':L, 'tof':t})\n",
-    "table = table.transform_coords('wavelength', graph=graph.tof.elastic(\"tof\"))\n",
     "wavmin = 5.0 * sc.Unit('angstrom')\n",
     "wavmax = 8.0 * sc.Unit('angstrom')\n",
-    "da = table.bin(wavelength=1).bins['wavelength', wavmin:wavmax]\n",
-    "size = len(da.bins.constituents['data'].meta['tof'])\n",
     "\n",
-    "tmp = da.copy()\n",
-    "for i in range(10):\n",
-    "    tmp.bins.constituents['data'].meta['tof'] += frame_period\n",
-    "    #tmp.bins.constituents['data'].meta['event_time_zero'] += frame_period\n",
-    "    da = da.bins.concatenate(tmp)\n",
-    "da.bins.constituents['data'].meta['tof'] -= 2*frame_period\n",
-    "#da.bins.constituents['data'].meta['event_time_zero'] += frame_period\n",
-    "da = da.bins['tof', 0.0*sc.Unit('ms'):8*frame_period]\n",
-    "del da.attrs['tof'] # problem with non-monotenous coord transform\n",
-    "#da.bins.constituents['data'].meta['tof'][size:] += frame_period\n",
-    "#da = da.bins.concatenate(da)\n",
-    "#da.bins.constituents['data'].meta['tof'][2*size:] += 2*frame_period\n",
-    "wrapped = da.transform_coords(event_time_offset=lambda tof: tof % pulse_period) \n",
-    "wrapped = wrapped.transform_coords(event_time_zero=lambda tof: pulse_period * (tof // pulse_period))\n",
+    "rng = np.random.default_rng(12345)\n",
     "\n",
-    "wrapped.hist(Ltotal=100, event_time_offset=500).plot()\n",
-    "da.hist(Ltotal=100, tof=500).plot()"
+    "def fake_frame(frame_number):\n",
+    "    dims = ['event']\n",
+    "    L = sc.array(dims=dims, values=rng.random(N)) * Lmax\n",
+    "    t = sc.array(dims=dims, values=rng.random(N)) * tmax\n",
+    "    table = sc.DataArray(sc.ones(dims=dims, shape=[N]), coords={'Ltotal':L, 'tof':t})\n",
+    "    table = table.transform_coords('wavelength', graph=graph.tof.elastic(\"tof\"))\n",
+    "    da = table.bin(wavelength=1).bins['wavelength', wavmin:wavmax]\n",
+    "    return da.transform_coords(time=lambda tof: tof + frame_number * frame_period)\n",
+    "\n",
+    "da = sc.concat([fake_frame(i) for i in range(-2, 8)], 'dummy').bins.concat('dummy')\n",
+    "    \n",
+    "da = da.bins['time', 0.0*sc.Unit('ms'):8*frame_period]\n",
+    "del da.attrs['time'] # problem with non-monotenous coord transform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58a8627d-a538-48fe-bf69-fe497dd8e959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da.hist(Ltotal=100, time=500).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cab93a0a-88ea-41a1-8bf8-87e732395c8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrapped = da.transform_coords(event_time_offset=lambda time: time % pulse_period) \n",
+    "wrapped = wrapped.transform_coords(event_time_zero=lambda time: pulse_period * (time // pulse_period))\n",
+    "wrapped.hist(Ltotal=100, event_time_offset=100).plot()"
    ]
   },
   {
@@ -201,6 +205,29 @@
    "outputs": [],
    "source": [
     "wrapped.group('event_time_zero').bins['Ltotal', 159.0 * sc.Unit('m'):].hist(event_time_offset=100).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56881d7c-2d11-4efa-a3df-69c7b6041255",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scippneutron.tof import frames\n",
+    "\n",
+    "# TODO explain how to set Ltotal or L1 to use chopper as virtual source\n",
+    "raw = wrapped.copy()\n",
+    "del raw.bins.attrs['tof']\n",
+    "unwrapped = frames.make_frames(\n",
+    "    raw,\n",
+    "    pulse_period=pulse_period,\n",
+    "    pulse_stride=2,\n",
+    "    lambda_min=wavmin,\n",
+    "    frame_offset=0.0 * sc.Unit('ms'),\n",
+    "    first_pulse_time=0 * pulse_period,\n",
+    ")\n",
+    "unwrapped.hist(Ltotal=100, tof=100).plot()"
    ]
   },
   {

--- a/src/scippneutron/tof/__init__.py
+++ b/src/scippneutron/tof/__init__.py
@@ -8,3 +8,4 @@ Specifics for time-of-flight neutron-scattering data reduction, including coordi
 """
 
 from .diagram import TimeDistanceDiagram
+from .frames import unwrap_frames

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -51,7 +51,7 @@ def time_zero_to_pulse_offset(*, pulse_period: sc.Variable, pulse_stride: sc.Var
     Example
     -------
     .. code-block::
-    
+
         event_time_zero = 12:05:00
         first_pulse_time = 12:00:00  # time of first (or any) pulse
                                        that passes through choppers

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -51,11 +51,8 @@ def time_zero_to_pulse_offset(*, pulse_period, pulse_stride, event_time_zero,
     # This is roughly equivalent to
     #   (event_time_zero - first_pulse_time) % frame_period
     # but should avoid some issues with precision and drift
-    #epsilon = sc.scalar(1000000, unit='ns', dtype='int64')
-
-    epsilon =(0.5*pulse_period).to(unit='ns', dtype='int64')
-    pulse_index = (event_time_zero - first_pulse_time) // pulse_period.to(unit=elem_unit(event_time_zero))
-    print(f'{pulse_index.bins.constituents["data"].values=}')
+    pulse_index = (event_time_zero -
+                   first_pulse_time) // pulse_period.to(unit=elem_unit(event_time_zero))
     return pulse_period * (pulse_index % pulse_stride)
 
 

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -175,7 +175,7 @@ def make_frames(da: sc.DataArray,
     :
         Data with 'tof' coordinate.
     """
-    if 'tof' in da.bins.meta or 'tof' in da.meta:
+    if 'tof' in da.meta or (da.bins is not None and 'tof' in da.bins.meta):
         raise ValueError("Coordinate 'tof' already defined in input data array. "
                          "Expected input with 'event_time_offset' coordinate.")
     da = da.copy(deep=False)

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -73,7 +73,7 @@ def to_tof(*, pulse_skipping: bool = False):
     - event_time_zero and event_time_offset as read from an NXevent_data group.
     - lambda_min, used as a proxy for defining where to split and unwrap frames.
     - pulse_period
-    - frame_length and frame_offset defining the frame structure.
+    - pulse_period and frame_offset defining the frame structure.
 
     This assumes elastic scattering, or at least that the gaps between frames arriving
     at detectors are sufficiently large such that a common lambda_min definition is
@@ -111,19 +111,20 @@ def to_tof(*, pulse_skipping: bool = False):
 
 def make_frames(da: sc.DataArray,
                 *,
-                frame_length,
+                pulse_period,
                 frame_offset=None,
                 lambda_min=None,
                 pulse_stride: int = 1) -> sc.DataArray:
     da = da.copy(deep=False)
     # TODO Should check if any of these exist, raise if they do
-    da.attrs['pulse_period'] = frame_length
+    da.attrs['pulse_period'] = pulse_period
+    da.attrs['pulse_stride'] = sc.scalar(pulse_stride)
     if frame_offset is not None:
         da.attrs['frame_offset'] = frame_offset
     if lambda_min is not None:
         da.attrs['lambda_min'] = lambda_min
     graph = Ltotal(scatter=True)
-    graph.update(to_tof(pulse_skipping = pulse_stride != 1))
+    graph.update(to_tof(pulse_skipping=pulse_stride != 1))
     if 'tof' in da.bins.meta or 'tof' in da.meta:
         raise ValueError("Coordinate 'tof' already defined in input data array. "
                          "Expected input with 'event_time_offset' coordinate.")

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -171,6 +171,9 @@ def make_frames(da: sc.DataArray,
     :
         Data with 'tof' coordinate.
     """
+    if 'tof' in da.bins.meta or 'tof' in da.meta:
+        raise ValueError("Coordinate 'tof' already defined in input data array. "
+                         "Expected input with 'event_time_offset' coordinate.")
     da = da.copy(deep=False)
     # TODO Should check if any of these exist, raise if they do
     da.attrs['pulse_period'] = pulse_period
@@ -183,7 +186,4 @@ def make_frames(da: sc.DataArray,
         da.attrs['lambda_min'] = lambda_min
     graph = Ltotal(scatter=True)
     graph.update(to_tof(pulse_skipping=pulse_stride != 1))
-    if 'tof' in da.bins.meta or 'tof' in da.meta:
-        raise ValueError("Coordinate 'tof' already defined in input data array. "
-                         "Expected input with 'event_time_offset' coordinate.")
     return da.transform_coords('tof', graph=graph)

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -16,25 +16,45 @@ def _tof_from_wavelength(*, wavelength, Ltotal):
     return as_float_type(Ltotal * scale, wavelength) * wavelength
 
 
-def _tof_to_time_offset(*, tof, frame_length, frame_offset):
+def _tof_to_time_offset(*, tof, frame_period, frame_offset):
     unit = tof.unit
-    frame_length = frame_length.to(unit=unit)
+    frame_period = frame_period.to(unit=unit)
     arrival_time_offset = frame_offset.to(unit=unit) + tof
-    time_offset = arrival_time_offset % frame_length
+    time_offset = arrival_time_offset % frame_period
     return time_offset
 
 
-def _time_offset_to_tof(*, time_offset, time_offset_pivot, tof_min, frame_length):
-    frame_length = frame_length.to(unit=elem_unit(time_offset))
+def _time_offset_to_tof(*, time_offset, time_offset_pivot, tof_min, frame_period):
+    frame_period = frame_period.to(unit=elem_unit(time_offset))
     time_offset_pivot = time_offset_pivot.to(unit=elem_unit(time_offset))
     tof_min = tof_min.to(unit=elem_unit(time_offset))
     shift = tof_min - time_offset_pivot
-    tof = sc.where(time_offset >= time_offset_pivot, shift, shift + frame_length)
+    tof = sc.where(time_offset >= time_offset_pivot, shift, shift + frame_period)
     tof += time_offset
     return tof
 
 
-def to_tof():
+def time_zero_to_detection_frame_index(*, frame_offset, tof_min, frame_period,
+                                       pulse_stride, event_time_zero):
+    """
+    Return 0-based source frame index of detection frame.
+
+    The source frames containing the time marked by tof_min receive index 0.
+    The frame after that index 1, and so on, until frame_stride-1.
+    """
+    shift = frame_period * ((frame_offset + tof_min) // frame_period)
+    return ((event_time_zero + shift) // (frame_period)).value % pulse_stride
+
+
+def update_time_offset_for_pulse_skipping(event_time_offset, pulse_index, pulse_period):
+    return event_time_offset + pulse_index * pulse_period
+
+
+def pulse_to_frame(pulse_period: sc.Variable, pulse_stride: int) -> sc.Variable:
+    return pulse_period * pulse_stride
+
+
+def to_tof(*, pulse_skipping: bool = False):
     """
     Return a graph suitable for :py:func:`scipp.transform_coords` to convert frames
     to time-of-flight.
@@ -43,6 +63,7 @@ def to_tof():
 
     - event_time_zero and event_time_offset as read from an NXevent_data group.
     - lambda_min, used as a proxy for defining where to split and unwrap frames.
+    - pulse_period
     - frame_length and frame_offset defining the frame structure.
 
     This assumes elastic scattering, or at least that the gaps between frames arriving
@@ -53,21 +74,29 @@ def to_tof():
     def _tof_min(*, Ltotal, lambda_min):
         return _tof_from_wavelength(Ltotal=Ltotal, wavelength=lambda_min)
 
-    def _time_offset_pivot(*, tof_min, frame_length, frame_offset):
+    def _time_offset_pivot(*, tof_min, frame_period, frame_offset):
         return _tof_to_time_offset(tof=tof_min,
-                                   frame_length=frame_length,
+                                   frame_period=frame_period,
                                    frame_offset=frame_offset)
 
-    def _tof(*, event_time_offset, time_offset_pivot, tof_min, frame_length):
+    def _tof(*, event_time_offset, time_offset_pivot, tof_min, frame_period):
         return _time_offset_to_tof(time_offset=event_time_offset,
                                    time_offset_pivot=time_offset_pivot,
                                    tof_min=tof_min,
-                                   frame_length=frame_length)
+                                   frame_period=frame_period)
 
     graph = {}
+    if pulse_skipping:
+        graph['frame_period'] = pulse_to_frame
+        graph['time_offset'] = update_time_offset_for_pulse_skipping
+        graph['pulse_index'] = time_zero_to_detection_frame_index
+    else:
+        graph['frame_period'] = 'pulse_period'
+        graph['time_offset'] = 'event_time_offset'
+
     graph['tof_min'] = _tof_min
     graph['time_offset_pivot'] = _time_offset_pivot
-    graph['tof'] = _tof
+    graph['tof'] = _time_offset_to_tof
     return graph
 
 
@@ -85,15 +114,3 @@ def make_frames(da, *, frame_length, frame_offset=None, lambda_min=None):
         raise ValueError("Coordinate 'tof' already defined in input data array. "
                          "Expected input with 'event_time_offset' coordinate.")
     return da.transform_coords('tof', graph=graph)
-
-
-def time_zero_to_detection_frame_index(*, frame_offset, tof_min, frame_length,
-                                       frame_stride, time_zero):
-    """
-    Return 0-based source frame index of detection frame.
-
-    The source frames containing the time marked by tof_min receive index 0.
-    The frame after that index 1, and so on, until frame_stride-1.
-    """
-    shift = frame_length * ((frame_offset + tof_min) // frame_length)
-    return ((time_zero + shift) // (frame_length)).value % frame_stride

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -50,9 +50,11 @@ def time_zero_to_pulse_offset(*, pulse_period: sc.Variable, pulse_stride: sc.Var
 
     Example
     -------
-    event_time_zero = 12:05:00
-    first_pulse_time = 12:00:00  # time of first (or any) pulse that passes through
-                                   choppers
+    .. code-block::
+    
+        event_time_zero = 12:05:00
+        first_pulse_time = 12:00:00  # time of first (or any) pulse
+                                       that passes through choppers
     """
     # This is roughly equivalent to
     #   (event_time_zero - first_pulse_time) % frame_period
@@ -134,7 +136,7 @@ def make_frames(da: sc.DataArray,
     - ``event_time_offset``, as read from ``NXevent_data``
     - ``event_time_zero``, as read from ``NXevent_data``
       (only for ``pulse_stride > 1``)
-    - ``Ltotal`` or coordinates that allow for computation of thereof. By default
+    - ``Ltotal`` or coordinates that allow for computation thereof. By default,
       ``Ltotal`` may be defined including the full distance between source and sample.
       If resolution choppers are used to shape the raw pulse then this should be
       redefined to set the position of this chopper as the source, and the opening
@@ -159,7 +161,7 @@ def make_frames(da: sc.DataArray,
         Stride of used pulses. Usually 1, but may be a small integer when choppers are
         used to skip pulses.
     frame_offset:
-        Offset of the frame, i.e., time the neutron are considered to be emitted,
+        Offset of the frame, i.e., time the neutrons are considered to be emitted,
         w.r.t., the corresponding ``event_time_zero``. This may be a small offset,
         e.g., to reference the neutron pulse shortly after the proton pulse. When a
         resolution chopper is used, the frame offset can be defined as the opening of

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -85,3 +85,15 @@ def make_frames(da, *, frame_length, frame_offset=None, lambda_min=None):
         raise ValueError("Coordinate 'tof' already defined in input data array. "
                          "Expected input with 'event_time_offset' coordinate.")
     return da.transform_coords('tof', graph=graph)
+
+
+def time_zero_to_detection_frame_index(*, frame_offset, tof_min, frame_length,
+                                       frame_stride, time_zero):
+    """
+    Return 0-based source frame index of detection frame.
+
+    The source frames containing the time marked by tof_min receive index 0.
+    The frame after that index 1, and so on, until frame_stride-1.
+    """
+    shift = frame_length * ((frame_offset + tof_min) // frame_length)
+    return ((time_zero + shift) // (frame_length)).value % frame_stride

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -4,6 +4,8 @@
 """
 Frame transformations for time-of-flight neutron scattering data.
 """
+from typing import Optional
+
 import scipp as sc
 from scipp.constants import h, m_n
 
@@ -115,11 +117,14 @@ def make_frames(da: sc.DataArray,
                 pulse_period,
                 frame_offset=None,
                 lambda_min=None,
-                pulse_stride: int = 1) -> sc.DataArray:
+                pulse_stride: int = 1,
+                first_pulse_time: Optional[sc.Variable] = None) -> sc.DataArray:
     da = da.copy(deep=False)
     # TODO Should check if any of these exist, raise if they do
     da.attrs['pulse_period'] = pulse_period
-    da.attrs['pulse_stride'] = sc.scalar(pulse_stride)
+    if pulse_stride != 1:
+        da.attrs['pulse_stride'] = sc.scalar(pulse_stride)
+        da.attrs['first_pulse_time'] = first_pulse_time
     if frame_offset is not None:
         da.attrs['frame_offset'] = frame_offset
     if lambda_min is not None:

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -51,12 +51,16 @@ def time_zero_to_pulse_offset(*, pulse_period, pulse_stride, event_time_zero,
     # This is roughly equivalent to
     #   (event_time_zero - first_pulse_time) % frame_period
     # but should avoid some issues with precision and drift
-    pulse_index = (event_time_zero - first_pulse_time) // pulse_period
+    #epsilon = sc.scalar(1000000, unit='ns', dtype='int64')
+
+    epsilon =(0.5*pulse_period).to(unit='ns', dtype='int64')
+    pulse_index = (event_time_zero - first_pulse_time) // pulse_period.to(unit=elem_unit(event_time_zero))
+    print(f'{pulse_index.bins.constituents["data"].values=}')
     return pulse_period * (pulse_index % pulse_stride)
 
 
 def update_time_offset_for_pulse_skipping(event_time_offset, pulse_offset):
-    return event_time_offset + pulse_offset
+    return event_time_offset + pulse_offset.to(unit=elem_unit(event_time_offset))
 
 
 def pulse_to_frame(pulse_period: sc.Variable, pulse_stride: int) -> sc.Variable:

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -115,14 +115,14 @@ def to_tof(*, pulse_skipping: Optional[bool] = False) -> dict:
     return graph
 
 
-def make_frames(da: sc.DataArray,
-                *,
-                scatter: Optional[bool] = None,
-                pulse_period: sc.Variable,
-                pulse_stride: int = 1,
-                frame_offset: sc.Variable,
-                lambda_min: sc.Variable,
-                first_pulse_time: Optional[sc.Variable] = None) -> sc.DataArray:
+def unwrap_frames(da: sc.DataArray,
+                  *,
+                  scatter: Optional[bool] = None,
+                  pulse_period: sc.Variable,
+                  pulse_stride: int = 1,
+                  frame_offset: sc.Variable,
+                  lambda_min: sc.Variable,
+                  first_pulse_time: Optional[sc.Variable] = None) -> sc.DataArray:
     """
     Unwrap raw timestamps from ``NXevent_data`` into time-of-flight.
 

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -34,38 +34,29 @@ def _time_offset_to_tof(*, time_offset, time_offset_pivot, tof_min, frame_period
     return tof
 
 
-def time_zero_to_detection_frame_index(*, frame_offset, tof_min, pulse_period,
-                                       pulse_stride, event_time_zero, first_pulse_time):
+def time_zero_to_pulse_offset(*, pulse_period, pulse_stride, event_time_zero,
+                              first_pulse_time):
     """
     Return 0-based source frame index of detection frame.
 
     The source frames containing the time marked by tof_min receive index 0.
     The frame after that index 1, and so on, until frame_stride-1.
+
+    Example
+    -------
+    event_time_zero = 12:05:00
+    first_pulse_time = 12:00:00  # time of first (or any) pulse that passes through
+                                   choppers
     """
-    # NO! this is all wrong! Later step does tof_min dependence, here we should just
-    # do offset for every other pulse!?
-    # TODO update name and docstring
-    # second term is similar to t_pivot, but using floordiv instead of modulo
-    return pulse_period * (((event_time_zero - first_pulse_time) // pulse_period -
-                            (frame_offset + tof_min) // pulse_period) % pulse_stride)
-    shift = frame_period * ((frame_offset + tof_min) // frame_period)
-    # TODO shouldn't this be a minus?
-    # TODO should also subtract datetime of first pulse
-    # TODO not // pulse_period?
-    # should be
-    # ((event_time_zero - first_pulse_time) // pulse_period
-    # - (frame_offset + tof_min) // pulse_period) % pulse_stride
-    #
-    # Example
-    # -------
-    # event_time_zero = 12:05:00
-    # first_pulse_time = 12:00:00  # time of first (or any) pulse that passes through choppers
-    return ((event_time_zero - shift) // (frame_period)).value % pulse_stride
+    # This is roughly equivalent to
+    #   (event_time_zero - first_pulse_time) % frame_period
+    # but should avoid some issues with precision and drift
+    pulse_index = (event_time_zero - first_pulse_time) // pulse_period
+    return pulse_period * (pulse_index % pulse_stride)
 
 
 def update_time_offset_for_pulse_skipping(event_time_offset, pulse_offset):
     return event_time_offset + pulse_offset
-    #return event_time_offset + pulse_index * pulse_period
 
 
 def pulse_to_frame(pulse_period: sc.Variable, pulse_stride: int) -> sc.Variable:
@@ -107,7 +98,7 @@ def to_tof(*, pulse_skipping: bool = False):
     if pulse_skipping:
         graph['frame_period'] = pulse_to_frame
         graph['time_offset'] = update_time_offset_for_pulse_skipping
-        graph['pulse_offset'] = time_zero_to_detection_frame_index
+        graph['pulse_offset'] = time_zero_to_pulse_offset
     else:
         graph['frame_period'] = 'pulse_period'
         graph['time_offset'] = 'event_time_offset'

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -13,12 +13,14 @@ from .._utils import as_float_type, elem_unit
 from ..conversion.graph.beamline import Ltotal
 
 
-def _tof_from_wavelength(*, wavelength, Ltotal):
+def _tof_from_wavelength(*, wavelength: sc.Variable,
+                         Ltotal: sc.Variable) -> sc.Variable:
     scale = (m_n / h).to(unit=sc.units.us / elem_unit(Ltotal) / elem_unit(wavelength))
     return as_float_type(Ltotal * scale, wavelength) * wavelength
 
 
-def _tof_to_time_offset(*, tof, frame_period, frame_offset):
+def _tof_to_time_offset(*, tof: sc.Variable, frame_period: sc.Variable,
+                        frame_offset: sc.Variable) -> sc.Variable:
     unit = tof.unit
     frame_period = frame_period.to(unit=unit)
     arrival_time_offset = frame_offset.to(unit=unit) + tof
@@ -26,7 +28,8 @@ def _tof_to_time_offset(*, tof, frame_period, frame_offset):
     return time_offset
 
 
-def _time_offset_to_tof(*, time_offset, time_offset_pivot, tof_min, frame_period):
+def _time_offset_to_tof(*, time_offset: sc.Variable, time_offset_pivot: sc.Variable,
+                        tof_min: sc.Variable, frame_period: sc.Variable) -> sc.Variable:
     frame_period = frame_period.to(unit=elem_unit(time_offset))
     time_offset_pivot = time_offset_pivot.to(unit=elem_unit(time_offset))
     tof_min = tof_min.to(unit=elem_unit(time_offset))
@@ -36,8 +39,9 @@ def _time_offset_to_tof(*, time_offset, time_offset_pivot, tof_min, frame_period
     return tof
 
 
-def time_zero_to_pulse_offset(*, pulse_period, pulse_stride, event_time_zero,
-                              first_pulse_time):
+def time_zero_to_pulse_offset(*, pulse_period: sc.Variable, pulse_stride: sc.Variable,
+                              event_time_zero: sc.Variable,
+                              first_pulse_time: sc.Variable) -> sc.Variable:
     """
     Return 0-based source frame index of detection frame.
 
@@ -58,15 +62,17 @@ def time_zero_to_pulse_offset(*, pulse_period, pulse_stride, event_time_zero,
     return pulse_period * (pulse_index % pulse_stride)
 
 
-def update_time_offset_for_pulse_skipping(event_time_offset, pulse_offset):
+def update_time_offset_for_pulse_skipping(*, event_time_offset: sc.Variable,
+                                          pulse_offset: sc.Variable) -> sc.Variable:
     return event_time_offset + pulse_offset.to(unit=elem_unit(event_time_offset))
 
 
-def pulse_to_frame(pulse_period: sc.Variable, pulse_stride: int) -> sc.Variable:
+def pulse_to_frame(*, pulse_period: sc.Variable,
+                   pulse_stride: sc.Variable) -> sc.Variable:
     return pulse_period * pulse_stride
 
 
-def to_tof(*, pulse_skipping: bool = False):
+def to_tof(*, pulse_skipping: Optional[bool] = False) -> dict:
     """
     Return a graph suitable for :py:func:`scipp.transform_coords` to convert frames
     to time-of-flight.
@@ -114,10 +120,10 @@ def to_tof(*, pulse_skipping: bool = False):
 
 def make_frames(da: sc.DataArray,
                 *,
-                pulse_period,
-                frame_offset=None,
-                lambda_min=None,
+                pulse_period: sc.Variable,
                 pulse_stride: int = 1,
+                frame_offset: Optional[sc.Variable] = None,
+                lambda_min: Optional[sc.Variable] = None,
                 first_pulse_time: Optional[sc.Variable] = None) -> sc.DataArray:
     da = da.copy(deep=False)
     # TODO Should check if any of these exist, raise if they do

--- a/src/scippneutron/tof/frames.py
+++ b/src/scippneutron/tof/frames.py
@@ -109,16 +109,21 @@ def to_tof(*, pulse_skipping: bool = False):
     return graph
 
 
-def make_frames(da, *, frame_length, frame_offset=None, lambda_min=None):
+def make_frames(da: sc.DataArray,
+                *,
+                frame_length,
+                frame_offset=None,
+                lambda_min=None,
+                pulse_stride: int = 1) -> sc.DataArray:
     da = da.copy(deep=False)
     # TODO Should check if any of these exist, raise if they do
-    da.attrs['frame_length'] = frame_length
+    da.attrs['pulse_period'] = frame_length
     if frame_offset is not None:
         da.attrs['frame_offset'] = frame_offset
     if lambda_min is not None:
         da.attrs['lambda_min'] = lambda_min
     graph = Ltotal(scatter=True)
-    graph.update(to_tof())
+    graph.update(to_tof(pulse_skipping = pulse_stride != 1))
     if 'tof' in da.bins.meta or 'tof' in da.meta:
         raise ValueError("Coordinate 'tof' already defined in input data array. "
                          "Expected input with 'event_time_offset' coordinate.")

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -6,6 +6,7 @@ import pytest
 import scipp as sc
 
 from scippneutron.tof import frames
+from scippneutron.tof.frames import time_zero_to_detection_frame_index
 
 
 def make_array(*, npixel=3, nevent=1000, frame_length=None, time_offset=None):
@@ -135,18 +136,6 @@ def test_make_frames_reproduces_true_pulses(tof_min, frame_offset):
                        reference,
                        atol=sc.scalar(1e-12, unit=reference.bins.unit),
                        rtol=sc.scalar(1e-12))
-
-
-def time_zero_to_detection_frame_index(*, frame_offset, tof_min, frame_length,
-                                       frame_stride, time_zero):
-    """
-    Return 0-based source frame index of detection frame.
-
-    The source frames containing the time marked by tof_min receive index 0.
-    The frame after that index 1, and so on, until frame_stride-1.
-    """
-    shift = frame_length * ((frame_offset + tof_min) // frame_length)
-    return ((time_zero + shift) // (frame_length)).value % frame_stride
 
 
 class Test_time_zero_to_detection_frame_index:

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -37,6 +37,7 @@ def test_make_frames_given_tof_bins_meta_data_raises_ValueError():
     da.coords['tof'] = sc.scalar(1.0, unit='ms')
     with pytest.raises(ValueError):
         frames.make_frames(da,
+                           scatter=True,
                            pulse_period=71.0 * sc.Unit('ms'),
                            frame_offset=30.1 * sc.Unit('ms'),
                            lambda_min=2.5 * sc.Unit('Angstrom'))
@@ -47,6 +48,7 @@ def test_make_frames_given_tof_event_meta_data_raises_ValueError():
     da.bins.coords['tof'] = da.bins.coords['event_time_offset']
     with pytest.raises(ValueError):
         frames.make_frames(da,
+                           scatter=True,
                            pulse_period=71.0 * sc.Unit('ms'),
                            frame_offset=30.1 * sc.Unit('ms'),
                            lambda_min=2.5 * sc.Unit('Angstrom'))
@@ -55,6 +57,7 @@ def test_make_frames_given_tof_event_meta_data_raises_ValueError():
 def test_make_frames_no_shift_and_infinite_energy_yields_tof_equal_time_offset():
     da = make_array(pulse_period=71.0 * sc.Unit('ms'))
     da = frames.make_frames(da,
+                            scatter=True,
                             pulse_period=71.0 * sc.Unit('ms'),
                             frame_offset=0.0 * sc.Unit('ms'),
                             lambda_min=0.0 * sc.Unit('Angstrom'))
@@ -67,6 +70,7 @@ def test_make_frames_no_shift_and_no_events_below_lambda_min_yields_tof_equal_ti
     da.bins.coords['event_time_offset'] += sc.to_unit(
         10.0 * sc.Unit('ms'), da.bins.coords['event_time_offset'].bins.unit)
     da = frames.make_frames(da,
+                            scatter=True,
                             pulse_period=81.0 * sc.Unit('ms'),
                             frame_offset=0.0 * sc.Unit('ms'),
                             lambda_min=0.2 * sc.Unit('Angstrom'))
@@ -84,7 +88,8 @@ def test_make_frames_time_offset_pivot_and_min_define_frames():
                        da.bins.coords['event_time_offset'].bins.unit)
     da.coords['time_offset_pivot'] = pivot
     da.coords['tof_min'] = 200.0 * sc.Unit('ms')
-    da = frames.make_frames(da, pulse_period=71.0 * sc.Unit('ms'))
+    da.coords['pulse_period'] = 71.0 * sc.Unit('ms')
+    da = da.transform_coords('tof', graph=frames.to_tof())
     tof = da.bins.coords['tof'].values[0]
     tof_values = [
         71.0 - 10.0 + 5.0 + 200.0,
@@ -131,6 +136,7 @@ def test_make_frames_reproduces_true_pulses(tof_min, frame_offset):
                                      Ltotal=da.coords['L1'] + da.coords['L2'])
 
     da = frames.make_frames(da,
+                            scatter=True,
                             pulse_period=pulse_period,
                             frame_offset=frame_offset,
                             lambda_min=lambda_min)
@@ -198,6 +204,7 @@ def test_make_frames_with_pulse_stride_reproduces_true_pulses(
                                      Ltotal=da.coords['L1'] + da.coords['L2'])
 
     da = frames.make_frames(da,
+                            scatter=True,
                             pulse_period=pulse_period,
                             pulse_stride=pulse_stride,
                             first_pulse_time=start,

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -159,11 +159,11 @@ def fake_pulse_skipping_data(*,
                              frame_offset,
                              tof_min):
     from scippneutron.conversion.tof import wavelength_from_tof
+    rng = np.random.default_rng(1234)
 
     # Setup data with known 'tof' coord, which will serve as a reference
     frame_period = (pulse_period * pulse_stride).to(unit=tof_min.unit)
-    tof = sc.array(dims=['event'],
-                   values=np.random.rand(nevent)) * frame_period + tof_min
+    tof = sc.array(dims=['event'], values=rng.random(nevent)) * frame_period + tof_min
     start = sc.datetime('now', unit='ns')
     time_zero = start + (frame_period * sc.linspace(
         'event', 0, nframe, num=nevent, dtype='int64')).to(unit='ns', dtype='int64')
@@ -189,7 +189,7 @@ def fake_pulse_skipping_data(*,
     return reference, da, start, lambda_min
 
 
-@given(nevent=st.integers(min_value=0, max_value=1000),
+@given(nevent=st.integers(min_value=0, max_value=10000),
        nframe=st.integers(min_value=1, max_value=1000000),
        frame_offset=st.floats(min_value=0.0, max_value=10000.0),
        tof_min=st.floats(min_value=0.1, max_value=100000.0))
@@ -220,5 +220,5 @@ def test_make_frames_with_pulse_stride_reproduces_true_pulses(
     expected = reference.bins.coords['tof']
     assert sc.allclose(da.bins.coords['tof'],
                        expected,
-                       atol=sc.scalar(1e-10, unit=expected.bins.unit),
-                       rtol=sc.scalar(1e-10))
+                       atol=sc.scalar(1e-9, unit=expected.bins.unit),
+                       rtol=sc.scalar(1e-9))

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -192,7 +192,6 @@ def test_make_frames_with_pulse_stride_reproduces_true_pulses(
                                      frame_offset=frame_offset)
     event_time_offset = time_offset % pulse_period.to(unit=time_offset.bins.unit)
     da.bins.coords['event_time_offset'] = event_time_offset
-    da.coords['first_pulse_time'] = start
     da.bins.coords['event_time_zero'] = da.bins.coords.pop('time_zero') + (
         time_offset - event_time_offset).to(unit='ns', dtype='int64')
     lambda_min = wavelength_from_tof(tof=tof_min,
@@ -201,6 +200,7 @@ def test_make_frames_with_pulse_stride_reproduces_true_pulses(
     da = frames.make_frames(da,
                             pulse_period=pulse_period,
                             pulse_stride=pulse_stride,
+                            first_pulse_time=start,
                             frame_offset=frame_offset,
                             lambda_min=lambda_min)
 

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -9,12 +9,12 @@ from scippneutron.tof import frames
 from scippneutron.tof.frames import time_zero_to_pulse_offset
 
 
-def make_array(*, npixel=3, nevent=1000, frame_length=None, time_offset=None):
-    frame_length = 71.0e3 * sc.Unit('us') if frame_length is None else frame_length.to(
+def make_array(*, npixel=3, nevent=1000, pulse_period=None, time_offset=None):
+    pulse_period = 71.0e3 * sc.Unit('us') if pulse_period is None else pulse_period.to(
         unit='us')
     if time_offset is None:
         time_offset = sc.array(dims=['event'],
-                               values=np.random.rand(nevent) * frame_length.value,
+                               values=np.random.rand(nevent) * pulse_period.value,
                                unit='us')
     pixel = sc.arange(dim='event', start=0, stop=nevent) % npixel
     events = sc.DataArray(sc.ones(sizes=time_offset.sizes),
@@ -33,7 +33,7 @@ def test_make_frames_given_tof_bins_meta_data_raises_ValueError():
     da.coords['tof'] = sc.scalar(1.0, unit='ms')
     with pytest.raises(ValueError):
         frames.make_frames(da,
-                           frame_length=71.0 * sc.Unit('ms'),
+                           pulse_period=71.0 * sc.Unit('ms'),
                            frame_offset=30.1 * sc.Unit('ms'),
                            lambda_min=2.5 * sc.Unit('Angstrom'))
 
@@ -43,15 +43,15 @@ def test_make_frames_given_tof_event_meta_data_raises_ValueError():
     da.bins.coords['tof'] = da.bins.coords['event_time_offset']
     with pytest.raises(ValueError):
         frames.make_frames(da,
-                           frame_length=71.0 * sc.Unit('ms'),
+                           pulse_period=71.0 * sc.Unit('ms'),
                            frame_offset=30.1 * sc.Unit('ms'),
                            lambda_min=2.5 * sc.Unit('Angstrom'))
 
 
 def test_make_frames_no_shift_and_infinite_energy_yields_tof_equal_time_offset():
-    da = make_array(frame_length=71.0 * sc.Unit('ms'))
+    da = make_array(pulse_period=71.0 * sc.Unit('ms'))
     da = frames.make_frames(da,
-                            frame_length=71.0 * sc.Unit('ms'),
+                            pulse_period=71.0 * sc.Unit('ms'),
                             frame_offset=0.0 * sc.Unit('ms'),
                             lambda_min=0.0 * sc.Unit('Angstrom'))
     assert sc.identical(da.bins.coords['tof'], da.bins.attrs['event_time_offset'])
@@ -59,11 +59,11 @@ def test_make_frames_no_shift_and_infinite_energy_yields_tof_equal_time_offset()
 
 def test_make_frames_no_shift_and_no_events_below_lambda_min_yields_tof_equal_time_offset(  # noqa #501
 ):
-    da = make_array(frame_length=71.0 * sc.Unit('ms'))
+    da = make_array(pulse_period=71.0 * sc.Unit('ms'))
     da.bins.coords['event_time_offset'] += sc.to_unit(
         10.0 * sc.Unit('ms'), da.bins.coords['event_time_offset'].bins.unit)
     da = frames.make_frames(da,
-                            frame_length=81.0 * sc.Unit('ms'),
+                            pulse_period=81.0 * sc.Unit('ms'),
                             frame_offset=0.0 * sc.Unit('ms'),
                             lambda_min=0.2 * sc.Unit('Angstrom'))
     assert sc.identical(da.bins.coords['tof'], da.bins.attrs['event_time_offset'])
@@ -72,7 +72,7 @@ def test_make_frames_no_shift_and_no_events_below_lambda_min_yields_tof_equal_ti
 def test_make_frames_time_offset_pivot_and_min_define_frames():
     # events [before, after, after, before] pivot point
     time_offset = sc.array(dims=['event'], values=[5.0, 70.0, 21.0, 6.0], unit='ms')
-    da = make_array(frame_length=71.0 * sc.Unit('ms'),
+    da = make_array(pulse_period=71.0 * sc.Unit('ms'),
                     npixel=1,
                     nevent=4,
                     time_offset=time_offset)
@@ -80,7 +80,7 @@ def test_make_frames_time_offset_pivot_and_min_define_frames():
                        da.bins.coords['event_time_offset'].bins.unit)
     da.coords['time_offset_pivot'] = pivot
     da.coords['tof_min'] = 200.0 * sc.Unit('ms')
-    da = frames.make_frames(da, frame_length=71.0 * sc.Unit('ms'))
+    da = frames.make_frames(da, pulse_period=71.0 * sc.Unit('ms'))
     tof = da.bins.coords['tof'].values[0]
     tof_values = [
         71.0 - 10.0 + 5.0 + 200.0,
@@ -91,10 +91,10 @@ def test_make_frames_time_offset_pivot_and_min_define_frames():
     assert sc.identical(tof, sc.array(dims=['event'], unit='ms', values=tof_values))
 
 
-def tof_array(*, npixel=3, nevent=1000, frame_length=None, tof_min=None):
-    frame_length = 71.0 * sc.Unit('ms') if frame_length is None else frame_length
+def tof_array(*, npixel=3, nevent=1000, pulse_period=None, tof_min=None):
+    pulse_period = 71.0 * sc.Unit('ms') if pulse_period is None else pulse_period
     tof_min = 234.0 * sc.Unit('ms') if tof_min is None else tof_min
-    tof = sc.array(dims=['event'], values=np.random.rand(nevent)) * frame_length.to(
+    tof = sc.array(dims=['event'], values=np.random.rand(nevent)) * pulse_period.to(
         unit=tof_min.unit) + tof_min
     pixel = sc.arange(dim='event', start=0, stop=nevent) % npixel
     events = sc.DataArray(sc.ones(sizes=tof.sizes), coords={'tof': tof, 'pixel': pixel})
@@ -104,9 +104,9 @@ def tof_array(*, npixel=3, nevent=1000, frame_length=None, tof_min=None):
     return da
 
 
-def tof_to_time_offset(tof, *, frame_length, frame_offset):
+def tof_to_time_offset(tof, *, pulse_period, frame_offset):
     unit = tof.bins.unit
-    return (frame_offset.to(unit=unit) + tof) % frame_length.to(unit=unit)
+    return (frame_offset.to(unit=unit) + tof) % pulse_period.to(unit=unit)
 
 
 @pytest.mark.parametrize(
@@ -115,19 +115,19 @@ def tof_to_time_offset(tof, *, frame_length, frame_offset):
     "frame_offset", [0.0 * sc.Unit('ms'), 11.0 * sc.Unit('ms'), 9999.0 * sc.Unit('us')])
 def test_make_frames_reproduces_true_pulses(tof_min, frame_offset):
     from scippneutron.conversion.tof import wavelength_from_tof
-    frame_length = 71.0 * sc.Unit('ms')
+    pulse_period = 71.0 * sc.Unit('ms')
     # Setup data with known 'tof' coord, which will serve as a reference
-    da = tof_array(frame_length=frame_length, tof_min=tof_min)
+    da = tof_array(pulse_period=pulse_period, tof_min=tof_min)
     reference = da.bins.coords['tof'].copy()
     # Compute backwards to "raw" input with 'event_time_offset'. 'tof' coord is removed
     da.bins.coords['event_time_offset'] = tof_to_time_offset(da.bins.coords.pop('tof'),
-                                                             frame_length=frame_length,
+                                                             pulse_period=pulse_period,
                                                              frame_offset=frame_offset)
     lambda_min = wavelength_from_tof(tof=tof_min,
                                      Ltotal=da.coords['L1'] + da.coords['L2'])
 
     da = frames.make_frames(da,
-                            frame_length=frame_length,
+                            pulse_period=pulse_period,
                             frame_offset=frame_offset,
                             lambda_min=lambda_min)
 
@@ -141,28 +141,28 @@ def test_make_frames_reproduces_true_pulses(tof_min, frame_offset):
 class Test_time_zero_to_detection_frame_index:
     tof_min = [234.0 * sc.Unit('ms'), 37.0 * sc.Unit('ms'), 337.0 * sc.Unit('ms')]
     frame_offset = [0.0 * sc.Unit('ms'), 11.0 * sc.Unit('ms'), 9.999 * sc.Unit('ms')]
-    frame_length = [71.0 * sc.Unit('ms')]
+    pulse_period = [71.0 * sc.Unit('ms')]
     time_zero = [
         t0 * sc.Unit('ms') for t0 in [0.0, 11.0, 70.0, 71.0, 71.1, 300.0, 345.6]
     ]
 
     @pytest.mark.parametrize("tof_min", tof_min)
     @pytest.mark.parametrize("frame_offset", frame_offset)
-    @pytest.mark.parametrize("frame_length", frame_length)
+    @pytest.mark.parametrize("pulse_period", pulse_period)
     @pytest.mark.parametrize("time_zero", time_zero)
-    def test_frame_stride_1_yields_index_0(self, frame_length, frame_offset, tof_min,
+    def test_frame_stride_1_yields_index_0(self, pulse_period, frame_offset, tof_min,
                                            time_zero):
-        assert time_zero_to_detection_frame_index(frame_length=frame_length,
+        assert time_zero_to_detection_frame_index(pulse_period=pulse_period,
                                                   frame_stride=1,
                                                   frame_offset=frame_offset,
                                                   tof_min=tof_min,
                                                   time_zero=time_zero) == 0
 
     def test_frame_stride_2_with_zero_params_yields_source_frame_index(self):
-        frame_length = 71.0 * sc.Unit('ms')
+        pulse_period = 71.0 * sc.Unit('ms')
         frame_offset = 0.0 * sc.Unit('ms')
         tof_min = 0.0 * sc.Unit('ms')
-        params = dict(frame_length=frame_length,
+        params = dict(pulse_period=pulse_period,
                       frame_stride=2,
                       frame_offset=frame_offset,
                       tof_min=tof_min)
@@ -176,15 +176,15 @@ class Test_time_zero_to_detection_frame_index:
                                                   time_zero=213.0 * sc.Unit('ms')) == 1
 
     def test_frame_stride_2_with_tof_min_yields_index_with_offset(self):
-        frame_length = 100.0 * sc.Unit('ms')
+        pulse_period = 100.0 * sc.Unit('ms')
         frame_offset = 0.0 * sc.Unit('ms')
         # Given fastest neutrons from source frame 0 arriving in third frame...
         tof_min = 317 * sc.Unit('ms')
-        params = dict(frame_length=frame_length,
+        params = dict(pulse_period=pulse_period,
                       frame_stride=2,
                       frame_offset=frame_offset,
                       tof_min=tof_min)
-        # ... should yield index 0 for time_zero=3*frame_length.
+        # ... should yield index 0 for time_zero=3*pulse_period.
         # TODO What about rounding issues? Can we end up with whole frames offset by 1?
         assert time_zero_to_detection_frame_index(**params,
                                                   time_zero=0.0 * sc.Unit('ms')) == 1
@@ -206,7 +206,7 @@ class Test_time_zero_to_detection_frame_index:
                       pulse_stride=2,
                       frame_offset=frame_offset,
                       tof_min=tof_min)
-        # ... should yield index 0 for time_zero=4*frame_length.
+        # ... should yield index 0 for time_zero=4*pulse_period.
         assert time_zero_to_detection_frame_index(**params,
                                                   event_time_zero=0.0 *
                                                   sc.Unit('ms')) == 0

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -6,7 +6,7 @@ import pytest
 import scipp as sc
 
 from scippneutron.tof import frames
-from scippneutron.tof.frames import time_zero_to_detection_frame_index
+from scippneutron.tof.frames import time_zero_to_pulse_offset
 
 
 def make_array(*, npixel=3, nevent=1000, frame_length=None, time_offset=None):

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -190,7 +190,7 @@ def fake_pulse_skipping_data(*,
 
 
 @given(nevent=st.integers(min_value=0, max_value=1000),
-       nframe=st.integers(min_value=1, max_value=10000),
+       nframe=st.integers(min_value=1, max_value=1000000),
        frame_offset=st.floats(min_value=0.0, max_value=10000.0),
        tof_min=st.floats(min_value=0.1, max_value=100000.0))
 @pytest.mark.parametrize("pulse_stride", [1, 2, 3, 4, 5])

--- a/tests/tof/frames_test.py
+++ b/tests/tof/frames_test.py
@@ -197,27 +197,34 @@ class Test_time_zero_to_detection_frame_index:
 
     def test_frame_stride_2_with_frame_offset_and_tof_min_yields_index_with_offset(
             self):
-        frame_length = 100.0 * sc.Unit('ms')
+        frame_period = 100.0 * sc.Unit('ms')
         # Given frame_offset, fastest neutrons from source frame 0 arriving in fourth
         # frame...
         frame_offset = 110.0 * sc.Unit('ms')  # offset is 1 frame
         tof_min = 317 * sc.Unit('ms')  # offset is 3 frames
-        params = dict(frame_length=frame_length,
-                      frame_stride=2,
+        params = dict(frame_period=frame_period,
+                      pulse_stride=2,
                       frame_offset=frame_offset,
                       tof_min=tof_min)
         # ... should yield index 0 for time_zero=4*frame_length.
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=0.0 * sc.Unit('ms')) == 0
+                                                  event_time_zero=0.0 *
+                                                  sc.Unit('ms')) == 0
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=100.0 * sc.Unit('ms')) == 1
+                                                  event_time_zero=100.0 *
+                                                  sc.Unit('ms')) == 1
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=200.0 * sc.Unit('ms')) == 0
+                                                  event_time_zero=200.0 *
+                                                  sc.Unit('ms')) == 0
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=299.0 * sc.Unit('ms')) == 0
+                                                  event_time_zero=299.0 *
+                                                  sc.Unit('ms')) == 0
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=300.0 * sc.Unit('ms')) == 1
+                                                  event_time_zero=300.0 *
+                                                  sc.Unit('ms')) == 1
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=301.0 * sc.Unit('ms')) == 1
+                                                  event_time_zero=301.0 *
+                                                  sc.Unit('ms')) == 1
         assert time_zero_to_detection_frame_index(**params,
-                                                  time_zero=400.0 * sc.Unit('ms')) == 0
+                                                  event_time_zero=400.0 *
+                                                  sc.Unit('ms')) == 0


### PR DESCRIPTION
Part of #402.
Fixes #236.

@arm61 please have a look if this matches what you will need for Estia.

Apart from the input parameters found in the NeXus files directly (`event_time_zero` and `event_time_offset`), the frame unwrapping with pulse skipping requires:

- `pulse_period` (I suppose this is fixed at ESS)
- `pulse_stride` (configured when selecting pulse-skipping)
- `frame_offset` (could be obtain from some monitors, or based on opening of resolution choppers, if present)
- `lambda_min` (from chopper params, may be configured by user in experiment-control software?)
- `first_pulse_time` (I think this can be obtain from the phasing information of the choppers)

There will be follow-up work in which we can implement functionality that may be required to parse or compute these input parameters, based on additional meta data that should be available from the NeXus files.

Here is a PDF version of the modified notebook:

[frame-unwrapping.pdf](https://github.com/scipp/scippneutron/files/10557783/frame-unwrapping.pdf)

To do (after initial review):

- [x] More thorough testing.
