### PR TITLE
Ignore links to sciencedirect

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -296,6 +296,7 @@ linkcheck_ignore = [
     r'https://opensource\.org/licenses/BSD-3-Clause',
     r'https://support\.orcid\.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier',
     r'https://www\.iucr\.org',
+    r'https?://www\.sciencedirect.com/',
     # Linkcheck seems to be denied access by some DOI resolvers.
     # Since DOIs are supposed to be permanent, we don't need to check them.'
     r'https?://doi\.org/',


### PR DESCRIPTION
These links are now forbidden for bots.