### PR TITLE
docs: add absorption docs to index

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -58,6 +58,7 @@ and possible confusion of `theta` (from Bragg’s law) with `theta` in spherical
    :recursive:
 
    atoms
+   absorption
    chopper
    conversion
    io

--- a/docs/user-guide/absorption-correction.ipynb
+++ b/docs/user-guide/absorption-correction.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "To compute $C(\\lambda, \\mathbf{p})$ you can use\n",
     "```python\n",
-    "scippneutron.absorption.base.compute_transmission_map(\n",
+    "scippneutron.absorption.compute_transmission_map(\n",
     "    shape,\n",
     "    material,\n",
     "    beam_direction,\n",


### PR DESCRIPTION
Adds a missing module to the api-reference index