### PR TITLE
Add a builder class for CIF files

### DIFF
--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -514,6 +514,8 @@ def _quotes_for_string_value(value: str) -> str | None:
         return "'"
     if ' ' in value:
         return "'"
+    if not value:
+        return "'"  # so that empty strings are shown as ''
     return None
 
 

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -131,6 +131,7 @@ import io
 import warnings
 from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
+from copy import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -180,7 +181,8 @@ def save_cif(
     """
     if isinstance(content, CIF):
         if comment:
-            raise ValueError('Cannot specify a comment when saving a CIF object')
+            content = copy(content)
+            content.comment = comment
         content.save(fname)
         return
 

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -12,7 +12,7 @@ This module supports two interfaces for writing files.
 The high-level interface uses a builder pattern for assembling files.
 It is implemented by :class:`CIF`.
 
-To demnstrate the interface, first make some mockup powder diffraction data:
+To demonstrate the interface, first make some mockup powder diffraction data:
 
   >>> import scipp as sc
   >>> tof = sc.array(dims=['tof'], values=[1.2, 1.4, 2.3], unit='us')

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -753,7 +753,8 @@ def _make_reduced_powder_loop(data: sc.DataArray, comment: str) -> Loop:
         res[data_name + '_su'] = sc.stddevs(data.data)
 
     if data.unit != 'one':
-        res.comment = f'Unit of intensity: [{data.unit}]'
+        pre = res.comment + '\n' if res.comment else ''
+        res.comment = f'{pre}Unit of intensity: [{data.unit}]'
 
     return res
 

--- a/tests/io/cif_test.py
+++ b/tests/io/cif_test.py
@@ -236,6 +236,18 @@ _audit.creation_method 'Unicode: \xb5\xc5'
     )
 
 
+def test_write_block_single_pair_empty_value():
+    block = cif.Block('utf-8', [{'audit.creation_method': ''}])
+    res = write_to_str(block)
+    assert (
+        res
+        == r'''data_utf-8
+
+_audit.creation_method ''
+'''
+    )
+
+
 def test_write_block_single_pair_single_line_comment():
     block = cif.Block('comment')
     block.add({'diffrn_radiation.probe': 'neutron'}, comment='a comment')
@@ -434,6 +446,26 @@ and some salt
 123
 sulfur
 x6a
+'''
+    )
+
+
+def test_write_block_single_loop_empty_string():
+    env = sc.array(dims=['x'], values=['', 'sulfur'])
+    id_ = sc.array(dims=['x'], values=['123', 'x6a'])
+    block = cif.Block(
+        'looped', [cif.Loop({'diffrn.ambient_environment': env, 'diffrn.id': id_})]
+    )
+    res = write_to_str(block)
+    assert (
+        res
+        == '''data_looped
+
+loop_
+_diffrn.ambient_environment
+_diffrn.id
+'' 123
+sulfur x6a
 '''
     )
 

--- a/tests/io/cif_test.py
+++ b/tests/io/cif_test.py
@@ -2,18 +2,27 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
 import io
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 import scipp as sc
 
+from scippneutron import __version__
 from scippneutron.io import cif
 
 
 def write_to_str(block: cif.Block) -> str:
     buffer = io.StringIO()
     block.write(buffer)
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def save_to_str(cif_: cif.CIF) -> str:
+    buffer = io.StringIO()
+    cif_.save(buffer)
     buffer.seek(0)
     return buffer.getvalue()
 
@@ -811,7 +820,76 @@ def test_loop_requires_matching_dims():
         cif.Loop({'a': sc.zeros(sizes={'x': 4}), 'b': sc.zeros(sizes={'y': 4})})
 
 
-def test_block_with_reduced_powder_data():
+def test_builder_writes_comment() -> None:
+    cif_ = cif.CIF(comment='This is a test comment\nacross multiple lines.')
+    res = save_to_str(cif_)
+
+    expected_start = r'''#\#CIF_1.1
+# This is a test comment
+# across multiple lines.
+data_
+'''
+    assert res.startswith(expected_start)
+
+
+def test_builder_writes_audit() -> None:
+    cif_ = cif.CIF()
+    res = save_to_str(cif_)
+
+    # Escape + to make this usable in a regex
+    expected_version = str(__version__).replace('+', r'\+')
+    expected = re.compile(rf'''#\\#CIF_1.1
+data_
+
+loop_
+_audit_conform.dict_name
+_audit_conform.dict_version
+_audit_conform.dict_location
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+
+_audit.creation_date \d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\+00.00
+_audit.creation_method 'Written by scippneutron v{expected_version}'
+''')
+    assert re.match(expected, res)
+
+
+def test_builder_writes_audit_with_reducer() -> None:
+    cif_ = cif.CIF(reducers='mypackage vFINAL')
+    res = save_to_str(cif_)
+
+    # Escape + to make this usable in a regex
+    expected_version = str(__version__).replace('+', r'\+')
+    expected = re.compile(rf'''#\\#CIF_1.1
+data_
+
+loop_
+_audit_conform.dict_name
+_audit_conform.dict_version
+_audit_conform.dict_location
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+
+_audit.creation_date \d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\+00.00
+_audit.creation_method 'Written by scippneutron v{expected_version}'
+_computing.diffrn_reduction 'mypackage vFINAL'
+''')
+    assert re.match(expected, res)
+
+
+def test_builder_with_beamline() -> None:
+    original = cif.CIF()
+    cif_ = original.with_beamline(beamline='DREAM', facility='ESS')
+    res = save_to_str(cif_)
+    original_res = save_to_str(original)
+
+    expected = '''_diffrn_radiation.probe neutron
+_diffrn_source.beamline DREAM
+_diffrn_source.facility ESS
+_diffrn_source.device spallation'''
+    assert expected in res
+    assert expected not in original_res
+
+
+def test_builder_with_reduced_powder_data():
     da = sc.DataArray(
         sc.array(
             dims=['tof'],
@@ -821,14 +899,14 @@ def test_block_with_reduced_powder_data():
         coords={'tof': sc.array(dims=['tof'], values=[1.2, 1.4, 2.3], unit='us')},
     )
 
-    block = cif.Block('reduced', [])
-    block.add_reduced_powder_data(da)
-    res = write_to_str(block)
+    cif_ = cif.CIF('reduced')
+    cif_ = cif_.with_reduced_powder_data(da)
+    res = save_to_str(cif_)
 
     assert 'pdCIF' in res
     assert 'coreCIF' in res
 
-    _, _, tof_loop = res.split('\n\n')
+    _, tof_loop = res.rsplit('\n\n', 1)
     assert (
         tof_loop
         == '''loop_
@@ -842,20 +920,20 @@ _pd_proc.intensity_net_su
     )
 
 
-def test_block_with_reduced_powder_data_custom_unit():
+def test_builder_with_reduced_powder_data_custom_unit():
     da = sc.DataArray(
         sc.array(dims=['tof'], values=[13.6, 26.0, 9.7], unit='counts'),
         coords={'tof': sc.array(dims=['tof'], values=[1.2, 1.4, 2.3], unit='us')},
     )
 
-    block = cif.Block('reduced', [])
-    block.add_reduced_powder_data(da)
-    res = write_to_str(block)
+    cif_ = cif.CIF('reduced')
+    cif_ = cif_.with_reduced_powder_data(da)
+    res = save_to_str(cif_)
 
     assert 'pdCIF' in res
     assert 'coreCIF' in res
 
-    _, _, tof_loop = res.split('\n\n')
+    _, tof_loop = res.rsplit('\n\n', 1)
     assert (
         tof_loop
         == '''# Unit of intensity: [counts]
@@ -869,7 +947,7 @@ _pd_proc.intensity_net
     )
 
 
-def test_block_with_reduced_powder_data_bad_dim():
+def test_builder_with_reduced_powder_data_bad_dim():
     da = sc.DataArray(
         sc.array(
             dims=['time'],
@@ -878,12 +956,12 @@ def test_block_with_reduced_powder_data_bad_dim():
         coords={'time': sc.array(dims=['time'], values=[1.2, 1.4, 2.3], unit='us')},
     )
 
-    block = cif.Block('reduced', [])
+    cif_ = cif.CIF('reduced')
     with pytest.raises(sc.CoordError):
-        block.add_reduced_powder_data(da)
+        cif_.with_reduced_powder_data(da)
 
 
-def test_block_with_reduced_powder_data_bad_name():
+def test_builder_with_reduced_powder_data_bad_name():
     da = sc.DataArray(
         sc.array(
             dims=['tof'],
@@ -893,22 +971,22 @@ def test_block_with_reduced_powder_data_bad_name():
         name='bad',
     )
 
-    block = cif.Block('reduced', [])
+    cif_ = cif.CIF('reduced')
     with pytest.raises(
         ValueError, match='Unrecognized name for reduced powder data: bad'
     ):
-        block.add_reduced_powder_data(da)
+        cif_.with_reduced_powder_data(da)
 
 
-def test_block_with_reduced_powder_data_bad_coord_unit():
+def test_builder_with_reduced_powder_data_bad_coord_unit():
     da = sc.DataArray(
         sc.array(dims=['tof'], values=[13.6, 26.0, 9.7]),
         coords={'tof': sc.array(dims=['tof'], values=[1.2, 1.4, 2.3], unit='ns')},
     )
 
-    block = cif.Block('reduced', [])
+    cif_ = cif.CIF('reduced')
     with pytest.raises(sc.UnitError):
-        block.add_reduced_powder_data(da)
+        cif_.with_reduced_powder_data(da)
 
 
 def test_block_powder_calibration():
@@ -916,14 +994,14 @@ def test_block_powder_calibration():
         sc.array(dims=['cal'], values=[1.2, 4.5, 6.7]),
         coords={'power': sc.array(dims=['cal'], values=[0, 1, -1])},
     )
-    block = cif.Block('cal', [])
-    block.add_powder_calibration(da)
-    res = write_to_str(block)
+    cif_ = cif.CIF('cal')
+    cif_ = cif_.with_powder_calibration(da)
+    res = save_to_str(cif_)
 
     assert 'pdCIF' in res
     assert 'coreCIF' in res
 
-    _, _, cal_loop = res.split('\n\n')
+    _, cal_loop = res.rsplit('\n\n', 1)
     assert (
         cal_loop
         == '''loop_


### PR DESCRIPTION
This PR adds a new class to simplify writing CIF files. When implementing https://github.com/scipp/essdiffraction/pull/89, I found that the existing low-level interface is tedious to use. And I needed to implement some functionality that should be in ScippNeutron and not ESS*, such as author and beamline handling. This will in particular be relevant once #473 is implemented. (Note that the current PR is meant as a stop-gap solution until the models from that issue are added.)

Fixes #547