### PR TITLE
Pin muparser

### DIFF
--- a/.buildconfig/ci-linux.yml
+++ b/.buildconfig/ci-linux.yml
@@ -47,3 +47,6 @@ dependencies:
 
   # docs and tests
   - sciline==24.10.0
+
+  # Temporary pin, see https://github.com/mantidproject/mantid/issues/39393
+  - muparser==2.3.4


### PR DESCRIPTION
Required to avoid crash in Mantid. Should get fixed in next Mantid release.

This might fix the issue reported in #624 and #626. See also https://github.com/mantidproject/mantid/issues/39393