### PR TITLE
Make CIF writer conform with expectations of EasyDiffraction

### DIFF
--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -150,12 +150,12 @@ class CIFSchema:
 CORE_SCHEMA = CIFSchema(
     name='coreCIF',
     version='3.3.0',
-    location='https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic',
+    location='https://github.com/COMCIFS/cif_core/blob/6f8502e81b623eb0fd779c79efaf191d49fa198c/cif_core.dic',
 )
 PD_SCHEMA = CIFSchema(
     name='pdCIF',
     version='2.5.0',
-    location='https://github.com/COMCIFS/Powder_Dictionary/blob/7608b92165f58f968f054344e67662e01d4b401a/cif_pow.dic',
+    location='https://github.com/COMCIFS/Powder_Dictionary/blob/970c2b2850a923796db5f4e9b7207d10ab5fd8e5/cif_pow.dic',
 )
 
 

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -298,7 +298,9 @@ class CIF:
         ``('tof', 'dspacing')``.
         The data array may also have a name in
         ``('intensity_net', 'intensity_norm', 'intensity_total')``.
-        If the name is not set, it defaults to ``'intensity_net'``.
+        If the name is not set, it defaults to ``'intensity_norm'``,
+        whichis appropriate for typical outputs from data reduction.
+        See https://github.com/COMCIFS/Powder_Dictionary/blob/master/cif_pow.dic
 
         The data gets written as intensity along a single coord whose
         name matches the dimension name.
@@ -884,7 +886,7 @@ def _normalize_reduced_powder_name(name: str) -> str:
 
 def _make_reduced_powder_loop(data: sc.DataArray, comment: str) -> Loop:
     coord_name, coord = _reduced_powder_coord(data)
-    data_name = _normalize_reduced_powder_name(data.name or 'intensity_net')
+    data_name = _normalize_reduced_powder_name(data.name or 'intensity_norm')
 
     res = Loop({coord_name: sc.values(coord)}, comment=comment, schema=PD_SCHEMA)
     if coord.variances is not None:

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -888,7 +888,14 @@ def _make_reduced_powder_loop(data: sc.DataArray, comment: str) -> Loop:
     coord_name, coord = _reduced_powder_coord(data)
     data_name = _normalize_reduced_powder_name(data.name or 'intensity_norm')
 
-    res = Loop({coord_name: sc.values(coord)}, comment=comment, schema=PD_SCHEMA)
+    res = Loop(
+        {
+            'pd_data.point_id': sc.arange(data.dim, len(data), unit=None),
+            coord_name: sc.values(coord),
+        },
+        comment=comment,
+        schema=PD_SCHEMA,
+    )
     if coord.variances is not None:
         res[coord_name + '_su'] = sc.stddevs(coord)
     res[data_name] = sc.values(data.data)

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -901,11 +901,13 @@ def _make_reduced_powder_loop(data: sc.DataArray, comment: str) -> Loop:
 
 
 def _make_powder_calibration_loop(data: sc.DataArray, comment: str) -> Loop:
