### PR TITLE
fix: escape newlines in xye column names

### DIFF
--- a/src/scippneutron/io/xye.py
+++ b/src/scippneutron/io/xye.py
@@ -194,7 +194,8 @@ def _generate_xye_column_header(da: sc.DataArray, coord: str) -> str:
     def format_unit(unit):
         return f'[{unit}]' if unit is not None else ''
 
-    c = f'{coord} {format_unit(da.coords[coord].unit)}'
+    escaped_coord = coord.translate(_LINE_SEPARATOR_ESCAPES)
+    c = f'{escaped_coord} {format_unit(da.coords[coord].unit)}'
     y = f'Y {format_unit(da.unit)}'
     e = f'E {format_unit(da.unit)}'
     # Widths are for the default format of `0.0`
@@ -202,6 +203,15 @@ def _generate_xye_column_header(da: sc.DataArray, coord: str) -> str:
 
 
 _HEADER_NOTE = "# ScippNeutron XYE file"
+
+# All characters that Python recognizes as line boundaries in str.splitlines().
+_LINE_SEPARATORS = '\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029'
+_LINE_SEPARATOR_ESCAPES = str.maketrans(
+    {
+        separator: separator.encode('unicode_escape').decode('ascii')
+        for separator in _LINE_SEPARATORS
+    }
+)
 
 
 def _serialize_xye_metadata(

--- a/tests/io/xye_test.py
+++ b/tests/io/xye_test.py
@@ -7,7 +7,7 @@ from io import StringIO
 import numpy as np
 import pytest
 import scipp as sc
-from hypothesis import assume, given, settings
+from hypothesis import assume, example, given, settings
 from hypothesis import strategies as st
 from packaging.version import Version
 from scipp.testing import strategies as scst
@@ -213,6 +213,13 @@ def test_can_set_header(da: sc.DataArray, header: str) -> None:
 
 @given(da=one_dim_data_arrays(), comment=headers())
 @settings(max_examples=40)
+@example(
+    da=sc.DataArray(
+        sc.array(dims=[''], values=[0.0], variances=[0.0]),
+        coords={'0\n': sc.array(dims=[''], values=[0.0], variances=[0.0])},
+    ),
+    comment='0',
+)
 def test_can_set_comment(da: sc.DataArray, comment: str) -> None:
     buffer = save_to_buffer(da, coord=next(iter(da.coords)), comment=comment)
     loaded = "\n".join(read_header(buffer)[1:-1]).strip()


### PR DESCRIPTION
Fixes https://github.com/scipp/scippneutron/actions/runs/31072043643/job/92521804721