### PR TITLE
Small improvements to DiskChopper.from_nexus

### DIFF
--- a/src/scippneutron/chopper/disk_chopper.py
+++ b/src/scippneutron/chopper/disk_chopper.py
@@ -357,7 +357,7 @@ class DiskChopper:
                 unit='rad'
             )
         return DiskChopper(
-            axle_position=chopper['position'],
+            axle_position=_get_0d_variable(chopper, 'position'),
             frequency=frequency,
             beam_position=_get_0d_variable(chopper, 'beam_position'),
             phase=phase,
@@ -671,6 +671,7 @@ def _get_0d_variable(
         val = val.data
     if not isinstance(val, sc.Variable):
         raise TypeError(msg.format(name=name, got=f'got a {type(val)}'))
+    val = val.squeeze()
     if val.ndim != 0:
         raise sc.DimensionError(
             msg.format(name=name, got=f'got a {val.ndim}d variable')

--- a/tests/chopper/disk_chopper_test.py
+++ b/tests/chopper/disk_chopper_test.py
@@ -1001,3 +1001,51 @@ def test_missing_both_phase_and_delay_raises(nexus_chopper):
                 _get_rotation_speed_key(nexus_chopper): sc.scalar(14.0, unit='Hz'),
             }
         )
+
+
+def _make_chopper_log(value):
+    return sc.DataArray(
+        data=sc.concat([value], dim='time'),
+        coords={
+            'time': sc.datetime('2022-01-01T00:00:00'),
+            'average_value': value,
+            'minimum_value': value,
+            'maximum_value': value,
+        },
+    )
+
+
+def test_from_nexus_nxlogs_with_single_value_are_squeezed():
+    chopper_nexus = sc.DataGroup(
+        {
+            'position': sc.vector([0, 0, 6], unit='m'),
+            'delay': _make_chopper_log(sc.scalar(0, unit='ns')),
+            'radius': sc.scalar(0.5, unit='m'),
+            'rotation_speed_setpoint': _make_chopper_log(sc.scalar(14.0, unit='Hz')),
+            'slit_edges': sc.array(dims=['edge'], values=[7.35, 54.08], unit='deg'),
+            'beam_position': sc.scalar(0.0, unit='deg'),
+        }
+    )
+
+    disk_chopper = DiskChopper.from_nexus(chopper_nexus)
+
+    assert sc.identical(disk_chopper.axle_position, sc.vector([0, 0, 6], unit='m'))
+    assert sc.identical(disk_chopper.phase, sc.scalar(0.0, unit='rad'))
+    assert sc.identical(disk_chopper.frequency, sc.scalar(14.0, unit='Hz'))
+
+
+def test_from_nexus_position_can_be_nxlog():
+    chopper_nexus = sc.DataGroup(
+        {
+            'position': _make_chopper_log(sc.vector([0, 0, 6.5], unit='m')),
+            'delay': sc.scalar(0, unit='ns'),
+            'radius': sc.scalar(0.5, unit='m'),
+            'rotation_speed_setpoint': sc.scalar(14.0, unit='Hz'),
+            'slit_edges': sc.array(dims=['edge'], values=[7.35, 54.08], unit='deg'),
+            'beam_position': sc.scalar(0.0, unit='deg'),
+        }
+    )
+
+    disk_chopper = DiskChopper.from_nexus(chopper_nexus)
+
+    assert sc.identical(disk_chopper.axle_position, sc.vector([0, 0, 6.5], unit='m'))


### PR DESCRIPTION
Add some small fixes to parse values in nexus tree for making DiskChopper.
When scalar values are expected, we attempt to squeeze first, as 1d variables with length 1 are also valid.

We also do not assume that the position of the axle is always scalar in the input.

These changes are needed to load the choppers from Odin coda file.