-    id_by_power = {0: 'tzero', 1: 'DIFC', 2: 'DIFA', -1: 'DIFB'}
+    # All names are valid python identifiers
+    id_by_power = {0: 'ZERO', 1: 'DIFC', 2: 'DIFA', -1: 'DIFB'}
     ids = sc.array(
         dims=[data.dim],
         values=[
-            id_by_power.get(power, str(power)) for power in data.coords['power'].values
+            id_by_power.get(power, f'c{power}'.replace('-', '_').replace('.', '_'))
+            for power in data.coords['power'].values
         ],
     )
     res = Loop(

--- a/src/scippneutron/io/cif.py
+++ b/src/scippneutron/io/cif.py
@@ -299,7 +299,7 @@ class CIF:
         The data array may also have a name in
         ``('intensity_net', 'intensity_norm', 'intensity_total')``.
         If the name is not set, it defaults to ``'intensity_norm'``,
-        whichis appropriate for typical outputs from data reduction.
+        which is appropriate for typical outputs from data reduction.
         See https://github.com/COMCIFS/Powder_Dictionary/blob/master/cif_pow.dic
 
         The data gets written as intensity along a single coord whose

--- a/tests/io/cif_test.py
+++ b/tests/io/cif_test.py
@@ -1034,7 +1034,7 @@ def test_builder_powder_calibration():
 _pd_calib_d_to_tof.id
 _pd_calib_d_to_tof.power
 _pd_calib_d_to_tof.coeff
-tzero 0 1.2
+ZERO 0 1.2
 DIFC 1 4.5
 DIFB -1 6.7
 '''

--- a/tests/io/cif_test.py
+++ b/tests/io/cif_test.py
@@ -678,7 +678,7 @@ loop_
 _audit_conform.dict_name
 _audit_conform.dict_version
 _audit_conform.dict_location
-coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/6f8502e81b623eb0fd779c79efaf191d49fa198c/cif_core.dic
 
 _audit.creation_method 'written by scippneutron'
 '''
@@ -702,7 +702,7 @@ loop_
 _audit_conform.dict_name
 _audit_conform.dict_version
 _audit_conform.dict_location
-coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/6f8502e81b623eb0fd779c79efaf191d49fa198c/cif_core.dic
 
 loop_
 _audit_author.name
@@ -845,7 +845,7 @@ loop_
 _audit_conform.dict_name
 _audit_conform.dict_version
 _audit_conform.dict_location
-coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/6f8502e81b623eb0fd779c79efaf191d49fa198c/cif_core.dic
 
 _audit.creation_date \d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\+00.00
 _audit.creation_method 'Written by scippneutron v{expected_version}'
@@ -866,7 +866,7 @@ loop_
 _audit_conform.dict_name
 _audit_conform.dict_version
 _audit_conform.dict_location
-coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/6f8502e81b623eb0fd779c79efaf191d49fa198c/cif_core.dic
 
 _audit.creation_date \d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\+00.00
 _audit.creation_method 'Written by scippneutron v{expected_version}'
@@ -888,7 +888,7 @@ loop_
 _audit_conform.dict_name
 _audit_conform.dict_version
 _audit_conform.dict_location
-coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/fc3d75a298fd7c0c3cde43633f2a8616e826bfd5/cif_core.dic
+coreCIF 3.3.0 https://github.com/COMCIFS/cif_core/blob/6f8502e81b623eb0fd779c79efaf191d49fa198c/cif_core.dic
 
 _audit.creation_date \d{{4}}-\d{{2}}-\d{{2}}T\d{{2}}:\d{{2}}:\d{{2}}\+00.00
 _audit.creation_method 'Written by scippneutron v{expected_version}'

--- a/tests/io/cif_test.py
+++ b/tests/io/cif_test.py
@@ -937,8 +937,8 @@ def test_builder_with_reduced_powder_data():
         tof_loop
         == '''loop_
 _pd_meas.time_of_flight
-_pd_proc.intensity_net
-_pd_proc.intensity_net_su
+_pd_proc.intensity_norm
+_pd_proc.intensity_norm_su
 1.2 13.6 0.9
 1.4 26.0 1.0
 2.3 9.7 0.6
@@ -965,7 +965,7 @@ def test_builder_with_reduced_powder_data_custom_unit():
         == '''# Unit of intensity: [counts]
 loop_
 _pd_meas.time_of_flight
-_pd_proc.intensity_net
+_pd_proc.intensity_norm
 1.2 13.6
 1.4 26.0
 2.3 9.7

--- a/tests/io/cif_test.py
+++ b/tests/io/cif_test.py
@@ -936,12 +936,13 @@ def test_builder_with_reduced_powder_data():
     assert (
         tof_loop
         == '''loop_
+_pd_data.point_id
 _pd_meas.time_of_flight
 _pd_proc.intensity_norm
 _pd_proc.intensity_norm_su
-1.2 13.6 0.9
-1.4 26.0 1.0
-2.3 9.7 0.6
+0 1.2 13.6 0.9
+1 1.4 26.0 1.0
+2 2.3 9.7 0.6
 '''
     )
 
@@ -964,11 +965,12 @@ def test_builder_with_reduced_powder_data_custom_unit():
         tof_loop
         == '''# Unit of intensity: [counts]
 loop_
+_pd_data.point_id
 _pd_meas.time_of_flight
 _pd_proc.intensity_norm
-1.2 13.6
-1.4 26.0
-2.3 9.7
+0 1.2 13.6
+1 1.4 26.0
+2 2.3 9.7
 '''
     )
 


### PR DESCRIPTION
Most importantly, this changes the default output key to `_pd_proc.intensity_norm`. The reason for this is that in `intensity_net`, the background has been subtracted. But we don't do this in data reduction; we only normalise.