### PR TITLE
Ensure unit consistency between times and distances in frame unwrapping and WFM

### DIFF
--- a/src/scippneutron/tof/chopper_cascade.py
+++ b/src/scippneutron/tof/chopper_cascade.py
@@ -201,12 +201,13 @@ class Frame:
         :
             Chopped frame.
         """
-        if chopper.distance < self.distance:
+        distance = chopper.distance.to(unit=self.distance.unit, copy=False)
+        if distance < self.distance:
             raise ValueError(
-                f'Chopper distance {chopper.distance} is smaller than frame distance '
+                f'Chopper distance {distance} is smaller than frame distance '
                 f'{self.distance}'
             )
-        frame = self.propagate_to(chopper.distance)
+        frame = self.propagate_to(distance)
 
         # A chopper can have multiple openings, call _chop for each of them. The result
         # is the union of the resulting subframes.

--- a/src/scippneutron/tof/chopper_cascade.py
+++ b/src/scippneutron/tof/chopper_cascade.py
@@ -46,7 +46,7 @@ def propagate_times(
         Propagated time.
     """
     inverse_velocity = wavelength_to_inverse_velocity(wavelength)
-    return time + distance * inverse_velocity
+    return time + (distance * inverse_velocity).to(unit=time.unit, copy=False)
 
 
 class Subframe:
@@ -174,7 +174,7 @@ class Frame:
         :
             Propagated frame.
         """
-        delta = distance - self.distance
+        delta = distance.to(unit=self.distance.unit, copy=False) - self.distance
         subframes = [subframe.propagate_by(delta) for subframe in self.subframes]
         return Frame(distance=distance, subframes=subframes)
 

--- a/tests/tof/wfm_dream_test.py
+++ b/tests/tof/wfm_dream_test.py
@@ -120,7 +120,9 @@ def overlap_choppers(disk_choppers):
         ),
     ],
 )
-def test_dream_wfm(disk_choppers, npulses, ltotal):
+@pytest.mark.parametrize("time_offset_unit", ['s', 'ms', 'us', 'ns'])
+@pytest.mark.parametrize("distance_unit", ['m', 'mm'])
+def test_dream_wfm(disk_choppers, npulses, ltotal, time_offset_unit, distance_unit):
     choppers = {
         key: chopper_cascade.Chopper.from_disk_chopper(
             chop, pulse_frequency=sc.scalar(14.0, unit="Hz"), npulses=npulses
@@ -158,6 +160,11 @@ def test_dream_wfm(disk_choppers, npulses, ltotal):
         dim='detector',
     ).fold(dim='detector', sizes=ltotal.sizes)
 
+    # Convert the time offset to the unit requested by the test
+    raw_data.bins.coords["event_time_offset"] = raw_data.bins.coords[
+        "event_time_offset"
+    ].to(unit=time_offset_unit, copy=False)
+
     # Verify that all 6 neutrons made it through the chopper cascade
     assert sc.identical(
         raw_data.bins.concat('pulse').hist().data,
@@ -191,7 +198,7 @@ def test_dream_wfm(disk_choppers, npulses, ltotal):
     )
 
     workflow[unwrap.Choppers] = choppers
-    workflow[unwrap.Ltotal] = ltotal
+    workflow[unwrap.Ltotal] = ltotal.to(unit=distance_unit, copy=False)
     workflow[unwrap.RawData] = raw_data
 
     # Compute time-of-flight
@@ -227,7 +234,11 @@ def test_dream_wfm(disk_choppers, npulses, ltotal):
         ),
     ],
 )
-def test_dream_wfm_with_subframe_time_overlap(overlap_choppers, npulses, ltotal):
+@pytest.mark.parametrize("time_offset_unit", ['s', 'ms', 'us', 'ns'])
+@pytest.mark.parametrize("distance_unit", ['m', 'mm'])
+def test_dream_wfm_with_subframe_time_overlap(
+    overlap_choppers, npulses, ltotal, time_offset_unit, distance_unit
+):
     choppers = {
         key: chopper_cascade.Chopper.from_disk_chopper(
             chop, pulse_frequency=sc.scalar(14.0, unit="Hz"), npulses=npulses
@@ -271,6 +282,11 @@ def test_dream_wfm_with_subframe_time_overlap(overlap_choppers, npulses, ltotal)
         dim='detector',
     ).fold(dim='detector', sizes=ltotal.sizes)
 
+    # Convert the time offset to the unit requested by the test
+    raw_data.bins.coords["event_time_offset"] = raw_data.bins.coords[
+        "event_time_offset"
+    ].to(unit=time_offset_unit, copy=False)
+
     # Verify that all 6 neutrons made it through the chopper cascade
     assert sc.identical(
         raw_data.bins.concat('pulse').hist().data,
@@ -304,7 +320,7 @@ def test_dream_wfm_with_subframe_time_overlap(overlap_choppers, npulses, ltotal)
     )
 
     workflow[unwrap.Choppers] = choppers
-    workflow[unwrap.Ltotal] = ltotal
+    workflow[unwrap.Ltotal] = ltotal.to(unit=distance_unit, copy=False)
     workflow[unwrap.RawData] = raw_data
 
     # Compute time-of-flight


### PR DESCRIPTION
We add unit conversions in several places to make sure that operations do not fail because of inconsistent units.