### PR TITLE
Check coords are identical in slicing dimension in instrument view

### DIFF
--- a/src/scippneutron/instrument_view.py
+++ b/src/scippneutron/instrument_view.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
 
+from functools import reduce
 from typing import Literal
 
 import plopp as pp
@@ -29,6 +30,12 @@ def _to_data_array(
             filtered.assign_coords(
                 {k: getattr(filtered.coords["position"].fields, k) for k in "xyz"}
             ).drop_coords("position")
+        )
+
+    if not reduce(sc.identical, [da.coords[dim] for da in pieces]):
+        raise ValueError(
+            "All inputs must have the same coordinate along the slider dimension "
+            f"'{dim}'."
         )
     return sc.concat(pieces, dim="pixel").squeeze()
 

--- a/src/scippneutron/instrument_view.py
+++ b/src/scippneutron/instrument_view.py
@@ -34,7 +34,7 @@ def _to_data_array(
 
     if (
         (dim is not None)
-        and len(pieces) > 1
+        and (len(pieces) > 1)
         and (not reduce(sc.identical, [da.coords[dim] for da in pieces]))
     ):
         raise ValueError(

--- a/src/scippneutron/instrument_view.py
+++ b/src/scippneutron/instrument_view.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
 
-from functools import reduce
 from typing import Literal
 
 import plopp as pp
@@ -15,10 +14,18 @@ def _to_data_array(
     if isinstance(data, sc.DataArray):
         data = sc.DataGroup({"": data})
     pieces = []
+    dim_coord = None
     for da in data.values():
         da = da.drop_coords(list(set(da.coords) - {pos, dim}))
         position_dims = tuple(da.coords[pos].dims)
         if dim is not None:
+            if dim_coord is None:
+                dim_coord = da.coords[dim]
+            elif not sc.identical(dim_coord, da.coords[dim]):
+                raise ValueError(
+                    "All inputs must have the same coordinate along the slider"
+                    f" dimension '{dim}'."
+                )
             # Ensure that the dims to be flattened are contiguous, and place them at
             # the end so that slicing the first (outer) dim with the slider is
             # efficient.
@@ -30,16 +37,6 @@ def _to_data_array(
             filtered.assign_coords(
                 {k: getattr(filtered.coords["position"].fields, k) for k in "xyz"}
             ).drop_coords("position")
-        )
-
-    if (
-        (dim is not None)
-        and (len(pieces) > 1)
-        and (not reduce(sc.identical, [da.coords[dim] for da in pieces]))
-    ):
-        raise ValueError(
-            "All inputs must have the same coordinate along the slider dimension "
-            f"'{dim}'."
         )
     return sc.concat(pieces, dim="pixel").squeeze()
 

--- a/src/scippneutron/instrument_view.py
+++ b/src/scippneutron/instrument_view.py
@@ -32,7 +32,11 @@ def _to_data_array(
             ).drop_coords("position")
         )
 
-    if not reduce(sc.identical, [da.coords[dim] for da in pieces]):
+    if (
+        (dim is not None)
+        and len(pieces) > 1
+        and (not reduce(sc.identical, [da.coords[dim] for da in pieces]))
+    ):
         raise ValueError(
             "All inputs must have the same coordinate along the slider dimension "
             f"'{dim}'."

--- a/tests/instrument_view_test.py
+++ b/tests/instrument_view_test.py
@@ -99,8 +99,11 @@ def test_instrument_view_two_banks_dict_with_dim_different_coords_raises():
     bank1 = make_detector_bank(center=(-1.5, 0, 5))
     bank2 = make_detector_bank(center=(1.5, 0, 5))
     bank2.coords['time'] *= 1.01
+    bank3 = make_detector_bank(center=(1.5, 0, 5))
     with pytest.raises(
         ValueError,
         match="All inputs must have the same coordinate along the slider dimension",
     ):
-        scn.instrument_view({"bank1": bank1, "bank2": bank2}, size=0.1, dim='time')
+        scn.instrument_view(
+            {"bank1": bank1, "bank2": bank2, "bank3": bank3}, size=0.1, dim='time'
+        )

--- a/tests/instrument_view_test.py
+++ b/tests/instrument_view_test.py
@@ -3,6 +3,7 @@
 
 import matplotlib
 import numpy as np
+import pytest
 import scipp as sc
 
 import scippneutron as scn
@@ -92,3 +93,14 @@ def test_neutron_instrument_view_with_masks():
 def test_neutron_instrument_view_with_cmap_args():
     bank = make_detector_bank(center=(0, 0, 5))
     scn.instrument_view(bank, size=0.1, vmin=10.0, vmax=50.0, cmap="magma", logc=True)
+
+
+def test_instrument_view_two_banks_dict_with_dim_different_coords_raises():
+    bank1 = make_detector_bank(center=(-1.5, 0, 5))
+    bank2 = make_detector_bank(center=(1.5, 0, 5))
+    bank2.coords['time'] *= 1.01
+    with pytest.raises(
+        ValueError,
+        match="All inputs must have the same coordinate along the slider dimension",
+    ):
+        scn.instrument_view({"bank1": bank1, "bank2": bank2}, size=0.1, dim='time')


### PR DESCRIPTION
If you passed `dg.hist(tof=100)` to the `instrument_view`, the different data arrays would have different tof coords, and the view would fail with a very strange error:
```
File ~/development/venv4essdiffraction/.venv_scipp_may26a/lib/python3.14/site-packages/plopp/widgets/slicing.py:155, in <genexpr>(.0)
    153 new = [min(max(x, self.min), self.max) for x in change["new"]]
    154 self._lock = True
--> 155 self._widget.value = " : ".join(f"{self._coord[x]:{self._fmt}}" for x in new)
    156 self._lock = False

TypeError: unsupported format string passed to numpy.ndarray.__format__
```

We add a safety net to catch this before we attempt to make the plot.

@celinedurniak