### PR TITLE
Ignore license link in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,6 +284,8 @@ linkcheck_ignore = [
     r'https?://github\.com/[^/]+/[^/]+\#',
     # Many links for PRs from our release notes. Slow and unlikely to cause issues.
     'https://github.com/scipp/scipp/pull/[0-9]+',
+    # This returns '403 Forbidden' but the link works in a browser.
+    'https://opensource.org/licenses/BSD-3-Clause',
 ]
 
 # Set env variable to enable plopp


### PR DESCRIPTION
This failed in multiple builds recently, e.g. https://github.com/scipp/scippneutron/actions/runs/4593741606/jobs/8111987831