### PR TITLE
Use import-mode=importlib in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ minversion = "7.0"
 addopts = """
 --strict-config
 --strict-markers
+--import-mode=importlib
 -ra
 -v
 """

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ description = Test with unpinned dependencies, as a user would install now.
 deps =
   -r requirements/basetest.txt
   scippneutron[all]
+  tof
 commands = pytest {posargs}
 
 [testenv:static]


### PR DESCRIPTION
This should fix the broken 'unpinned' nightly build. The problem is that pytest imports `tests/tof` when there is no installed `tof` package. Changing the import mode turns this into an import error instead of importing `test/tof` and failing later with attribute errors.