### PR TITLE
Skip horace tests if pace_neutrons is not installed

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,7 +32,9 @@ test:
 
   {# Conda does not allow spaces between package name and version, so remove them #}
   {% for package in test_dependencies %}
+    {% if package != "pace_neutrons" %}
     - {% if package == "graphviz" %}python-graphviz{% else %}{{ package|replace(" ", "") }}{% endif %}
+    {% endif %}
   {% endfor %}
     # Note that we add tof here because it depends on plopp, and plopp should not be in
     # basetest.in because of the nightly dependencies

--- a/tests/io/sqw/sqw_horace_test.py
+++ b/tests/io/sqw/sqw_horace_test.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import pace_neutrons
 import pytest
 import scipp as sc
 from dateutil.parser import parse as parse_datetime
@@ -25,9 +24,13 @@ from scippneutron.io.sqw import (
     SqwLineProj,
 )
 
+pytest.importorskip("pace_neutrons")
+
 
 @pytest.fixture(scope="module")
 def matlab() -> Any:
+    import pace_neutrons
+
     try:
         return pace_neutrons.Matlab()
     except RuntimeError as e:

--- a/tests/io/sqw/sqw_horace_test.py
+++ b/tests/io/sqw/sqw_horace_test.py
@@ -24,13 +24,11 @@ from scippneutron.io.sqw import (
     SqwLineProj,
 )
 
-pytest.importorskip("pace_neutrons")
+pace_neutrons = pytest.importorskip("pace_neutrons")
 
 
 @pytest.fixture(scope="module")
 def matlab() -> Any:
-    import pace_neutrons
-
     try:
         return pace_neutrons.Matlab()
     except RuntimeError as e:


### PR DESCRIPTION
`pace_neutrons` is only available on pip, not conda.
During a conda build, we cannot install it, so we remove the dependency in the recipe from the test dependencies, and skip the tests if package is not installed.