### PR TITLE
Update conda test dependencies

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,18 +28,17 @@ test:
   imports:
     - scippneutron
   requires:
-    - hypothesis==6.108.8
+    - hypothesis==6.112.1
     - ipympl==0.9.4
-    - ipywidgets==8.1.3
-    - markupsafe>=1.1.1,<2.1.0  # see https://github.com/pallets/markupsafe/issues/284
-    - matplotlib-base==3.9.1
-    - plopp==24.06.0
+    - ipywidgets==8.1.5
+    - matplotlib-base==3.9.2
+    - plopp==24.09.1
     - pooch==1.8.2
     - psutil==6.0.0
-    - pytest==8.3.2
-    - pytest-asyncio==0.23.8
+    - pytest==8.3.3
+    - pytest-asyncio==0.24.0
     - pythreejs==2.4.2
-    - sciline==24.06.2
+    - sciline==24.06.3
   source_files:
     - pyproject.toml
     - tests/


### PR DESCRIPTION
The release failed because of a conflict between the minimum pooch version of the package and the version listed in `meta.yaml`.