### PR TITLE
Use local install for release docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
         default: false
         type: boolean
       version:
+        description: 'Version of ScippNeutron to use for building the docs. Requires this version to be available on conda-forge! If not set, the current version will be used.'
         default: ''
         required: false
         type: string
@@ -21,6 +22,7 @@ on:
         default: false
         type: boolean
       version:
+        description: 'Version of ScippNeutron to use for building the docs. Requires this version to be available on conda-forge! If not set, the current version will be used.'
         default: ''
         required: false
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       publish: ${{ github.event_name == 'release' && github.event.action == 'published' }}
-      version: ${{ github.event.release.tag_name }}
     secrets: inherit
 
   assets:


### PR DESCRIPTION
This should fix the broken docs build in a release (https://github.com/scipp/scippneutron/actions/runs/19627948536/job/56200774373)

I left the `version` parameter so that we can still select a different version if we need to patch up the docs later. But the release build no longer depends on 