### PR TITLE
 MAINT: Use lazy_loader for lazy loading of submodules 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dynamic = ["version"]
 # Run 'tox -e deps' after making changes here. This will update requirement files.
 # Make sure to list one dependency per line.
 dependencies = [
+    "lazy_loader",
     "h5py",
     "mpltoolbox",
     "numpy>=1.20",

--- a/src/scippneutron/__init__.py
+++ b/src/scippneutron/__init__.py
@@ -19,50 +19,30 @@ try:
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
-from .beamline_components import (
-    position,
-    source_position,
-    sample_position,
-    incident_beam,
-    scattered_beam,
-    Ltotal,
-    L1,
-    L2,
-    two_theta,
-)
-from .core import convert
-from .mantid import (
-    from_mantid,
-    to_mantid,
-    load_with_mantid,
-    fit,
-)
-from .instrument_view import instrument_view
-from .masking import MaskingTool
-from . import atoms
-from . import chopper
-from . import io
-
 del importlib
 
-__all__ = [
-    "position",
-    "source_position",
-    "sample_position",
-    "incident_beam",
-    "scattered_beam",
-    "Ltotal",
-    "L1",
-    "L2",
-    "two_theta",
-    "convert",
-    "from_mantid",
-    "to_mantid",
-    "io",
-    "load_with_mantid",
-    "fit",
-    "instrument_view",
-    "atoms",
-    "chopper",
-    "MaskingTool",
-]
+import lazy_loader as lazy
+
+submodules = ['atoms' 'chopper', 'io']
+
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__,
+    submodules=submodules,
+    submod_attrs={
+        'beamline_components': [
+            'position',
+            'source_position',
+            'sample_position',
+            'incident_beam',
+            'scattered_beam',
+            'Ltotal',
+            'L1',
+            'L2',
+            'two_theta',
+        ],
+        'core': ['convert'],
+        'mantid': ['from_mantid', 'to_mantid', 'load_with_mantid', 'fit'],
+        'instrument_view': ['instrument_view'],
+        'masking': ['MaskingTool'],
+    },
+)

--- a/src/scippneutron/chopper/__init__.py
+++ b/src/scippneutron/chopper/__init__.py
@@ -3,15 +3,13 @@
 
 """Chopper utilities."""
 
-from .disk_chopper import DiskChopper, DiskChopperType
-from .filtering import collapse_plateaus, filter_in_phase, find_plateaus
-from .nexus_chopper import extract_chopper_from_nexus
+import lazy_loader as lazy
 
-__all__ = [
-    'DiskChopper',
-    'DiskChopperType',
-    'collapse_plateaus',
-    'filter_in_phase',
-    'find_plateaus',
-    'extract_chopper_from_nexus',
-]
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__,
+    submod_attrs={
+        'disk_chopper': ['DiskChopper', 'DiskChopperType'],
+        'filtering': ['collapse_plateaus', 'filter_in_phase', 'find_plateaus'],
+        'nexus_chopper': ['extract_chopper_from_nexus'],
+    },
+)

--- a/src/scippneutron/io/__init__.py
+++ b/src/scippneutron/io/__init__.py
@@ -2,4 +2,11 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 """File input and output."""
 
-from .xye import load_xye, save_xye  # noqa: F401
+import lazy_loader as lazy
+
+__getattr__, __dir__, __all__ = lazy.attach(
+    __name__,
+    submod_attrs={
+        'xye': ['load_xye', 'save_xye'],
+    },
+)


### PR DESCRIPTION
This adds lazy loading to scippneutron, we should ideally also add this to plopp to propogate it across the ess ecosystem. Tox will not be happy here as I haven't run tox -e deps locally (libpymcr doesn't do ARM wheels).

Locally I can see a 100x speedup in import time (600ms vs 6ms) with cached modules in an env, in a freshly installed env it's ~10seconds for scippneutron.

This should fix https://github.com/scipp/scippneutron/issues/594