### PR TITLE
deps: add matplotlib

### DIFF
--- a/requirements/basetest.in
+++ b/requirements/basetest.in
@@ -2,6 +2,7 @@
 # Do not make an environment from this file, use test.txt instead!
 
 hypothesis
+matplotlib
 psutil
 pytest
 pytest-xdist


### PR DESCRIPTION
Fixes #495

The alternative solution would be to treat matplotlib as an optional dependency, and only run the tests that use it if it is installed.
