### PR TITLE
Bump deps in mantid test env

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -10,40 +10,40 @@ channels:
   - nodefaults
 dependencies:
   - email-validator==2.2.0
-  - h5py==3.12.1
-  - hypothesis==6.119.4
+  - h5py==3.13.0
+  - hypothesis==6.131.20
   - ipykernel==6.29.5
-  - ipympl==0.9.4
-  - ipywidgets==8.1.5
+  - ipympl==0.9.7
+  - ipywidgets==8.1.7
   - lazy-loader==0.4
-  - mantid==6.11.0
-  - matplotlib==3.7.3
-  - mpltoolbox==24.05.1
-  - plopp==24.10.0
+  - mantid==6.12.0
+  - matplotlib==3.10.3
+  - mpltoolbox==25.4.0
+  - plopp==25.05.0
   - pooch==1.8.2
-  - pydantic==2.10.5
-  - pytest==8.3.3
-  - pytest-asyncio==0.24.0
+  - pydantic==2.11.4
+  - pytest==8.3.5
+  - pytest-asyncio==0.26.0
   - python-dateutil==2.9.0
   - python-graphviz==0.20.3
   - pythreejs==2.4.2
-  - scipp==24.11.1
-  - scippnexus==24.11.0
-  - scipy==1.15.1
-  - tox==4.23.2
+  - scipp==25.05.0
+  - scippnexus==25.04.0
+  - scipy==1.15.2
+  - tox==4.26.0
 
   # docs
-  - myst-parser==4.0.0
-  - nbsphinx==0.9.5
+  - myst-parser==4.0.1
+  - nbsphinx==0.9.7
   - packaging==25.0
-  - pandoc==3.4.0
-  - pydata-sphinx-theme==0.16.0
-  - sphinx==8.1.3
-  - sphinx-autodoc-typehints==2.5.0
+  - pandoc==3.7
+  - pydata-sphinx-theme==0.16.1
+  - sphinx==8.2.3
+  - sphinx-autodoc-typehints==3.2.0
   - sphinx-copybutton==0.5.2
   - sphinx-design==0.6.1
   - sphinxcontrib-bibtex==2.6.3
-  - tof==25.1.2
+  - tof==25.05.0
 
   # docs and tests
-  - sciline==24.10.0
+  - sciline==25.05.1


### PR DESCRIPTION
Not sure what's going wrong with https://github.com/scipp/scippneutron/pull/623, but it looks like some packages haven't been bumped in a while in the env used for running mantid tests.