### PR TITLE
Support serializing metadata to XYE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "setuptools>=77",
-  "setuptools_scm[toml]>=8.0",
+    "setuptools>=77",
+    "setuptools_scm[toml]>=8.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -39,6 +39,7 @@ dependencies = [
     "numpy>=1.20",
     "plopp>=26.5.0",
     "pydantic>=2",
+    "pyyaml>=5.3",
     "scipp>=25.11.0",
     "scippnexus>=23.11.0",
     "scipy>=1.7.0",
@@ -78,15 +79,15 @@ addopts = """
 """
 testpaths = "tests"
 filterwarnings = [
-  "error",
-  'ignore:You are running a "Debug" build of scipp:',
-  # from ipywidgets; they are migrating away from ipykernel, this warning should go away
-  'ignore:The `ipykernel.comm.Comm` class has been deprecated.:DeprecationWarning',
-  # Plotting related warnings.
-  'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning',
-  # TODO Plotting warnings that need to be addressed
-  'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning',
-  'ignore:Passing unrecognized arguments to super:DeprecationWarning',
+    "error",
+    'ignore:You are running a "Debug" build of scipp:',
+    # from ipywidgets; they are migrating away from ipykernel, this warning should go away
+    'ignore:The `ipykernel.comm.Comm` class has been deprecated.:DeprecationWarning',
+    # Plotting related warnings.
+    'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning',
+    # TODO Plotting warnings that need to be addressed
+    'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning',
+    'ignore:Passing unrecognized arguments to super:DeprecationWarning',
 ]
 
 [tool.ruff]
@@ -111,19 +112,19 @@ pydocstyle.convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 # those files have an increased risk of relying on import order
 "tests/*" = [
-    "S101",  # asserts are fine in tests
-    "B018",  # 'useless expressions' are ok because some tests just check for exceptions
+    "S101", # asserts are fine in tests
+    "B018", # 'useless expressions' are ok because some tests just check for exceptions
 ]
 "*.ipynb" = [
-    "E501",  # longer lines are sometimes more readable
-    "F403",  # *-imports used with domain types
-    "F405",  # linter may fail to find names because of *-imports
-    "I",  # we don't collect imports at the top
-    "S101",  # asserts are used for demonstration and are safe in notebooks
-    "T201",  # printing is ok for demonstration purposes
+    "E501", # longer lines are sometimes more readable
+    "F403", # *-imports used with domain types
+    "F405", # linter may fail to find names because of *-imports
+    "I", # we don't collect imports at the top
+    "S101", # asserts are used for demonstration and are safe in notebooks
+    "T201", # printing is ok for demonstration purposes
 ]
 "docs/user-guide/recipes.ipynb" = [
-  "F821"  # this notebook is never executed and uses undefined names
+    "F821"  # this notebook is never executed and uses undefined names
 ]
 
 [tool.ruff.format]

--- a/src/scippneutron/io/xye.py
+++ b/src/scippneutron/io/xye.py
@@ -3,10 +3,13 @@
 """File writer and reader for XYE files."""
 
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 import numpy as np
+import pydantic
 import scipp as sc
+import yaml
+from pydantic import BaseModel
 
 from ..logging import get_logger
 
