### PR TITLE
Use all optional dependencies in unpinned nightly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands = pytest
 description = Test with unpinned dependencies, as a user would install now.
 deps =
   -r requirements/basetest.txt
-  scippneutron
+  scippneutron[all]
 commands = pytest
 
 [testenv:static]


### PR DESCRIPTION
The current unpinned tests are failing because of missing dependencies.