### PR TITLE
Support multiple pulses in chopper cascade

### DIFF
--- a/src/scippneutron/tof/chopper_cascade.py
+++ b/src/scippneutron/tof/chopper_cascade.py
@@ -298,6 +298,9 @@ class FrameSequence:
         time_max: sc.Variable,
         wavelength_min: sc.Variable,
         wavelength_max: sc.Variable,
+        npulses: int = 1,
+        pulse_period: sc.Variable | None = None,
+        distance: sc.Variable | None = None,
     ):
         """
         Initialize a frame sequence from min/max time and wavelength of a pulse.
@@ -311,10 +314,21 @@ class FrameSequence:
             [wavelength_min, wavelength_min, wavelength_max, wavelength_max],
             dim='vertex',
         ).to(unit='angstrom')
+
+        if npulses > 1:
+            if pulse_period is None:
+                raise ValueError('pulse_period must be provided if npulses > 1')
+            subframes = [
+                Subframe(time=time + i * pulse_period, wavelength=wavelength)
+                for i in range(npulses)
+            ]
+        else:
+            subframes = [Subframe(time=time, wavelength=wavelength)]
+
         frames = [
             Frame(
-                distance=sc.scalar(0, unit='m'),
-                subframes=[Subframe(time=time, wavelength=wavelength)],
+                distance=sc.scalar(0.0, unit='m') if distance is None else distance,
+                subframes=subframes,
             )
         ]
         return FrameSequence(frames)

--- a/src/scippneutron/tof/chopper_cascade.py
+++ b/src/scippneutron/tof/chopper_cascade.py
@@ -318,6 +318,7 @@ class FrameSequence:
         if npulses > 1:
             if pulse_period is None:
                 raise ValueError('pulse_period must be provided if npulses > 1')
+            pulse_period = pulse_period.to(unit='s')
             subframes = [
                 Subframe(time=time + i * pulse_period, wavelength=wavelength)
                 for i in range(npulses)

--- a/tests/tof/chopper_cascade_test.py
+++ b/tests/tof/chopper_cascade_test.py
@@ -493,3 +493,68 @@ def test_frame_sequence_getitem_by_distance_selects_correct_chopper(
     distance = sc.scalar(3.0, unit='m')
     result = frames[distance]
     assert_identical(result.bounds(), frames[2].propagate_to(distance).bounds())
+
+
+def test_frame_sequence_with_multiple_pulses():
+
+    pulse_period = sc.scalar(1 / 14, unit='s')
+    frames = chopper_cascade.FrameSequence.from_source_pulse(
+        time_min=sc.scalar(0.0, unit='ms'),
+        time_max=sc.scalar(1.0, unit='ms'),
+        wavelength_min=sc.scalar(1.0, unit='angstrom'),
+        wavelength_max=sc.scalar(10.0, unit='angstrom'),
+        npulses=3,
+        pulse_period=pulse_period,
+    )
+    assert len(frames) == 1
+    assert len(frames[0].subframes) == 3
+    expected_time = sc.array(dims=['vertex'], values=[0.0, 1.0, 1.0, 0.0], unit='ms')
+    expected_wavelength = sc.array(
+        dims=['vertex'], values=[1.0, 1.0, 10.0, 10.0], unit='angstrom'
+    )
+
+    for i in range(3):
+        expected_subframe = chopper_cascade.Subframe(
+            time=expected_time + i * pulse_period.to(unit='ms'),
+            wavelength=expected_wavelength,
+        )
+        assert frames[0].subframes[i] == expected_subframe
+
+
+def test_chop_frame_sequence_with_multiple_pulses():
+    pulse_period = sc.scalar(1 / 14, unit='s')
+    frames = chopper_cascade.FrameSequence.from_source_pulse(
+        time_min=sc.scalar(0.0, unit='ms'),
+        time_max=sc.scalar(1.0, unit='ms'),
+        wavelength_min=sc.scalar(1.0, unit='angstrom'),
+        wavelength_max=sc.scalar(10.0, unit='angstrom'),
+        npulses=3,
+        pulse_period=pulse_period,
+    )
+
+    offset = sc.arange('pulse', 3) * pulse_period
+
+    chopper1 = chopper_cascade.Chopper(
+        distance=sc.scalar(5, unit='m'),
+        time_open=(sc.array(dims=['slit'], values=[0.002], unit='s') + offset).flatten(
+            to='slit'
+        ),
+        time_close=(sc.array(dims=['slit'], values=[0.006], unit='s') + offset).flatten(
+            to='slit'
+        ),
+    )
+    chopper2 = chopper_cascade.Chopper(
+        distance=sc.scalar(10, unit='m'),
+        time_open=(
+            sc.array(dims=['slit'], values=[0.007, 0.009], unit='s') + offset
+        ).flatten(to='slit'),
+        time_close=(
+            sc.array(dims=['slit'], values=[0.008, 0.010], unit='s') + offset
+        ).flatten(to='slit'),
+    )
+
+    frames = frames.chop([chopper1, chopper2])
+
+    assert len(frames[0].subframes) == 3
+    assert len(frames[1].subframes) == 3
+    assert len(frames[2].subframes) == 6  # 3 from each slit of chopper2

--- a/tests/tof/chopper_cascade_test.py
+++ b/tests/tof/chopper_cascade_test.py
@@ -496,7 +496,6 @@ def test_frame_sequence_getitem_by_distance_selects_correct_chopper(
 
 
 def test_frame_sequence_with_multiple_pulses():
-
     pulse_period = sc.scalar(1 / 14, unit='s')
     frames = chopper_cascade.FrameSequence.from_source_pulse(
         time_min=sc.scalar(0.0, unit='ms'),


### PR DESCRIPTION
Example:
```Py
from scippneutron.tof import chopper_cascade
from ess.odin.beamline import choppers
import scipp as sc

source_position = sc.vector([0, 0, 0], unit='m')
disk_choppers = choppers(source_position)

pulse_frequency = sc.scalar(14.0, unit='Hz')
pulse_period = 1 / pulse_frequency

chops = {
    key: chopper_cascade.Chopper(
        distance=(ch.axle_position - source_position).fields.z,
        time_open=ch.time_offset_open(pulse_frequency=pulse_frequency / 4),
        time_close=ch.time_offset_close(pulse_frequency=pulse_frequency / 4),
    )
    for key, ch in disk_choppers.items()
}

frames = chopper_cascade.FrameSequence.from_source_pulse(
    time_min=sc.scalar(0.0, unit='ms'),
    time_max=sc.scalar(4.0, unit='ms'),
    wavelength_min=sc.scalar(0.0, unit='angstrom'),
    wavelength_max=sc.scalar(10.0, unit='angstrom'),
    npulses=3,
    pulse_period=pulse_period,
)
frames = frames.chop(chops.values())

at_sample = frames.propagate_to(sc.scalar(65.0, unit="m"))
at_sample.draw()
```
<img width="640" height="480" alt="Figure 3 (1)" src="https://github.com/user-attachments/assets/77d09ced-063e-4286-b806-a10932cd66d1" />
