### PR TITLE
Restore warning ignore for ipykernel.comm.Comm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ testpaths = "tests"
 filterwarnings = [
   "error",
   'ignore:You are running a "Debug" build of scipp:',
+  # from ipywidgets; they are migrating away from ipykernel, this warning should go away
+  'ignore:The `ipykernel.comm.Comm` class has been deprecated.:DeprecationWarning',
   # Plotting related warnings.
   'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning',
   # TODO Plotting warnings that need to be addressed


### PR DESCRIPTION
This warning has been fixed upstream but not in our lowest supported version. This failed the nightly.