### PR TITLE
Set unit=None in conversion from mantid.MaskWorkspace

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -34,6 +34,14 @@ Release Notes
    Neil Vaytet :sup:`a`\ ,
    and Jan-Lukas Wynen :sup:`a`
 
+v23.03.1 (March 2022)
+---------------------
+
+Bugfixes
+~~~~~~~~
+
+* Conversion from ``mantid.MaskWorkspace`` now correctly sets ``unit=None`` instead of using dimensionless `424 <https://github.com/scipp/scipp/pull/424>`_.
+
 v23.03.0
 --------
 

--- a/src/scippneutron/mantid.py
+++ b/src/scippneutron/mantid.py
@@ -564,7 +564,7 @@ def convert_Workspace2D_to_data_array(ws,
     _, data_unit = validate_and_get_unit(ws.YUnit(), allow_empty=True)
     if ws.id() == 'MaskWorkspace':
         coords_labs_data["data"] = sc.Variable(dims=[spec_dim],
-                                               unit=data_unit,
+                                               unit=None,
                                                values=ws.extractY().flatten(),
                                                dtype=sc.DType.bool)
     else:

--- a/tests/mantid_test.py
+++ b/tests/mantid_test.py
@@ -859,6 +859,7 @@ def test_from_mask_workspace():
     dir_path = path.dirname(path.realpath(__file__))
     mask = LoadMask('HYS', path.join(dir_path, 'HYS_mask.xml'))
     da = scn.from_mantid(mask)
+    assert da.unit is None
     assert da.data.dtype == sc.DType.bool
     assert da.dims == ('spectrum', )
     assert da.variances is None


### PR DESCRIPTION
This code predates the support for `unit=None` in Scipp and was missed when updating. Code for masks of workspaces seems to be correct, only this special case of the mask being values was affected.