@@ -25,6 +28,8 @@ def save_xye(
     *,
     coord: str | None = None,
     header: str | GenerateHeaderType = GenerateHeader,
+    metadata: dict[str, BaseModel | str | list[Any] | dict[str, Any]] | None = None,
+    comment: str = "",
 ) -> None:
     """Write a data array to an XYE file.
 
@@ -40,8 +45,18 @@ def save_xye(
     This format is lossy, coordinates other than X, attributes,
     and masks are not written and the coordinate name, dimension name, and
     units of the input are lost.
-    To improve the situation slightly, ``save_xye`` writes a basic header by default.
-    All lines in the header are prefixed with ``#``.
+    To improve the situation slightly, ``save_xye`` can write some description
+    to the top of the file.
+    All lines in the description are prefixed with ``#``.
+
+    The description is structured like this:
+
+    .. code-block:: yaml
+
+        # ScippNeutron XYE file
+        # <comment>
+        # <metadata>
+        # <header>
 
     Parameters
     ----------
@@ -59,6 +74,26 @@ def save_xye(
         String to write at the beginning of the file.
         A simple table header gets generated automatically by default.
         Set ``header=''`` to prevent this.
+    metadata:
+        Optional dictionary of metadata to serialize into the header.
+        The metadata is serialized as YAML.
+        Each entry can be any data that pydantic can serialize.
+
+        Note that there is no fixed schema for metadata, so ``save_xye`` will
+        accept any serializable metadata.
+    comment:
+        Optional string to show at the top of the file.
+
+    Examples
+    --------
+
+    >>> from scippneutron.io.xye import save_xye
+    >>> from scippneutron.metadata import Beamline
+    >>> # Make test data
+    >>> data = sc.DataArray(sc.arange('x', 4.0), coords={'x': sc.arange('x', 4)})
+    >>> data.variances = 0.1 * data.values
+    >>> # Serialize
+    >>> save_xye("data.xye", data, metadata={"beamline": Beamline(name="test")})
 
     See Also
     --------
@@ -90,7 +125,12 @@ def save_xye(
         )
     to_save = np.c_[da.coords[coord].values, da.values, np.sqrt(da.variances)]
     if header is GenerateHeader:
-        header = _generate_xye_header(da, coord)
+        header = _generate_xye_column_header(da, coord)
+    if metadata is not None:
+        header = "\n".join((_serialize_xye_metadata(metadata), header))
+    if comment:
+        header = "\n".join((comment, header))
+    header = "\n".join((_HEADER_NOTE, header))
 
     get_logger().info(
         "Saving data with unit %s and coordinate '%s' to XYE file %s",
@@ -150,7 +190,7 @@ def load_xye(
     )
 
 
-def _generate_xye_header(da: sc.DataArray, coord: str) -> str:
+def _generate_xye_column_header(da: sc.DataArray, coord: str) -> str:
     def format_unit(unit):
         return f'[{unit}]' if unit is not None else ''
 
@@ -159,6 +199,19 @@ def _generate_xye_header(da: sc.DataArray, coord: str) -> str:
     e = f'E {format_unit(da.unit)}'
     # Widths are for the default format of `0.0`
     return f'{c:22} {y:24} {e:24}'
+
+
+_HEADER_NOTE = "# ScippNeutron XYE file"
+
+
+def _serialize_xye_metadata(
+    metadata: dict[str, BaseModel | str | list[Any] | dict[str, Any]],
+) -> str:
+    return yaml.safe_dump(
+        pydantic.create_model(
+            "xye_metadata", **{key: (type(val), val) for key, val in metadata.items()}
+        )().model_dump(mode="json", exclude_none=True)
+    )
 
 
 def _deduce_coord(da: sc.DataArray) -> str:

--- a/tests/io/xye_test.py
+++ b/tests/io/xye_test.py
@@ -13,6 +13,7 @@ from packaging.version import Version
 from scipp.testing import strategies as scst
 
 import scippneutron as scn
+from scippneutron.metadata import Beamline, Software
 
 
 @st.composite
@@ -59,8 +60,12 @@ def roundtrip(da: sc.DataArray, coord: str | None = None, **kwargs) -> sc.DataAr
     )
 
 
+def read_header(buffer: StringIO) -> list[str]:
+    return [line[2:] for line in buffer.getvalue().splitlines() if line.startswith('#')]
+
+
 @given(initial=one_dim_data_arrays(), header=headers(), data=st.data())
-def test_roundtrip(initial, header, data):
+def test_roundtrip(initial: sc.DataArray, header: str, data: st.DataObject) -> None:
     coord_name = data.draw(st.sampled_from(list(initial.coords.keys())))
     loaded = roundtrip(initial, coord=coord_name, header=header)
     assert set(loaded.coords.keys()) == {coord_name}
@@ -73,7 +78,7 @@ def test_roundtrip(initial, header, data):
 
 
 @given(da=one_dim_data_arrays(), data=st.data())
-def test_saved_file_contains_data_table(da, data):
+def test_saved_file_contains_data_table(da: sc.DataArray, data: st.DataObject) -> None:
     coord_name = data.draw(st.sampled_from(list(da.coords.keys())))
     file_contents = save_to_buffer(da, coord=coord_name).getvalue()
     for i, line in enumerate(
@@ -89,7 +94,7 @@ def test_saved_file_contains_data_table(da, data):
 
 @given(initial=one_dim_data_arrays(max_n_coords=1))
 @settings(max_examples=20)
-def test_save_deduce_coord_data_with_one_coord(initial):
+def test_save_deduce_coord_data_with_one_coord(initial: sc.DataArray) -> None:
     coord_name = next(iter(initial.coords.keys()))
     loaded = roundtrip(initial)
     loaded = loaded.rename_dims({loaded.dim: initial.dim})
@@ -101,7 +106,9 @@ def test_save_deduce_coord_data_with_one_coord(initial):
 
 @given(initial=one_dim_data_arrays(), data=st.data())
 @settings(max_examples=20)
-def test_save_deduce_coord_dim_coord(initial, data):
+def test_save_deduce_coord_dim_coord(
+    initial: sc.DataArray, data: st.DataObject
+) -> None:
     dim = initial.dim
     initial_coord = data.draw(
         scst.variables(sizes=initial.sizes, dtype='float64', with_variances=False)
@@ -118,7 +125,7 @@ def test_save_deduce_coord_dim_coord(initial, data):
 
 @given(da=one_dim_data_arrays(min_n_coords=2))
 @settings(max_examples=20)
-def test_save_cannot_deduce_coord_if_multiple_non_dim_coords(da):
+def test_save_cannot_deduce_coord_if_multiple_non_dim_coords(da: sc.DataArray) -> None:
     # It can deduce if there is a dim-coord, exclude that.
     assume(da.dim not in da.coords)
     with pytest.raises(
@@ -131,7 +138,7 @@ def test_save_cannot_deduce_coord_if_multiple_non_dim_coords(da):
 
 @given(da=one_dim_data_arrays(max_n_coords=1))
 @settings(max_examples=20)
-def test_input_must_have_at_least_one_coord(da):
+def test_input_must_have_at_least_one_coord(da: sc.DataArray) -> None:
     for c in list(da.coords.keys()):
         del da.coords[c]
     with pytest.raises(
@@ -142,7 +149,7 @@ def test_input_must_have_at_least_one_coord(da):
 
 @given(da=one_dim_data_arrays(), data=st.data())
 @settings(max_examples=20)
-def test_input_must_have_variances(da, data):
+def test_input_must_have_variances(da: sc.DataArray, data: st.DataObject) -> None:
     da.variances = None
     coord_name = data.draw(st.sampled_from(list(da.coords.keys())))
     with pytest.raises(sc.VariancesError):
@@ -151,7 +158,7 @@ def test_input_must_have_variances(da, data):
 
 @given(da=one_dim_data_arrays(), data=st.data())
 @settings(max_examples=20)
-def test_cannot_save_data_with_bin_edges(da, data):
+def test_cannot_save_data_with_bin_edges(da: sc.DataArray, data: st.DataObject) -> None:
     coord_name = data.draw(st.sampled_from(list(da.coords.keys())))
     da.coords[coord_name] = sc.concat(
         [da.coords[coord_name], sc.scalar(0.0, unit=da.coords[coord_name].unit)],
@@ -163,7 +170,7 @@ def test_cannot_save_data_with_bin_edges(da, data):
 
 @given(da=one_dim_data_arrays(), data=st.data())
 @settings(max_examples=20)
-def test_cannot_save_data_with_masks(da, data):
+def test_cannot_save_data_with_masks(da: sc.DataArray, data: st.DataObject) -> None:
     mask = data.draw(scst.variables(sizes=da.sizes, dtype=bool))
     da.masks[data.draw(st.text())] = mask
     with pytest.raises(
@@ -178,7 +185,7 @@ def test_cannot_save_data_with_masks(da, data):
 )
 @given(data=st.data())
 @settings(max_examples=20)
-def test_input_must_be_one_dimensional(data):
+def test_input_must_be_one_dimensional(data: sc.DataArray) -> None:
     da = data.draw(
         scst.dataarrays(
             data_args={
@@ -197,18 +204,55 @@ def test_input_must_be_one_dimensional(data):
 
 
 @given(da=one_dim_data_arrays(), header=headers())
-def test_can_set_header(da, header):
+@settings(max_examples=40)
+def test_can_set_header(da: sc.DataArray, header: str) -> None:
     buffer = save_to_buffer(da, coord=next(iter(da.coords)), header=header)
-    commented_header = (
-        '\n'.join(f'# {line}' for line in header.splitlines()) if header else ''
-    )
-    assert buffer.getvalue().startswith(commented_header)
+    loaded = "\n".join(read_header(buffer)[1:]).strip()
+    assert loaded == header.strip()
+
+
+@given(da=one_dim_data_arrays(), comment=headers())
+@settings(max_examples=40)
+def test_can_set_comment(da: sc.DataArray, comment: str) -> None:
+    buffer = save_to_buffer(da, coord=next(iter(da.coords)), comment=comment)
+    loaded = "\n".join(read_header(buffer)[1:-1]).strip()
+    assert loaded == comment.strip()
+
+
+@given(da=one_dim_data_arrays())
+@settings(max_examples=1)
+def test_can_set_metadata(da: sc.DataArray) -> None:
+    metadata = {
+        "beamline": Beamline(name="test", facility="pytest"),
+        "software": [
+            Software(name="scippneutron", version="2026.7.0"),
+            Software(name="scipp", version="100", url="https://scipp.github.io"),
+        ],
+        "other": 123,
+    }
+    buffer = save_to_buffer(da, coord=next(iter(da.coords)), metadata=metadata)
+    loaded = "\n".join(read_header(buffer)[1:-1]).strip()
+
+    expected = """beamline:
+  facility: pytest
+  name: test
+other: 123
+software:
+- name: scippneutron
+  version: 2026.7.0
+- name: scipp
+  url: https://scipp.github.io
+  version: '100'"""
+
+    assert loaded == expected
 
 
 @given(
     da=one_dim_data_arrays(), coord_name=st.text(string.ascii_letters + string.digits)
 )
-def test_generated_header_includes_coord_name_and_units(da, coord_name):
+def test_generated_header_includes_coord_name_and_units(
+    da: sc.DataArray, coord_name: str
+) -> None:
     # Detecting the coord name in the file can be tricky if it can contain arbitrary
     # characters (like '\n' or '#') because lines in the header start with '# '.
     initial_name = next(iter(da.coords))
@@ -222,7 +266,7 @@ def test_generated_header_includes_coord_name_and_units(da, coord_name):
         assert str(da.unit) in buffer.getvalue()
 
 
-def test_loads_correct_values():
+def test_loads_correct_values() -> None:
     file_contents = '''1 2 3
 1.003 32.1 5
 0.1111 0 2.1e-3


### PR DESCRIPTION
This implements the ScippNeutron part of #706. Once merged, we can hook this up to metadata providers in `ess.dream`.