### PR TITLE
Parse chopper tdc in the same way as the other logs

### DIFF
--- a/src/scippneutron/chopper/nexus_chopper.py
+++ b/src/scippneutron/chopper/nexus_chopper.py
@@ -33,15 +33,21 @@ def extract_chopper_from_nexus(
     return sc.DataGroup(
         {
             "type": DiskChopperType(chopper.get("type", DiskChopperType.single)),
-            **{key: _parse_field(key, val) for key, val in chopper.items()},
+            **{key: _parse_field(val) for key, val in chopper.items()},
         }
     )
 
 
 def _parse_field(
-    key: str, value: sc.Variable | sc.DataArray | sc.DataGroup
+    x: sc.Variable | sc.DataArray | sc.DataGroup,
 ) -> sc.Variable | sc.DataArray:
-    if isinstance(value, sc.DataGroup) and "value" in value:
-        # An NXlog
-        return value["value"].squeeze()
-    return value
+    if isinstance(x, sc.DataGroup):
+        if "value" in x:
+            # A NXlog
+            return x["value"].squeeze()
+        elif "time" in x:
+            # A NXlog without 'value' field
+            return x["time"].squeeze()
+        else:
+            return x
+    return x

--- a/tests/chopper/nexus_chopper_test.py
+++ b/tests/chopper/nexus_chopper_test.py
@@ -60,3 +60,16 @@ def test_post_process_extracts_tdc_from_log(raw_nexus_chopper):
     raw_nexus_chopper['top_dead_center'] = sc.DataGroup({'value': timestamps})
     processed = extract_chopper_from_nexus(raw_nexus_chopper)
     assert sc.identical(processed['top_dead_center'], timestamps)
+
+
+def test_post_process_extracts_tdc_from_log_without_value(raw_nexus_chopper):
+    timestamps = sc.array(
+        dims=['time'],
+        values=np.arange(
+            '2025-02-01', '2025-02-01T00:00:00.000002000', dtype='datetime64'
+        ),
+        unit='ns',
+    )
+    raw_nexus_chopper['top_dead_center'] = sc.DataGroup({'time': timestamps})
+    processed = extract_chopper_from_nexus(raw_nexus_chopper)
+    assert sc.identical(processed['top_dead_center'], timestamps)


### PR DESCRIPTION
Choppers in ECDC NeXus files store TDC as a normal NXlog with a "value".
Scippneutron had assumed that it would be a log without a value, just a "time" entry.

<img width="1465" height="354" alt="Screenshot_20251112_135305" src="https://github.com/user-attachments/assets/e9b55618-d719-4eff-84da-407b6314e7fd" />

We now deal with both cases, with and without value.