### PR TITLE
Convert metadata fields from sc.Variable

### DIFF
--- a/tests/metadata/metadata_model_test.py
+++ b/tests/metadata/metadata_model_test.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
-
 import pytest
 import scipp as sc
 import scippnexus as snx
@@ -12,7 +11,7 @@ import scippneutron.data
 from scippneutron import metadata
 
 
-def test_experiment_from_nexus_entry() -> None:
+def test_measurement_from_nexus_entry() -> None:
     with snx.File(scn.data.get_path('PG3_4844_event.nxs')) as f:
         experiment = metadata.Measurement.from_nexus_entry(f['entry'])
     assert experiment.title == 'diamond cw0.533 4.22e12 60Hz [10x30]'
@@ -20,6 +19,18 @@ def test_experiment_from_nexus_entry() -> None:
     assert experiment.experiment_id == 'IPTS-2767'
     assert experiment.start_time == parse_datetime('2011-08-12T11:50:17-04:00')
     assert experiment.end_time == parse_datetime('2011-08-12T13:22:05-04:00')
+    assert experiment.experiment_doi is None
+
+
+def test_measurement_from_individual_variables() -> None:
+    experiment = metadata.Measurement(
+        title=sc.scalar('The title'),
+        run_number='12b',
+        experiment_id=sc.scalar('EXP-1', unit=''),
+    )
+    assert experiment.title == 'The title'
+    assert experiment.run_number == '12b'
+    assert experiment.experiment_id == 'EXP-1'
     assert experiment.experiment_doi is None
 
 


### PR DESCRIPTION
When we read metadata from files, values may be wrapped in `sc.Variable`s. This tripped up the build in https://github.com/scipp/esssans/pull/195. It is likely not a big problem when we use scippnexus-based loaders (the linked PR failed for ISIS data). But this PR introduces a mechanism that allows us to extract data from scalar variables so that we need to worry less about the precise input types.