### PR TITLE
Use u64 for data block size

### DIFF
--- a/docs/developer/file-formats/sqw.md
+++ b/docs/developer/file-formats/sqw.md
@@ -120,8 +120,8 @@ The structure of the BAT is
 ```
 where the `:descriptor` type is
 ```text
-| block_type  | name        | level2_name | position | size | locked |
-| :char array | :char array | :char array | :u64     | u32  | u32    |
+| block_type  | name        | level2_name | position | size |
+| :char array | :char array | :char array | :u64     | u64  |
 ```
 - `Bat.size`: Size in bytes of the BAT.
 - `Bat.n_blocks`: The number of blocks.
@@ -133,7 +133,6 @@ where the `:descriptor` type is
   - `descriptor.name` and `descriptor.level2_name`: The block's name.
   - `descriptor.position`: Offset in bytes from the start of the file where the block is located.
   - `descriptor.size`: Size in bytes of the block.
-  - `descriptor.locked`: Interpreted as a boolean. If true, the block is currently locked for writing and should not be accessed.
 
 ### Block Storage
 

--- a/src/scippneutron/io/sqw/_build.py
+++ b/src/scippneutron/io/sqw/_build.py
@@ -260,7 +260,6 @@ class SqwBuilder:
                 name=name,
                 position=0,
                 size=len(buf),
-                locked=False,
             )
 
         self._serialize_dnd_data(buffers, descriptors)
@@ -272,7 +271,6 @@ class SqwBuilder:
                 name=("pix", "data_wrap"),
                 position=0,
                 size=self._pix_wrap.size(),
-                locked=False,
             )
 
         return buffers, descriptors
@@ -290,7 +288,6 @@ class SqwBuilder:
                     name=("data", "nd_data"),
                     position=0,
                     size=placeholder.size(),
-                    locked=False,
                 )
             case _DndData() as data:
                 buffers[("data", "nd_data")] = None
@@ -299,7 +296,6 @@ class SqwBuilder:
                     name=("data", "nd_data"),
                     position=0,
                     size=data.size(),
-                    locked=False,
                 )
 
     def _prepare_data_blocks(self) -> dict[DataBlockName, Any]:
@@ -392,8 +388,7 @@ def _write_data_block_descriptor(
     sqw_io.write_char_array(descriptor.name[1])
     pos = sqw_io.position
     sqw_io.write_u64(descriptor.position)
-    sqw_io.write_u32(descriptor.size)
-    sqw_io.write_u32(int(descriptor.locked))
+    sqw_io.write_u64(descriptor.size)
     return pos
 
 

--- a/src/scippneutron/io/sqw/_models.py
+++ b/src/scippneutron/io/sqw/_models.py
@@ -40,8 +40,7 @@ class SqwDataBlockDescriptor:
     block_type: SqwDataBlockType
     name: DataBlockName
     position: int  # u64
-    size: int  # u32
-    locked: bool  # u32
+    size: int  # u64
 
 
 @dataclass(kw_only=True, slots=True)

--- a/src/scippneutron/io/sqw/_sqw.py
+++ b/src/scippneutron/io/sqw/_sqw.py
@@ -98,10 +98,9 @@ class Sqw:
         """Return an iterator over the names of all stored data blocks."""
         return self._block_allocation_table.keys()
 
-    # TODO lock blocks during writing, esp pix data
     def read_data_block(
         self, name: DataBlockName | str, level2_name: str | None = None, /
-    ) -> Any:  # TODO type
+    ) -> Any:
         block_name = _normalize_data_block_name(name, level2_name)
         try:
             block_descriptor = self._block_allocation_table[block_name]
@@ -165,10 +164,9 @@ def _read_data_block_descriptor(sqw_io: LowLevelSqw) -> SqwDataBlockDescriptor:
     block_type = SqwDataBlockType(sqw_io.read_char_array())
     name = sqw_io.read_char_array(), sqw_io.read_char_array()
     position = sqw_io.read_u64()
-    size = sqw_io.read_u32()
-    locked = sqw_io.read_u32() == 1
+    size = sqw_io.read_u64()
     return SqwDataBlockDescriptor(
-        block_type=block_type, name=name, position=position, size=size, locked=locked
+        block_type=block_type, name=name, position=position, size=size
     )
 
 


### PR DESCRIPTION
The previous code was based on a misunderstanding of the MATLAB object that represents data blocks and how that gets serialized. The locked attribute does not seem to be written to file.

This slipped through until now because I only wrote files smaller than 4GiB for testing. But writing a larger one now, I got an out of range error for u32. With this change, horace can load a large file properly.